### PR TITLE
fix: reduce color choices for a number of components

### DIFF
--- a/@internal/build-tools/src/postprocess-css-colors.ts
+++ b/@internal/build-tools/src/postprocess-css-colors.ts
@@ -2,6 +2,21 @@ import fs from 'node:fs/promises';
 import { cwd } from 'node:process';
 import { resolve } from 'node:path';
 
+/*
+ * A list of selectors that should reset the color palette to "neutral"
+ * instead of inheriting the closest ancestor color palette
+ */
+const neutralComponents = [
+  '.ds-breadcrumbs',
+  '.ds-button',
+  '.ds-field',
+  '.ds-input',
+  '.ds-link',
+  '.ds-pagination',
+  '.ds-suggestion',
+  '.ds-togglegroup',
+];
+
 export async function postprocessCssColors(file: string) {
   // Change default color from accent to neutral
   const css = (await fs.readFile(resolve(cwd(), file), { encoding: 'utf-8' }))
@@ -11,7 +26,7 @@ export async function postprocessCssColors(file: string) {
     )
     .replace(
       '[data-color="neutral"]',
-      ':root, [data-color-scheme], [data-color="neutral"]',
+      `:root, [data-color-scheme], :not([data-color]):where(${neutralComponents.join(', ')}), [data-color="neutral"]`,
     );
 
   await fs.writeFile(file, css, { encoding: 'utf-8' });

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import {
-  Breadcrumbs,
-  type BreadcrumbsProps,
+  Breadcrumbs as DigdirBreadcrumbs,
+  type BreadcrumbsProps as DigdirBreadcrumbsProps,
   BreadcrumbsItem,
   type BreadcrumbsItemProps,
   BreadcrumbsLink,
@@ -8,6 +8,13 @@ import {
   BreadcrumbsList,
   type BreadcrumbsListProps,
 } from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type BreadcrumbsProps = Omit<DigdirBreadcrumbsProps, 'data-color'>;
+
+const Breadcrumbs =
+  DigdirBreadcrumbs as ForwardRefExoticComponent<BreadcrumbsProps> &
+    Pick<typeof DigdirBreadcrumbs, 'Item' | 'Link' | 'List'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Breadcrumbs.displayName = 'Breadcrumbs';

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -2,13 +2,7 @@ import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 import { Do, Dont, Stack } from '../../../.storybook/docs-components';
 import { Button } from './Button';
 import * as ButtonStories from './Button.stories';
-import {
-  ButtonEx1,
-  ButtonEx2,
-  ButtonEx3,
-  ButtonEx4,
-  ButtonEx5,
-} from './docs/doAndDont';
+import { ButtonEx1, ButtonEx2, ButtonEx4, ButtonEx5 } from './docs/doAndDont';
 
 <Meta of={ButtonStories} />
 
@@ -55,27 +49,19 @@ Denne knappen bruker vi til nedtonede handlinger. Hvis vi vil bruke den alene, m
 
 ## Fargevarianter
 
-### Hovedfarger
+Knappene kommer i to fargevarianter: `neutral` og `danger`.
 
-Knappene kommer i to hovedfarger `accent` og `neutral`.
-
-- `accent`-fargen stikker seg mer ut enn `neutral` og brukes gjerne når handlingen skal ha oppmerksomhet.
-
-<Canvas of={ButtonStories.Accent} />
-
-- `neutral`-fargen er mer nøytral og kan brukes når det er flere knapper på en side som ikke skal ta så mye oppmerksomhet.
+- `neutral` er standardfargen.
 
 <Canvas of={ButtonStories.Neutral} />
 
-### Danger
-
-`Danger`-fargen bruker vi til handlinger som brukeren ikke kan angre, for eksempel Slett.
+- `danger`-fargen bruker vi til handlinger som brukeren ikke kan angre, for eksempel Slett.
 
 <Canvas of={ButtonStories.Danger} />
 
 ### Kombinere ulike fargevarianter
 
-En gruppe med knapper bør bruke samme fargevariant. Unntaket er når vi skal tydeliggjøre en handling brukeren ikke kan angre, for eksempel Forkast. Vi skal ikke kombinere andre fargevarianter.
+Vi kan bruke en `danger`-knapp sammen med én eller flere `neutral`-knapper når vi skal tydeliggjøre en handling brukeren ikke kan angre, for eksempel Forkast. Vi skal ikke kombinere andre fargevarianter.
 
 <Canvas of={ButtonStories.CombinedColors} />
 
@@ -174,13 +160,6 @@ Vi skal tydelig beskrive handlingene knappene utfører. En knapp kan bare ha én
 Vi skal holde oss til én primærknapp per side. Hvis det er flere hovedhandlinger kan brukerne bli usikre på hva de skal gjøre.
 
 <ButtonEx2 />
-<br />
-
-### Bruk samme farge på knappene i en gruppe
-
-Vi skal holde oss til samme fargevariant for en gruppe knapper.
-
-<ButtonEx3 />
 <br />
 
 ### Ett ikon per knapp

--- a/@udir-design/react/src/components/button/Button.stories.tsx
+++ b/@udir-design/react/src/components/button/Button.stories.tsx
@@ -13,7 +13,7 @@ import {
   PrinterSmallIcon,
   TrashIcon,
 } from '@navikt/aksel-icons';
-import { Label, Tooltip } from '../alpha';
+import { Card, Label, Tooltip } from '../alpha';
 
 export type Story = StoryObj<typeof Button>;
 
@@ -79,30 +79,6 @@ export const Tertiary: Story = {
     children: [<PencilWritingIcon aria-hidden />, 'Rediger'],
   },
 };
-
-export const Accent: Story = {
-  args: {
-    'data-color': 'accent',
-  },
-
-  render: (args) => {
-    return (
-      <>
-        <Button variant="primary" {...args}>
-          Gå videre
-        </Button>
-        <Button variant="secondary" {...args}>
-          Fortsett senere
-        </Button>
-        <Button variant="tertiary" {...args}>
-          Avbryt
-        </Button>
-      </>
-    );
-  },
-};
-
-export const AccentPseudoStates: Story = makePseudoStatesStory(Accent);
 
 export const Neutral: Story = {
   args: {
@@ -361,6 +337,26 @@ export const IconsOnlyPrimary: Story = {
           <CogIcon title="Innstillinger" />
         </Button>
       </>
+    );
+  },
+};
+
+export const ButtonInColorContext: Story = {
+  render: (args) => (
+    <Card data-color="accent" variant="tinted">
+      <Button {...args}>Knapp</Button>
+    </Card>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Should have neutral color palette by default, no matter the surrounding color palette',
+      async () => {
+        const button = within(canvasElement).getByRole('button');
+        const expectedColor = getComputedStyle(button).getPropertyValue(
+          '--ds-color-neutral-base-default',
+        );
+        expect(button).toHaveStyle(`background-color: ${expectedColor}`);
+      },
     );
   },
 };

