### PR TITLE
ci(commitlint): allow longer commit body lines, with a warning

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,5 +1,8 @@
-import type { UserConfig } from '@commitlint/types';
+import { RuleConfigSeverity, type UserConfig } from '@commitlint/types';
 
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [RuleConfigSeverity.Warning, 'always', 100],
+  },
 } satisfies UserConfig;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": "^20.0.0"
   },
   "devDependencies": {
+    "@commitlint/types": "^19.5.0",
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@eslint/compat": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.6.0
         version: 19.6.0
+      '@commitlint/types':
+        specifier: ^19.5.0
+        version: 19.5.0
       '@eslint/compat':
         specifier: ^1.2.4
         version: 1.2.4(eslint@9.17.0(jiti@2.4.2))
@@ -16140,7 +16143,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.10.5
+      '@types/node': 20.17.12
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -16154,7 +16157,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.10.5
+      '@types/node': 20.17.12
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
This ensures dependabot's commit messages are accepted by commitlint