### PR TITLE
ci: pin all external actions to commit hash to avoid supply chain attacks

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Note: pnpm version is set in package.json "packageManager"
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
     # Cache node_modules
     # Note: node version is set in package.json "engines.node"
@@ -25,6 +25,6 @@ runs:
     - run: pnpm install
       shell: bash
 
-    - uses: nrwl/nx-set-shas@v4
+    - uses: nrwl/nx-set-shas@dbe0650947e5f2c81f59190a38512cf49126fe6b # v4.3.0
       with:
         main-branch-name: ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       run_ui_tests: ${{ steps.job_condition.outputs.run_ui_tests }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -55,21 +55,21 @@ jobs:
 
       - name: Skip 'Storybook Publish' check
         if: steps.job_condition.outputs.run_ui_tests == 'false'
-        uses: LouisBrunner/checks-action@v2.0.0
+        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Storybook Publish
           conclusion: skipped
       - name: Skip 'UI Tests' check
         if: steps.job_condition.outputs.run_ui_tests == 'false'
-        uses: LouisBrunner/checks-action@v2.0.0
+        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: UI Tests
           conclusion: skipped
       - name: Skip 'UI Review' check
         if: steps.job_condition.outputs.run_ui_tests == 'false'
-        uses: LouisBrunner/checks-action@v2.0.0
+        uses: LouisBrunner/checks-action@6b626ffbad7cc56fd58627f774b9067e6118af23 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: UI Review
@@ -93,7 +93,7 @@ jobs:
     needs: main
     if: needs.main.outputs.run_ui_tests == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: ./.github/actions/pnpm-setup
@@ -108,7 +108,7 @@ jobs:
     needs: [main]
     if: needs.main.outputs.run_ui_tests == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -118,7 +118,7 @@ jobs:
         run: pnpm nx build:storybook
 
       - name: Publish Storybook to Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@e8cc4c31775280b175a3c440076c00d19a9014d7 # v11.28.2
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: '@udir-design/react'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -10,11 +10,11 @@ jobs:
   update-deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/pnpm-setup
       - run: pnpm update -r
       - name: Create or update pull request
-        uses: peter-evans/create-pull-request@v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           branch: build/update-patch-and-minor-deps
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/update-digdir.yml
+++ b/.github/workflows/update-digdir.yml
@@ -9,7 +9,7 @@ jobs:
   update-digdir:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/pnpm-setup
       - name: Check if update is necessary
         run: echo "version=$(pnpm outdated -r '@digdir/*' --json | jq -r '."@digdir/designsystemet".latest // ""')" >> "$GITHUB_OUTPUT"
@@ -19,7 +19,7 @@ jobs:
         if: steps.digdir_info.outputs.version
       - name: Create or update pull request
         if: steps.digdir_info.outputs.version
-        uses: peter-evans/create-pull-request@v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           branch: build/update-digdir
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/update-major-alert.yml
+++ b/.github/workflows/update-major-alert.yml
@@ -9,7 +9,7 @@ jobs:
   update-major-alert:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/pnpm-setup
       - name: Find outdated major versions
         id: outdated_majors
@@ -21,7 +21,7 @@ jobs:
           } >> $GITHUB_OUTPUT
       - name: Post to slack
         if: steps.outdated_majors.outputs.slack_message
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_DS_UDIR_DEV_WEBHOOK }}
           webhook-type: incoming-webhook

--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -9,7 +9,7 @@ jobs:
   update-prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/pnpm-setup
       - name: Configure git user
         run: |
@@ -38,7 +38,7 @@ jobs:
           git commit --all -m "chore: update .git-blame-ignore-revs"
 
       - name: Create or update pull request
-        uses: peter-evans/create-pull-request@v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           branch: build/update-prettier
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
E.g. https://unit42.paloaltonetworks.com/github-actions-supply-chain-attack/

> **Pin GitHub actions**: Instead of referencing GitHub actions by tag or branch
> (e.g., `@v3` or `@main`), pin actions to a full-length commit SHA-1 hash to ensure
> that the code cannot be changed by a malicious actor.

This is also the primary recomendation from GitHub:

> We strongly recommend that you include the version of the action you are using by specifying
> a Git ref, SHA, or Docker tag number.
> [...]
> - Using the commit SHA of a released action version is the safest for stability and security.

dependabot is able to update these hashes and the version comments.