--- a/@udir-design/react/src/components/button/Button.tsx
+++ b/@udir-design/react/src/components/button/Button.tsx
@@ -1,2 +1,16 @@
-import { Button, type ButtonProps } from '@digdir/designsystemet-react';
+import {
+  Button as DigdirButton,
+  type ButtonProps as DigdirButtonProps,
+} from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type ButtonProps = Omit<DigdirButtonProps, 'data-color'> & {
+  /**
+   * Change the color scheme of the button
+   */
+  'data-color'?: 'neutral' | 'danger';
+};
+
+const Button = DigdirButton as ForwardRefExoticComponent<ButtonProps>;
+
 export { Button, ButtonProps };

--- a/@udir-design/react/src/components/button/__snapshots__/Button.stories.tsx.snap
+++ b/@udir-design/react/src/components/button/__snapshots__/Button.stories.tsx.snap
@@ -1,142 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Accent 1`] = `
-<button
-  data-variant="primary"
-  type="button"
-  data-color="accent"
->
-  Gå videre
-</button>
-<button
-  data-variant="secondary"
-  type="button"
-  data-color="accent"
->
-  Fortsett senere
-</button>
-<button
-  data-variant="tertiary"
-  type="button"
-  data-color="accent"
->
-  Avbryt
-</button>
-`;
-
-exports[`Accent Pseudo States 1`] = `
-<div style="display: grid; grid-template-columns: repeat(4, auto); gap: inherit; place-items: center;">
-  <label
-    data-weight="medium"
-    data-size="sm"
-  >
-    Default
-  </label>
-  <button
-    data-variant="primary"
-    type="button"
-    data-color="accent"
-  >
-    Gå videre
-  </button>
-  <button
-    data-variant="secondary"
-    type="button"
-    data-color="accent"
-  >
-    Fortsett senere
-  </button>
-  <button
-    data-variant="tertiary"
-    type="button"
-    data-color="accent"
-  >
-    Avbryt
-  </button>
-  <label
-    data-weight="medium"
-    data-size="sm"
-  >
-    Hover
-  </label>
-  <button
-    data-variant="primary"
-    type="button"
-    data-color="accent"
-  >
-    Gå videre
-  </button>
-  <button
-    data-variant="secondary"
-    type="button"
-    data-color="accent"
-  >
-    Fortsett senere
-  </button>
-  <button
-    data-variant="tertiary"
-    type="button"
-    data-color="accent"
-  >
-    Avbryt
-  </button>
-  <label
-    data-weight="medium"
-    data-size="sm"
-  >
-    Pressed
-  </label>
-  <button
-    data-variant="primary"
-    type="button"
-    data-color="accent"
-  >
-    Gå videre
-  </button>
-  <button
-    data-variant="secondary"
-    type="button"
-    data-color="accent"
-  >
-    Fortsett senere
-  </button>
-  <button
-    data-variant="tertiary"
-    type="button"
-    data-color="accent"
-  >
-    Avbryt
-  </button>
-  <label
-    data-weight="medium"
-    data-size="sm"
-  >
-    Focused
-  </label>
-  <button
-    data-variant="primary"
-    type="button"
-    data-color="accent"
-  >
-    Gå videre
-  </button>
-  <button
-    data-variant="secondary"
-    type="button"
-    data-color="accent"
-  >
-    Fortsett senere
-  </button>
-  <button
-    data-variant="tertiary"
-    type="button"
-    data-color="accent"
-  >
-    Avbryt
-  </button>
-</div>
-`;
-
 exports[`As Link 1`] = `
 <a
   target="_blank"
