### PR TITLE
ci: ensure CI doesn't fail if no projects are affected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
 
       - name: Print affected projects
-        run: pnpm nx show projects --affected --base $NX_BASE --head $NX_HEAD | grep -v "^info"
+        run: |
+          pnpm nx show projects --affected --base $NX_BASE --head $NX_HEAD \
+            | grep -v "^info" || echo "No projects affected" && true
 
       - name: Determine whether storybook-tests & chromatic need to run
         id: job_condition


### PR DESCRIPTION
The cause was that grep will exit with exit code 1 if no lines match, which will be the case when no projects are affected