### PR TITLE
ci(dependabot): adding dependabot config with group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    # Grouping based on dependency type and semver version
+    groups:
+      dev-patch-minor:
+        dependency-type: 'development'
+        update-types:
+          - 'patch'
+          - 'minor'
+      dev-major:
+        dependency-type: 'development'
+        update-types:
+          - 'major'
+      prod-patch-minor:
+        dependency-type: 'production'
+        update-types:
+          - 'patch'
+          - 'minor'
+      prod-major:
+        dependency-type: 'production'
+        update-types:
+          - 'major'


### PR DESCRIPTION
> [!IMPORTANT]  
> Sikkerhetsoppdateringer er ikke påvirket av denne. Det vil si at dependabot fortsatt vil lage egne prer basert på alerts i sikkerhetsfanen på github.

For å gjøre det enkelt å gå gjennom og merge prer fra dependabot så deler vi pakkeoppdateringene opp i fire grupper:
1. dev dep ssom er patch og minor
2. dev deps som er major
3. prod deps som er patch og minor
4. prod deps som er major

Hver gruppe får sin egen pr. Da blir det lettere å oppdatere flere dependencies om gangen. 

**Schedule:**
Det hadde vært fint å ha forskjellig schedule på dev og prod dependencies, men det ser ikke ut til at det er mulig. 

> [!NOTE]  
> Jeg har ikke testet å gruppere med både `dependency-type` og `update-type` i samme gruppe før, men det burde ikke være noe problem basert på [github docsen](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#schedule-).