@@ -167,6 +30,20 @@ exports[`As Link 1`] = `
     </path>
   </svg>
 </a>
+`;
+
+exports[`Button In Color Context 1`] = `
+<div
+  data-variant="tinted"
+  data-color="accent"
+>
+  <button
+    data-variant="primary"
+    type="button"
+  >
+    Knapp
+  </button>
+</div>
 `;
 
 exports[`Combined Colors 1`] = `

--- a/@udir-design/react/src/components/button/docs/doAndDont.tsx
+++ b/@udir-design/react/src/components/button/docs/doAndDont.tsx
@@ -38,19 +38,6 @@ export const ButtonEx2 = () => {
   );
 };
 
-export const ButtonEx3 = () => {
-  return (
-    <Stack style={{ margin: 'var(--ds-size-8) 0' }}>
-      <Do description="Knappene i en gruppe skal ha samme farge">
-        <Ex3Do />
-      </Do>
-      <Dont description="Ulike farger i en gruppe kan være forvirrende">
-        <Ex3Dont />
-      </Dont>
-    </Stack>
-  );
-};
-
 export const ButtonEx4 = () => {
   return (
     <Stack style={{ margin: 'var(--ds-size-8) 0' }}>
@@ -112,32 +99,6 @@ const Ex2Dont = () => {
       <Button variant="primary">Send inn</Button>
       <Button variant="primary">Lagre utkast</Button>
       <Button variant="primary">Forkast</Button>
-    </Stack>
-  );
-};
-
-const Ex3Do = () => {
-  return (
-    <Stack>
-      <Button variant="primary" data-color="accent">
-        Publiser
-      </Button>
-      <Button variant="secondary" data-color="accent">
-        Lagre
-      </Button>
-    </Stack>
-  );
-};
-
-const Ex3Dont = () => {
-  return (
-    <Stack>
-      <Button variant="primary" data-color="accent">
-        Publiser
-      </Button>
-      <Button variant="secondary" data-color="support1">
-        Lagre
-      </Button>
     </Stack>
   );
 };

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -231,7 +231,7 @@ export const Composed: Story = {
           <Textfield id={context.id + '-last-name'} label="Etternavn" />
         </Card.Block>
         <Card.Block>
-          <Button variant="secondary" data-color="accent" data-size="sm">
+          <Button variant="secondary" data-size="sm">
             Legg til rolle
             <PlusIcon aria-hidden />
           </Button>

--- a/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
+++ b/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
@@ -170,7 +170,6 @@ exports[`Composed 1`] = `
       <button
         data-variant="secondary"
         type="button"
