### PR TITLE
test: add interaction test for search

### DIFF
--- a/@udir-design/react/src/components/search/Search.stories.tsx
+++ b/@udir-design/react/src/components/search/Search.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from '@storybook/test';
 import { Search } from './Search';
 import { useState } from 'react';
-
 import { Button, Divider, Field, Label, Paragraph } from '../alpha';
+import { assertExists } from '../../utilities/helpers/assertExists';
 
 const meta: Meta<typeof Search> = {
   component: Search,
@@ -13,6 +14,9 @@ export default meta;
 type Story = StoryObj<typeof Search>;
 
 export const Preview: Story = {
+  args: {
+    onClick: fn(),
+  },
   render: (args) => (
     <Search {...args}>
       <Search.Input aria-label="Søk" />
@@ -20,6 +24,38 @@ export const Preview: Story = {
       <Search.Button />
     </Search>
   ),
+  play: async ({ canvasElement, step, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('searchbox');
+
+    await step('Search input is rendered', async () => {
+      expect(input).toBeInTheDocument();
+    });
+
+    await step('User can type in the search input', async () => {
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Test search');
+      expect(input).toHaveValue('Test search');
+    });
+
+    await step('Clicking clear button clears the search input', async () => {
+      const clearButton = assertExists(
+        canvasElement.querySelector('button[type="reset"]'),
+        'Clear button not found'
+      );
+      await userEvent.click(clearButton);
+      expect(input).toHaveValue('');
+    });
+
+    await step('Search button is rendered and clickable', async () => {
+      const searchButton = assertExists(
+        canvasElement.querySelector('button[type="submit"]'),
+        'Search button not found'
+      );
+      await userEvent.click(searchButton);
+      expect(args.onClick).toHaveBeenCalled();
+    });
+  },
 };
 
 export const Controlled: Story = {

--- a/@udir-design/react/src/utilities/helpers/assertExists.ts
+++ b/@udir-design/react/src/utilities/helpers/assertExists.ts
@@ -1,0 +1,10 @@
+// A helper function to assert the element is not null.
+export function assertExists<T>(
+  element: T | null,
+  errorMessage = 'Element not found'
+): T {
+  if (element === null) {
+    throw new Error(errorMessage);
+  }
+  return element;
+}


### PR DESCRIPTION
- Interaksjonstest for search
- Legger til en utility for assertExists dersom man velger å finne komponent med querySelector: `canvasElement.querySelector('button[type="reset"]')`. 
- Man kan finne elementene med getByRole eller getByTestId som automatisk failer, men jeg tenker det er greit å sjekke at man har komponenter med `button[type="reset"]` og `button[type="submit"]` fordi det blir semantisk riktig for search.