### PR TITLE
ci: fix failing webhook call by changing Slack message from markdown to rich_text

### DIFF
--- a/.github/workflows/update-major-alert.yml
+++ b/.github/workflows/update-major-alert.yml
@@ -15,33 +15,16 @@ jobs:
         id: outdated_majors
         run: |
           {
-            echo "markdown<<EOF"
+            echo "slack_message<<EOF"
             ./@internal/build-tools/bin/get-outdated-majors.sh
             echo EOF
           } >> $GITHUB_OUTPUT
       - name: Post to slack
-        if: steps.outdated_majors.outputs.markdown != ''
+        if: steps.outdated_majors.outputs.slack_message
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_DS_UDIR_DEV_WEBHOOK }}
           webhook-type: incoming-webhook
-          payload: |
-            blocks:
-              - type: header
-                text:
-                  type: plain_text
-                  text: >-
-                    :warning: Tilgjengelige major-versjonsoppdateringer
-              - type: section
-                text:
-                  type: plain_text
-                  text: >-
-                    Disse avhengighetene ligger bak siste major-versjon, og bør oppdateres:
-              - type: markdown
-                text: "${{ steps.outdated_majors.outputs.markdown }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: >-
-                      Følg <https://github.com/Utdanningsdirektoratet/designsystem?tab=readme-ov-file#oppdatere-til-nye-major-versjoner|disse instruksene>
-                      for å bli kvitt disse meldingene.
+          errors: true
+          retries: RAPID
+          payload: ${{ steps.outdated_majors.outputs.slack_message }}

--- a/@internal/build-tools/bin/get-outdated-majors.sh
+++ b/@internal/build-tools/bin/get-outdated-majors.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-## Prints a Markdown-formatted list of dependencies
+## Creates a Slack message payload which lists dependencies
 ## which are outdated by one or more major versions
-pnpm outdated -r --format=json | jq -r 'to_entries[]
-  | { name: .key, current_full: .value.current, latest_full: .value.latest} + .value
-  | (.current, .latest) |= (split(".").[0])
-  | select(.current < .latest)
-  | "- **\(.name)**: ~v\(.current_full)~ → v\(.latest_full)"'
+CURRENT_DIR=${BASH_SOURCE%/*}
+OUTDATED_MAJORS="$($CURRENT_DIR/../src/get-outdated-majors/make-list.sh)"
+echo "$(/usr/bin/env -S pnpm tsx $CURRENT_DIR/../src/get-outdated-majors/slack-message-template.ts "$OUTDATED_MAJORS")"
+

--- a/@internal/build-tools/src/get-outdated-majors/make-list.sh
+++ b/@internal/build-tools/src/get-outdated-majors/make-list.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+## Prints a JSON list of formatted list of dependencies
+## which are outdated by one or more major versions
+pnpm outdated -r --format=json | jq -c 'to_entries | map(
+  { name: .key, current_full: .value.current, latest_full: .value.latest} + .value
+  | (.current, .latest) |= (split(".").[0])
+  | select(.current < .latest)
+  | {type: "rich_text_section", elements: [
+      { type: "text", text: .name, style: { bold: true }},
+      { type: "text", text: ": " },
+      { type: "text", text: "v\(.current_full)", style: { strike: true }},
+      { type: "text", text: " → v\(.latest_full)"}
+    ]}
+)'
+

--- a/@internal/build-tools/src/get-outdated-majors/slack-message-template.ts
+++ b/@internal/build-tools/src/get-outdated-majors/slack-message-template.ts
@@ -1,0 +1,47 @@
+import { argv, exit } from 'node:process';
+
+const bulletPoints: unknown[] = argv[2] ? JSON.parse(argv[2]) : [];
+if (!bulletPoints.length) {
+  exit(0);
+}
+
+const template = {
+  blocks: [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: ':warning: Tilgjengelige major-versjonsoppdateringer',
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'plain_text',
+        text: 'Disse avhengighetene ligger bak siste major-versjon, og bør oppdateres:',
+      },
+    },
+    {
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_list',
+          style: 'bullet',
+          indent: 0,
+          elements: bulletPoints,
+        },
+      ],
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: 'Følg <https://github.com/Utdanningsdirektoratet/designsystem?tab=readme-ov-file#oppdatere-til-nye-major-versjoner|disse instruksene> for å bli kvitt disse meldingene.',
+        },
+      ],
+    },
+  ],
+};
+
+console.log(JSON.stringify(template));


### PR DESCRIPTION
Apparently blocks with { "type": "markdown" } don't work with Slack webhooks (this is not documented) so we have to change to the much more verbose and complex to generate "rich_text" syntax to get the formatting we want.