-        data-color="accent"
         data-size="sm"
       >
         Legg til rolle

--- a/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
@@ -11,7 +11,7 @@ import {
   ValidationMessage,
   useCheckboxGroup,
 } from '../../alpha';
-import { expect, fn, userEvent, within } from '@storybook/test';
+import { expect, fn, userEvent, waitFor, within } from '@storybook/test';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
@@ -33,12 +33,11 @@ export const Preview: Story = {
     id: 'checkbox-preview',
   },
   play: async ({ canvasElement, step, args }) => {
-    await Promise.resolve(); // ensure fieldObserver has had time to connect the elements
     const canvas = within(canvasElement);
     const checkbox = canvas.getByRole('checkbox');
 
     await step('Label and description are rendered', async () => {
-      const label = canvas.getByText(args.label as string);
+      const label = await waitFor(() => canvas.getByText(args.label as string));
       expect(label).toBeInTheDocument();
 
       const description = canvas.getByText(args.description as string);

--- a/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   Button,
+  Card,
   Checkbox,
   Divider,
   Fieldset,
@@ -259,6 +260,32 @@ export const InTable: GroupStory = {
           ))}
         </Table.Body>
       </Table>
+    );
+  },
+};
+
+export const CheckboxInColorContext: Story = {
+  args: {
+    label: 'Checkbox label',
+    description: 'Description',
+    checked: true,
+    id: 'checkbox-in-color-context',
+  },
+  render: (args) => (
+    <Card data-color="accent" variant="tinted">
+      <Checkbox {...args} />
+    </Card>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Should have neutral color palette by default, no matter the surrounding color palette',
+      async () => {
+        const checkbox = within(canvasElement).getByRole('checkbox');
+        const expectedColor = getComputedStyle(checkbox).getPropertyValue(
+          '--ds-color-neutral-base-default',
+        );
+        expect(checkbox).toHaveStyle(`background-color: ${expectedColor}`);
+      },
     );
   },
 };

--- a/@udir-design/react/src/components/checkbox/Checkbox.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.tsx
@@ -1,2 +1,11 @@
-import { Checkbox, type CheckboxProps } from '@digdir/designsystemet-react';
+import {
+  Checkbox as DigdirCheckbox,
+  type CheckboxProps as DigdirCheckboxProps,
+} from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type CheckboxProps = Omit<DigdirCheckboxProps, 'data-color'>;
+
+const Checkbox = DigdirCheckbox as ForwardRefExoticComponent<CheckboxProps>;
+
 export { Checkbox, CheckboxProps };

--- a/@udir-design/react/src/components/checkbox/__snapshots__/Checkbox.stories.tsx.snap
+++ b/@udir-design/react/src/components/checkbox/__snapshots__/Checkbox.stories.tsx.snap
@@ -11,6 +11,34 @@ exports[`Aria Label 1`] = `
 </div>
 `;
 
