### PR TITLE
ci: refinements to automatic updates 

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           branch: build/update-patch-and-minor-deps
           base: ${{ github.event.repository.default_branch }}
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           commit-message: 'build: update patch and minor versions of dependencies'
           # Unfortunately GITHUB_TOKEN doesn't have permission to read teams
           # team-reviewers: Designsystemet-devs

--- a/.github/workflows/update-digdir.yml
+++ b/.github/workflows/update-digdir.yml
@@ -11,14 +11,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-setup
-      - run: pnpm update -r --latest "@digdir/*"
-      - run: echo "version=$(npm view @digdir/designsystemet version)" >> "$GITHUB_OUTPUT"
+      - name: Check if update is necessary
+        run: echo "version=$(pnpm outdated -r '@digdir/*' --json | jq -r '."@digdir/designsystemet".latest // ""')" >> "$GITHUB_OUTPUT"
         id: digdir_info
+      - name: Update @digdir/* packages
+        run: pnpm update -r --latest "@digdir/*"
+        if: steps.digdir_info.outputs.version
       - name: Create or update pull request
+        if: steps.digdir_info.outputs.version
         uses: peter-evans/create-pull-request@v7.0.8
         with:
           branch: build/update-digdir
           base: ${{ github.event.repository.default_branch }}
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           commit-message: 'build: update `@digdir/*` to ${{ steps.digdir_info.outputs.version }}'
           title: 'build: update `@digdir/*` to ${{ steps.digdir_info.outputs.version }}'
           body: |

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -11,10 +11,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm-setup
-      - run: echo "version=$(npm view prettier version)" >> "$GITHUB_OUTPUT"
+      - name: Configure git user
+        run: |
+          # Setup the committers identity.
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Check if update is necessary
+        run: echo "version=$(pnpm outdated -r prettier --json | jq -r '.prettier.latest // ""')" >> "$GITHUB_OUTPUT"
         id: prettier_info
 
       - name: Update Prettier and format all files
+        if: steps.prettier_info.outputs.version
         id: prettier_run
         run: |
           pnpm update -r --latest prettier
@@ -34,6 +42,7 @@ jobs:
         with:
           branch: build/update-prettier
           base: ${{ github.event.repository.default_branch }}
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: 'build: update prettier to ${{ steps.prettier_info.outputs.version }}'
           body: Updates prettier to the latest version and formats all files
           draft: always-true

--- a/README.md
+++ b/README.md
@@ -374,38 +374,47 @@ Deretter, oppdater alle avhengigheter innenfor versjonsgrensene satt i `package.
 pnpm update -r
 ```
 
+> [!IMPORTANT]
+> Oppdateringer innenfor versjonsgrensene skjer automatisk [hver søndag kl 23:00 (UTC)](https://github.com/Utdanningsdirektoratet/designsystem/actions/workflows/update-deps.yml), og eventuelle endringer må godkjennes i en pull request.
+
 Vi har noen avhengigheter som er pinnet til spesifikke versjoner. Disse trenger egne kommandoer.
 
-- **`@digdir/*`**
+### `@digdir/*`
 
-  Designsystem-bibliotekene fra Digdir er pinnet for å ha full kontroll over hvilke versjoner som er i bruk hos Udir. Derfor må disse oppdateres slik:
+> [!IMPORTANT]
+> Oppdateringer av Digdir-bibliotekene skjer automatisk [hver natt kl 01:00 (UTC)](https://github.com/Utdanningsdirektoratet/designsystem/actions/workflows/update-digdir.yml), og eventuelle endringer må godkjennes i en pull request.
 
-  ```sh
-  pnpm update -r --latest "@digdir/*"
-  ```
+Designsystem-bibliotekene fra Digdir er pinnet for å ha full kontroll over hvilke versjoner som er i bruk hos Udir. Derfor må disse oppdateres slik:
 
-- **`nx` og `@nx/*`**
+```sh
+pnpm update -r --latest "@digdir/*"
+```
 
-  `nx` har sin egen oppdateringskommando, som også klargjør migreringer i de tilfellene det er relevant.
+### `nx` og `@nx/*`
 
-  ```sh
-  pnpm nx migrate latest
-  pnpm nx --run-migrations # kun dersom migrations.json ble opprettet
-  pnpm install --no-frozen-lockfile
-  ```
+`nx` har sin egen oppdateringskommando, som også klargjør migreringer i de tilfellene det er relevant.
 
-- **`prettier`**
+```sh
+pnpm nx migrate latest
+pnpm nx --run-migrations # kun dersom migrations.json ble opprettet
+pnpm install --no-frozen-lockfile
+```
 
-  Siden nye versjoner av `prettier` ofte påvirker kodeformateringen, er denne versjonen pinnet slik at disse endringene kun skjer når vi velger det selv. Det beste er å gjøre følgende på en branch med ingen uncommited changes:
+### `prettier`
 
-  ```sh
-  pnpm update -r --latest prettier
-  git commit --all -m "build: update prettier to $(npm view prettier version)"
-  pnpm nx format:write --all
-  git commit --all -m "style: format files with prettier $(npm view prettier version)"
-  echo "# $(git show -s --format='%s')\n$(git rev-parse HEAD)" > .git-blame-ignore-revs
-  git commit --all -m "chore: update .git-blame-ignore-revs"
-  ```
+> [!IMPORTANT]
+> Oppdateringer av `prettier` skjer automatisk [hver mandag kl 02:00 (UTC)](https://github.com/Utdanningsdirektoratet/designsystem/actions/workflows/update-prettier.yml), og eventuelle endringer må godkjennes i en pull request.
+
+Siden nye versjoner av `prettier` ofte påvirker kodeformateringen, er denne versjonen pinnet slik at disse endringene kun skjer når vi velger det selv. Det beste er å gjøre følgende på en branch med ingen uncommited changes:
+
+```sh
+pnpm update -r --latest prettier
+git commit --all -m "build: update prettier to $(npm view prettier version)"
+pnpm nx format:write --all
+git commit --all -m "style: format files with prettier $(npm view prettier version)"
+echo "# $(git show -s --format='%s')\n$(git rev-parse HEAD)" > .git-blame-ignore-revs
+git commit --all -m "chore: update .git-blame-ignore-revs"
+```
 
 > [!NOTE]
 > Vi legger commits med Prettier-formatering inn i `.git-blame-ignore-revs` slik at de


### PR DESCRIPTION
- Set author as github-actions[bot]
- Only run update for prettier & digdir if there is actually a new version
- Properly set git user info in prettier workflow
- Document which update processes are automated in README