+exports[`Checkbox In Color Context 1`] = `
+<div
+  data-variant="tinted"
+  data-color="accent"
+>
+  <div>
+    <input
+      type="checkbox"
+      id="checkbox-in-color-context"
+      checked
+      aria-describedby="checkbox-in-color-context:description"
+    >
+    <label
+      data-weight="regular"
+      for="checkbox-in-color-context"
+    >
+      Checkbox label
+    </label>
+    <div
+      data-field="description"
+      id="checkbox-in-color-context:description"
+    >
+      Description
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Content Ex 1 1`] = `
 <fieldset>
   <legend data-weight="medium">

--- a/@udir-design/react/src/components/field/Field.tsx
+++ b/@udir-design/react/src/components/field/Field.tsx
@@ -1,6 +1,6 @@
 import {
-  Field,
-  type FieldProps,
+  Field as DigdirField,
+  type FieldProps as DigdirFieldProps,
   FieldAffix,
   type FieldAffixProps,
   FieldCounter,
@@ -10,6 +10,12 @@ import {
   FieldAffixes,
   type FieldAffixesProps,
 } from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type FieldProps = Omit<DigdirFieldProps, 'data-color'>;
+
+const Field = DigdirField as ForwardRefExoticComponent<FieldProps> &
+  Pick<typeof DigdirField, 'Affix' | 'Affixes' | 'Counter' | 'Description'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Field.displayName = 'Field';

--- a/@udir-design/react/src/components/input/Input.tsx
+++ b/@udir-design/react/src/components/input/Input.tsx
@@ -1,2 +1,11 @@
-import { Input, type InputProps } from '@digdir/designsystemet-react';
+import {
+  Input as DigdirInput,
+  type InputProps as DigdirInputProps,
+} from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type InputProps = Omit<DigdirInputProps, 'data-color'>;
+
+const Input = DigdirInput as ForwardRefExoticComponent<InputProps>;
+
 export { Input, InputProps };

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -39,10 +39,6 @@ Ikonet burde være skjult fra skjermleser, ved å legge på `aria-hidden`.
 
 <Canvas of={LinkStories.LongLink} />
 
-### Nøytral farge
-
-<Canvas of={LinkStories.Neutral} />
-
 ## Retningslinjer for Link
 
 Når vi legger `Link` på siden, kan brukerne gå direkte til en annen relevant nettside,

--- a/@udir-design/react/src/components/link/Link.stories.tsx
+++ b/@udir-design/react/src/components/link/Link.stories.tsx
@@ -55,11 +55,3 @@ export const LongLink: Story = {
     </Paragraph>
   ),
 };
-
-export const Neutral: Story = {
-  args: {
-    children: 'Gå til designsystemet',
-    href: udirLink,
-    'data-color': 'neutral',
-  },
-};

--- a/@udir-design/react/src/components/link/Link.tsx
+++ b/@udir-design/react/src/components/link/Link.tsx
@@ -1,2 +1,11 @@
-import { Link, type LinkProps } from '@digdir/designsystemet-react';
+import {
+  Link as DigdirLink,
+  type LinkProps as DigdirLinkProps,
+} from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type LinkProps = Omit<DigdirLinkProps, 'data-color'>;
+
+const Link = DigdirLink as ForwardRefExoticComponent<LinkProps>;
+
 export { Link, LinkProps };

--- a/@udir-design/react/src/components/link/__snapshots__/Link.stories.tsx.snap
+++ b/@udir-design/react/src/components/link/__snapshots__/Link.stories.tsx.snap
@@ -18,15 +18,6 @@ exports[`Long Link 1`] = `
 </p>
 `;
 
-exports[`Neutral 1`] = `
-<a
-  href="https://udir.no/"
-  data-color="neutral"
->
-  Gå til designsystemet
-</a>
-`;
-
 exports[`Preview 1`] = `
 <a href="https://udir.no/">
   Gå til udirs hjemmeside

--- a/@udir-design/react/src/components/pagination/Pagination.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 import {
-  Pagination,
-  type PaginationProps,
+  Pagination as DigdirPagination,
+  type PaginationProps as DigdirPaginationProps,
   PaginationButton,
   type PaginationButtonProps,
   PaginationItem,
@@ -10,6 +10,13 @@ import {
   usePagination,
   type UsePaginationProps,
 } from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type PaginationProps = Omit<DigdirPaginationProps, 'data-color'>;
+
+const Pagination =
+  DigdirPagination as ForwardRefExoticComponent<PaginationProps> &
+    Pick<typeof DigdirPagination, 'Button' | 'List' | 'Item'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Pagination.displayName = 'Pagination';

--- a/@udir-design/react/src/components/radio/Radio.stories.tsx
+++ b/@udir-design/react/src/components/radio/Radio.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   Button,
+  Card,
   Divider,
   Fieldset,
   Paragraph,
@@ -208,4 +209,30 @@ export const Inline: Story = {
       </div>
     </Fieldset>
   ),
+};
+
+export const RadioInColorContext: Story = {
+  args: {
+    label: 'Radio',
+    description: 'Description',
+    checked: true,
+    id: 'radio-in-color-context',
+  },
+  render: (args) => (
+    <Card data-color="accent" variant="tinted">
+      <Radio {...args} />
+    </Card>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Should have neutral color palette by default, no matter the surrounding color palette',
+      async () => {
+        const radio = within(canvasElement).getByRole('radio');
+        const expectedColor = getComputedStyle(radio).getPropertyValue(
+          '--ds-color-neutral-base-default',
+        );
+        expect(radio).toHaveStyle(`background-color: ${expectedColor}`);
+      },
+    );
+  },
 };

--- a/@udir-design/react/src/components/radio/Radio.tsx
+++ b/@udir-design/react/src/components/radio/Radio.tsx
@@ -1,2 +1,11 @@
-import { Radio, type RadioProps } from '@digdir/designsystemet-react';
+import {
+  Radio as DigdirRadio,
+  type RadioProps as DigdirRadioProps,
+} from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type RadioProps = Omit<DigdirRadioProps, 'data-color'>;
+
+const Radio = DigdirRadio as ForwardRefExoticComponent<RadioProps>;
+
 export { Radio, RadioProps };

--- a/@udir-design/react/src/components/radio/__snapshots__/Radio.stories.tsx.snap
+++ b/@udir-design/react/src/components/radio/__snapshots__/Radio.stories.tsx.snap
@@ -342,6 +342,34 @@ exports[`Preview 1`] = `
 </div>
 `;
 
+exports[`Radio In Color Context 1`] = `
+<div
+  data-variant="tinted"
+  data-color="accent"
+>
+  <div>
+    <input
+      type="radio"
+      id="radio-in-color-context"
+      checked
+      aria-describedby="radio-in-color-context:description"
+    >
+    <label
+      data-weight="regular"
+      for="radio-in-color-context"
+    >
+      Radio
+    </label>
+    <div
+      data-field="description"
+      id="radio-in-color-context:description"
+    >
+      Description
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Read Only 1`] = `
 <fieldset>
   <legend data-weight="medium">

--- a/@udir-design/react/src/components/suggestion/Suggestion.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.tsx
@@ -1,6 +1,6 @@
 import {
-  EXPERIMENTAL_Suggestion as Suggestion,
-  type SuggestionProps,
+  EXPERIMENTAL_Suggestion as DigdirSuggestion,
+  type SuggestionProps as DigdirSuggestionProps,
   EXPERIMENTAL_SuggestionClear as SuggestionClear,
   type SuggestionClearProps,
   EXPERIMENTAL_SuggestionEmpty as SuggestionEmpty,
@@ -12,6 +12,16 @@ import {
   EXPERIMENTAL_SuggestionOption as SuggestionOption,
   type SuggestionOptionProps,
 } from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type SuggestionProps = Omit<DigdirSuggestionProps, 'data-color'>;
+
+const Suggestion =
+  DigdirSuggestion as ForwardRefExoticComponent<SuggestionProps> &
+    Pick<
+      typeof DigdirSuggestion,
+      'Clear' | 'Empty' | 'Input' | 'List' | 'Option'
+    >;
 
 Suggestion.displayName = 'Suggestion';
 SuggestionClear.displayName = 'Suggestion.Clear';

--- a/@udir-design/react/src/components/switch/Switch.stories.tsx
+++ b/@udir-design/react/src/components/switch/Switch.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Switch } from './Switch';
+import { Card } from '@digdir/designsystemet-react';
+import { expect, within } from '@storybook/test';
 
 const meta: Meta<typeof Switch> = {
   component: Switch,
@@ -14,4 +16,30 @@ export const Preview: Story = {
     label: 'En bryter',
   },
   render: (args, context) => <Switch {...args} id={context.id} />,
+};
+
+export const SwitchInColorContext: Story = {
+  args: {
+    label: 'Radio',
+    description: 'Description',
+    checked: true,
+    id: 'switch-in-color-context',
+  },
+  render: (args) => (
+    <Card data-color="accent" variant="tinted">
+      <Switch {...args} />
+    </Card>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Should have neutral color palette by default, no matter the surrounding color palette',
+      async () => {
+        const element = within(canvasElement).getByRole('switch');
+        const expectedColor = getComputedStyle(element).getPropertyValue(
+          '--ds-color-neutral-base-default',
+        );
+        expect(element).toHaveStyle(`background-color: ${expectedColor}`);
+      },
+    );
+  },
 };

--- a/@udir-design/react/src/components/switch/Switch.tsx
+++ b/@udir-design/react/src/components/switch/Switch.tsx
@@ -1,2 +1,11 @@
-import { Switch, type SwitchProps } from '@digdir/designsystemet-react';
+import {
+  Switch as DigdirSwitch,
+  type SwitchProps as DigdirSwitchProps,
+} from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type SwitchProps = Omit<DigdirSwitchProps, 'data-color'>;
+
+const Switch = DigdirSwitch as ForwardRefExoticComponent<SwitchProps>;
+
 export { Switch, SwitchProps };

--- a/@udir-design/react/src/components/switch/__snapshots__/Switch.stories.tsx.snap
+++ b/@udir-design/react/src/components/switch/__snapshots__/Switch.stories.tsx.snap
@@ -15,3 +15,32 @@ exports[`Preview 1`] = `
   </label>
 </div>
 `;
+
+exports[`Switch In Color Context 1`] = `
+<div
+  data-variant="tinted"
+  data-color="accent"
+>
+  <div>
+    <input
+      type="checkbox"
+      role="switch"
+      id="switch-in-color-context"
+      checked
+      aria-describedby="switch-in-color-context:description"
+    >
+    <label
+      data-weight="regular"
+      for="switch-in-color-context"
+    >
+      Radio
+    </label>
+    <div
+      data-field="description"
+      id="switch-in-color-context:description"
+    >
+      Description
+    </div>
+  </div>
+</div>
+`;

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from '@storybook/test';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
 import { Textfield } from './Textfield';
 import { useState } from 'react';
 import { Button, Divider, Paragraph } from '../alpha';
@@ -63,7 +63,9 @@ export const Preview: Story = {
     });
 
     await step('Label is rendered', async () => {
-      const labelElement = canvas.getByText(args.label as string);
+      const labelElement = await waitFor(() =>
+        canvas.getByText(args.label as string),
+      );
       expect(labelElement).toBeInTheDocument();
     });
 

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { ToggleGroup } from './ToggleGroup';
+import { Card } from '@digdir/designsystemet-react';
+import { expect, within } from '@storybook/test';
 
 const meta: Meta<typeof ToggleGroup> = {
   component: ToggleGroup,
@@ -21,4 +23,25 @@ export const Preview: Story = {
       <ToggleGroup.Item value="sendt">Sendt</ToggleGroup.Item>
     </ToggleGroup>
   ),
+};
+
+export const ToggleGroupInColorContext: Story = {
+  args: Preview.args,
+  render: (args, context) => (
+    <Card data-color="accent" variant="tinted">
+      {Preview.render?.(args, context)}
+    </Card>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Should have neutral color palette by default, no matter the surrounding color palette',
+      async () => {
+        const firstButton = within(canvasElement).getAllByRole('radio')[0];
+        const expectedColor = getComputedStyle(firstButton).getPropertyValue(
+          '--ds-color-neutral-base-default',
+        );
+        expect(firstButton).toHaveStyle(`background-color: ${expectedColor}`);
+      },
+    );
+  },
 };

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.tsx
@@ -1,11 +1,17 @@
 import {
-  ToggleGroup,
-  type ToggleGroupProps,
+  ToggleGroup as DigdirToggleGroup,
+  type ToggleGroupProps as DigdirToggleGroupProps,
   ToggleGroupItem,
   type ToggleGroupItemProps,
 } from '@digdir/designsystemet-react';
+import { ForwardRefExoticComponent } from 'react';
+
+type ToggleGroupProps = Omit<DigdirToggleGroupProps, 'data-color'>;
+
+const ToggleGroup =
+  DigdirToggleGroup as ForwardRefExoticComponent<ToggleGroupProps> &
+    Pick<typeof DigdirToggleGroup, 'Item'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 ToggleGroup.displayName = 'ToggleGroup';
-
 export { ToggleGroup, ToggleGroupProps, ToggleGroupItem, ToggleGroupItemProps };

--- a/@udir-design/react/src/components/toggleGroup/__snapshots__/ToggleGroup.stories.tsx.snap
+++ b/@udir-design/react/src/components/toggleGroup/__snapshots__/ToggleGroup.stories.tsx.snap
@@ -63,3 +63,72 @@ exports[`Preview 1`] = `
   </button>
 </div>
 `;
+
+exports[`Toggle Group In Color Context 1`] = `
+<div
+  data-variant="tinted"
+  data-color="accent"
+>
+  <div
+    role="radiogroup"
+    tabindex="0"
+  >
+    <button
+      data-variant="primary"
+      type="button"
+      value="innboks"
+      id="togglegroup-item-:rb:"
+      aria-checked="true"
+      aria-current="true"
+      role="radio"
+      name="togglegroup-name-:r9:"
+      data-roving-tabindex-item="true"
+      tabindex="0"
+    >
+      Innboks
+    </button>
+    <button
+      data-variant="tertiary"
+      type="button"
+      value="utkast"
+      id="togglegroup-item-:rd:"
+      aria-checked="false"
+      aria-current="false"
+      role="radio"
+      name="togglegroup-name-:r9:"
+      data-roving-tabindex-item="true"
+      tabindex="-1"
+    >
+      Utkast
+    </button>
+    <button
+      data-variant="tertiary"
+      type="button"
+      value="arkiv"
+      id="togglegroup-item-:rf:"
+      aria-checked="false"
+      aria-current="false"
+      role="radio"
+      name="togglegroup-name-:r9:"
+      data-roving-tabindex-item="true"
+      tabindex="-1"
+    >
+      Arkiv
+    </button>
+    <button
+      data-variant="tertiary"
+      type="button"
+      value="sendt"
+      id="togglegroup-item-:rh:"
+      aria-checked="false"
+      aria-current="false"
+      role="radio"
+      name="togglegroup-name-:r9:"
+      data-roving-tabindex-item="true"
+      tabindex="-1"
+    >
+      Sendt
+    </button>
+  </div>
+</div>
+`;

--- a/@udir-design/theme/dist/udir.css
+++ b/@udir-design/theme/dist/udir.css
@@ -965,7 +965,7 @@
  */
 
 @layer ds.theme.color {
-:root, [data-color-scheme], [data-color="neutral"] {
+:root, [data-color-scheme], :not([data-color]):where(.ds-button, .ds-field, .ds-input, .ds-togglegroup), [data-color="neutral"] {
   --ds-color-background-default: var(--ds-color-neutral-background-default);
   --ds-color-background-tinted: var(--ds-color-neutral-background-tinted);
   --ds-color-surface-default: var(--ds-color-neutral-surface-default);

--- a/@udir-design/theme/project.json
+++ b/@udir-design/theme/project.json
@@ -7,7 +7,8 @@
   "// targets": "to see all targets run: nx show project @udir-design/theme --web",
   "targets": {
     "build": {
-      "cache": true
+      "cache": true,
+      "inputs": ["default", "^default", "{workspaceRoot}/@internal/build-tools"]
     }
   }
 }


### PR DESCRIPTION
This affects the following components:
- **Button**: only allow "neutral" and "danger" colors
- **Breadcrumbs, Checkbox, Field, Link, Input, Pagination, Radio, Suggestion, Switch, ToggleGroup**: only allow "neutral" color
- All the mentioned components: always default to "neutral" color if `data-color` is not set explicitly