### PR TITLE
feat: table-beta

### DIFF
--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -3,14 +3,8 @@ import './customTheme.scss';
 import { INITIAL_VIEWPORTS, type ViewportMap } from 'storybook/viewport';
 import { Preview } from '@storybook/react-vite';
 import customTheme from './customTheme';
-import {
-  Heading,
-  HeadingProps,
-  Link,
-  List,
-  Paragraph,
-  Table,
-} from '../src/alpha';
+import { Heading, HeadingProps, Link, List, Paragraph } from '../src/alpha';
+import { Table } from '../src/beta';
 import componentStyles from './componentOverrides.module.scss';
 import { customStylesDecorator } from './utils/customStylesDecorator';
 import { MdxComponentOverrides } from './types/parameters';

--- a/@udir-design/react/src/components/alpha.ts
+++ b/@udir-design/react/src/components/alpha.ts
@@ -5,7 +5,6 @@
 export * from './dropdown/Dropdown';
 export * from './suggestion/Suggestion';
 export * from './switch/Switch';
-export * from './table/Table';
 export * from './tabs/Tabs';
 export * from './toggleGroup/ToggleGroup';
 export * from './typography';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -29,5 +29,6 @@ export * from './skipLink/SkipLink';
 export * from './spinner/Spinner';
 export * from './tag/Tag';
 export * from './textarea/Textarea';
+export * from './table';
 export * from './textfield/Textfield';
 export * from './tooltip/Tooltip';

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -8,8 +8,6 @@ import {
 
 import * as TableStories from './Table.stories';
 
-import { TableHeaderCell } from './Table';
-
 <Meta of={TableStories} />
 
 # Table
@@ -20,12 +18,15 @@ Tabeller gjør det enklere for brukerne å skanne og sammenligne informasjon.
 **Passer til å**
 
 - gjøre det enkelt for brukerne å sammenligne og skanne informasjon
-- organisere og vise data på en effektiv måte i rekker og kolonner
+- strukturere og vise data effektivt i rader og kolonner
+- presentere oversikter med tall eller annen informasjon som kan sorteres
 
 **Passer ikke til å**
 
-- lage layout for innholdet på nettsiden eller å dele opp innholdet på en side systematisk
-- vise store mengder data på mobil
+- lage layout eller strukturere innholdet på en side visuelt
+- presentere informasjon som egner seg bedre i liste- eller kortform
+- vise bare én kolonne eller svært få datapunkter uten behov for sammenligning
+- vise store datamengder på mobil, der tabellen blir vanskelig å lese
 
 ## Slik bruker du Table
 
@@ -48,12 +49,18 @@ import { Table } from '@udir-design/react';
       <Table.Cell>Cell 2</Table.Cell>
     </Table.Row>
   </Table.Body>
+  <Table.Foot>
+    <Table.Row>
+      <Table.HeaderCell>Footer 1</Table.HeaderCell>
+      <Table.HeaderCell>Footer 2</Table.HeaderCell>
+    </Table.Row>
+  </Table.Foot>
 </Table>;
 ```
 
 ### Tabelltekst
 
-Bruk [`caption`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption) til å beskrive en tabell
+Bruk [`<caption>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption) til å beskrive en tabell
 på samme måte som vi ville brukt en overskrift.
 En tabelltekst hjelper brukerne til å finne, navigere og forstå tabeller.
 Denne plasseres rett etter `Table`-taggen.
@@ -65,7 +72,7 @@ Denne plasseres rett etter `Table`-taggen.
 </Table>
 ```
 
-### Tabelloverskrifter
+### Rad- og kolonneoverskrifter
 
 Bruk tabelloverskrifter til å fortelle brukerne hva som er innholdet i radene og kolonnene.
 Bruk [scope-atributtet](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope) til å hjelpe brukere av hjelpeteknologi til å
@@ -79,7 +86,7 @@ Tabelloverskrifter kan få en tinted farge. Dette kontrolleres med to props for 
 
 Når det er tall i en tabell som skal sammenlignes, plasser tallene til høyre i tabellfeltet.
 
-## Varianter av Table
+## Eksempler
 
 Tabeller kan være enkle med få rader og kolonner, eller de kan ha mye innhold med interaktive komponenter som lenker, knapper,
 avkryssingsbokser og nedtrekkslister.
@@ -101,15 +108,24 @@ Du kan legge inn skjemaelementer i en tabell, men du må håndtere logikken selv
 
 ### Sortering av rader
 
-Props på `Table.HeaderCell` kan brukes for å vise at radene i tabellen kan sorteres basert på innholdet i kolonnen.
-Bruk `sort` prop for å indikere sorteringsretningen (`"none"` = usortert, `"ascending"` = stigende, eller `"descending"` = synkende), og `onClick` prop for å håndtere klikk på sorterbare kolonneoverskrifter.
+Du kan bruke props på `Table.HeaderCell` for å vise at tabellen kan sorteres etter innholdet i en kolonne.
+
+- Bruk `sort`-prop'en for å indikere sorteringsretningen:
+  - `"none"` – ingen sortering
+  - `"ascending"` – stigende rekkefølge
+  - `"descending"` – synkende rekkefølge
+- Bruk `onClick` for å håndtere hva som skal skje når brukeren klikker på kolonneoverskriften.
+
+Dette gir brukeren visuell tilbakemelding på sorteringsstatus og gjør det mulig å implementere egendefinert sorteringslogikk.
 
 <Canvas of={TableStories.Sortable} />
 
 ### Fixed
 
 Du kan legge på `table-layout: fixed` for å få en tabell som ikke endrer bredden på kolonnene når innholdet endrer seg.
-Dette hjelper nettleseren til å tegne tabellen raskere, og er nyttig når du har paginering eller andre elementer som endrer innholdet i tabellen.
+Dette hjelper nettleseren til å tegne tabellen raskere.
+
+Det er spesielt nyttig i tabeller med paginering eller annen dynamisk oppdatering av innhold, der stabil kolonnebredde gir bedre brukeropplevelse.
 
 <Canvas of={TableStories.FixedTable} />
 
@@ -121,26 +137,18 @@ Dette hjelper nettleseren til å tegne tabellen raskere, og er nyttig når du ha
 
 Vi bruker `Table` når vi skal organisere og vise data på en strukturert måte i rader og kolonner for brukerne.
 
-Alt innhold bør være venstrejustert i tabeller, unntatt tall som bør høyrejusteres for at brukerne lett skal kunne sammenligne tallene.
+- Alt innhold bør være venstrejustert i tabeller, unntatt tall som bør høyrejusteres for at brukerne lett skal kunne sammenligne tallene.
 
-For å spare plass, kan vi bruke en meny, hvis flere handlinger i en tabellrad ikke må være synlig for brukerne hele tiden.
+- For å spare plass, kan vi bruke en meny, hvis flere handlinger i en tabellrad ikke må være synlig for brukerne hele tiden.
 
-I overskriftceller bruker vi `<Table.HeaderCell>`, ikke `<Table.Cell>`. En celle er en overskrift hvis den beskriver
-innholdet i samme rad eller kolonne.
+- I overskriftceller bruker vi `<Table.HeaderCell>`, ikke `<Table.Cell>`. En celle er en overskrift hvis den beskriver
+  innholdet i samme rad eller kolonne.
 
 ## Tekst i Table
 
-Vi bruker overskrifter til å fortelle brukerne hva som er innholdet i radene og kolonnene.
+Unngå lange tekster i tabellceller. Hold innholdet kort og konsist, slik at det er lett å skanne på tvers av rader og kolonner. Hvis du trenger å vise mer informasjon, kan du vurdere å lenke til en detaljside. Bruk overskrifter til å fortelle brukerne hva slags innhold de finner i radene og kolonnene.
 
-Innholdet i cellene skal som regel være venstrejustert.
-Unntak som skal være høyrejustert:
-
-- Tall og valuta
-- Knapper
-
-For å gjøre tabellraden lesbar på smale skjermer, skal innholdet normalt være toppjustert.
-Men hvis raden har én eller flere knapper, bruker vi sentrering.
-Overskrifter kan med fordel gjøres `sticky`, det vil si at de fortsatt blir vist, selv om brukeren ruller nedover i tabellen.
+Som hovedregel skal innhold i celler være venstrejustert, slik at det blir lettere å lese og skanne informasjon. Unntaket er tall og valuta, og noen ganger skjemaelementer og knapper. For å sikre god lesbarhet på smale skjermer, skal innhold i rader som hovedregel være toppjustert.
 
 ## Tilgjengelighet
 
@@ -151,11 +159,11 @@ For å sikre at tabeller fungerer optimalt for alle brukere er det viktig å fø
 - **Overskrifter:**
   For at brukerne skal kunne navigere i innholdet med skjermleser, er det viktig å bruke rad- og/eller kolonneoverskrifter (`<Table.HeaderCell>`). Bruk `scope="row"` og `scope="col"` for å angi om overskriften gjelder en rad eller kolonne. Hvis det er behov for å spare plass, kan vi visuelt skjule én eller flere overskrifter.
 - **Caption-element:**
-  Tabeller skal alltid ha et caption-element med kort tekst om hva tabellen viser. Skjermlesere vil lese caption-elementet, og brukerne kan ta stilling til om de vil lese videre i tabellen.
+  Tabeller skal alltid ha et `<caption>`-element med kort tekst om hva tabellen viser. Skjermlesere vil lese `<caption>`-elementet, og brukerne kan ta stilling til om de vil lese videre i tabellen.
 - **Tomme celler:**
   Tomme celler skal være `Table.Cell`. Dette er viktig for å sikre at skjermlesere kan navigere riktig i tabellen.
 - **Tastaturnavigering:**
   Sjekk at du kan velge ulik sortering med tastatur. Test med skjermleser at du hører hva som er sorterbart, typer sortering og at du ikke mister fokus når du endrer sortering.
 - **Tilpasning for mobil:**
   Det kan være vanskelig å vise tabeller på mobil, siden det ikke finnes et felles design som fungerer i alle sammenhenger.
-  De vanligste alternativene som brukes på mobil er en tabell som ruller horisontalt eller omgjøring til listevisning.
+  De vanligste alternativene for mobil er en tabell som ruller horisontalt eller omgjøring til listevisning.

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -71,6 +71,8 @@ Bruk tabelloverskrifter til å fortelle brukerne hva som er innholdet i radene o
 Bruk [scope-atributtet](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th#scope) til å hjelpe brukere av hjelpeteknologi til å
 skille mellom overskriftene på rader og kolonner.
 
+Tabelloverskrifter kan få en tinted farge. Dette kontrolleres med to props for column- og row headers respektivt: `tintedColumnHeader` og `tintedRowHeader`. Vær bevisst på når man velger å bruke tinted headere, og vær gjerne konsekvent i hvert system.
+
 <Canvas of={TableStories.ColumnAndRowHeaders} />
 
 ### Tall i en tabell
@@ -87,7 +89,7 @@ Tabellen skal kunne vises i den bredden som innholdet krever.
 
 ### Sticky header
 
-Bruk `stickyHeader={true}` for å få en sticky header.
+Bruk `stickyHeader={true}` for å få en sticky header som gjør det lettere å få oversikt i større tabeller med mye informasjon. Dette gjelder både row- og column headere.
 
 <Canvas of={TableStories.StickyHeader} />
 

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -1,17 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import {
-  Checkbox,
-  Table,
-  TableHeaderCellProps,
-  Textfield,
-} from '@udir-design/react/alpha';
+import { Checkbox, Tag, Textfield } from '@udir-design/react/alpha';
+import { List, Table, TableHeaderCellProps } from '@udir-design/react/beta';
 import { useState } from 'react';
 import { useCheckboxGroup } from '@udir-design/react/alpha';
 import { expect, within } from 'storybook/test';
+import { Pagination, usePagination } from '@digdir/designsystemet-react';
 
 const meta: Meta<typeof Table> = {
   component: Table,
-  tags: ['alpha'],
+  tags: ['beta'],
   parameters: {
     customStyles: {
       width: 'fit-content',
@@ -25,7 +22,7 @@ type Story = StoryObj<typeof Table>;
 
 export const Preview: Story = {
   args: {
-    zebra: true,
+    zebra: false,
     stickyHeader: false,
     border: false,
     hover: false,
@@ -34,33 +31,85 @@ export const Preview: Story = {
     'data-color': 'neutral',
   },
   render: (args) => {
+    const [sortField, setSortField] = useState<
+      keyof (typeof dummyData)[0] | null
+    >(null);
+    const [sortDirection, setSortDirection] =
+      useState<TableHeaderCellProps['sort']>(undefined);
+    const handleSort = (field: keyof (typeof dummyData)[0]) => {
+      if (sortField === field && sortDirection === 'descending') {
+        setSortField(null);
+        setSortDirection(undefined);
+      } else {
+        setSortField(field);
+        setSortDirection(
+          sortField === field && sortDirection === 'ascending'
+            ? 'descending'
+            : 'ascending',
+        );
+      }
+    };
+    const sortedData = [...dummyData].sort((a, b) => {
+      if (sortField === null) return 0;
+      if (a[sortField] < b[sortField])
+        return sortDirection === 'ascending' ? -1 : 1;
+      if (a[sortField] > b[sortField])
+        return sortDirection === 'ascending' ? 1 : -1;
+      return 0;
+    });
+    const { getCheckboxProps } = useCheckboxGroup({
+      name: 'my-checkbox',
+    });
     return (
       <Table {...args}>
-        <caption>Table caption</caption>
+        <caption>Sensur FSP6236 Tegnspråk III</caption>
         <Table.Head>
           <Table.Row>
-            <Table.HeaderCell>Header 1</Table.HeaderCell>
-            <Table.HeaderCell>Header 2</Table.HeaderCell>
-            <Table.HeaderCell>Header 3</Table.HeaderCell>
+            <Table.HeaderCell>
+              <Checkbox
+                aria-label="Velg alle ansatte"
+                id="checkbox-select-all"
+                {...getCheckboxProps({
+                  allowIndeterminate: true,
+                })}
+              />
+            </Table.HeaderCell>
+            <Table.HeaderCell
+              sort={sortField === 'navn' ? sortDirection : 'none'}
+              onClick={() => handleSort('navn')}
+            >
+              Navn
+            </Table.HeaderCell>
+            <Table.HeaderCell>E-post</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
+            <Table.HeaderCell>Besvarelser</Table.HeaderCell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
-          <Table.Row>
-            <Table.Cell>Cell 1</Table.Cell>
-            <Table.Cell>Cell 2</Table.Cell>
-            <Table.Cell>Cell 3</Table.Cell>
-          </Table.Row>
-          <Table.Row>
-            <Table.Cell>Cell 4</Table.Cell>
-            <Table.Cell>Cell 5</Table.Cell>
-            <Table.Cell>Cell 6</Table.Cell>
-          </Table.Row>
+          {sortedData.map((row) => (
+            <Table.Row key={row.id}>
+              <Table.Cell>
+                <Checkbox
+                  id={'checkbox-' + row.id}
+                  aria-label={`Velg ${row}`}
+                  {...getCheckboxProps(String(row.id))}
+                />
+              </Table.Cell>
+              <Table.Cell>{row.navn}</Table.Cell>
+              <Table.Cell>{row.epost}</Table.Cell>
+              <Table.Cell>
+                <Tag data-color={tagColor(row.status)}>{row.status}</Tag>
+              </Table.Cell>
+              <Table.Cell style={{ textAlign: 'right' }}>
+                {row.prover}
+              </Table.Cell>
+            </Table.Row>
+          ))}
         </Table.Body>
         <Table.Foot>
           <Table.Row>
-            <Table.Cell>Footer 1</Table.Cell>
-            <Table.Cell>Footer 2</Table.Cell>
-            <Table.Cell>Footer 3</Table.Cell>
+            <Table.Cell colSpan={4}>Totalt gjenstår</Table.Cell>
+            <Table.Cell style={{ textAlign: 'right' }}>68</Table.Cell>
           </Table.Row>
         </Table.Foot>
       </Table>
@@ -145,29 +194,63 @@ export const ColumnAndRowHeaders: Story = {
 const dummyData = [
   {
     id: 1,
-    navn: 'Lise Nordmann',
-    epost: 'lise@nordmann.no',
+    navn: 'Rita Nordmann',
+    epost: 'rita@nordmann.no',
     telefon: '22345678',
+    rolle: 'Rektor',
+    prover: 19,
+    status: 'I arbeid',
   },
   {
     id: 2,
     navn: 'Kari Nordmann',
     epost: 'kari@nordmann.no',
     telefon: '87654321',
+    rolle: 'Lektor',
+    prover: 0,
+    status: 'Ferdig',
   },
   {
     id: 3,
     navn: 'Ola Nordmann',
     epost: 'ola@nordmann.no',
     telefon: '32345678',
+    rolle: 'Lektor',
+    prover: 14,
+    status: 'I arbeid',
   },
   {
     id: 4,
-    navn: 'Per Nordmann',
-    epost: 'per@nordmann.no',
+    navn: 'Kai Nordmann',
+    epost: 'kai@nordmann.no',
+    telefon: '62353278',
+    rolle: 'Lektor',
+    prover: 35,
+    status: 'Ikke begynt',
+  },
+  {
+    id: 5,
+    navn: 'Mateo Nordmann',
+    epost: 'mateo@nordmann.no',
     telefon: '12345678',
+    rolle: 'Ass. rektor',
+    prover: 0,
+    status: 'Ferdig',
   },
 ];
+
+const tagColor = (status: string) => {
+  switch (status) {
+    case 'Ikke begynt':
+      return 'warning';
+    case 'I arbeid':
+      return 'info';
+    case 'Ferdig':
+      return 'success';
+    default:
+      return 'info';
+  }
+};
 
 export const Sortable: Story = {
   render(args) {
@@ -219,6 +302,13 @@ export const Sortable: Story = {
             >
               Telefon
             </Table.HeaderCell>
+            <Table.HeaderCell
+              data-testid="sortable-th-rolle"
+              sort={sortField === 'rolle' ? sortDirection : 'none'}
+              onClick={() => handleSort('rolle')}
+            >
+              Rolle
+            </Table.HeaderCell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
@@ -227,6 +317,7 @@ export const Sortable: Story = {
               <Table.Cell>{row.navn}</Table.Cell>
               <Table.Cell>{row.epost}</Table.Cell>
               <Table.Cell>{row.telefon}</Table.Cell>
+              <Table.Cell>{row.rolle}</Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>
@@ -251,6 +342,9 @@ export const StickyHeader: Story = {
     tabIndex: 0,
     stickyHeader: true,
     zebra: true,
+    tintedColumnHeader: true,
+    tintedRowHeader: true,
+    'data-color': 'support1',
   },
   parameters: {
     customStyles: {
@@ -261,38 +355,79 @@ export const StickyHeader: Story = {
     },
   },
   render: (args) => {
-    const rows = Array.from({ length: 50 }, (_, i) => i + 1);
     return (
       <Table {...args}>
         <Table.Head>
           <Table.Row>
-            <Table.Cell />
-            <Table.HeaderCell>Header 1</Table.HeaderCell>
-            <Table.HeaderCell>Header 2</Table.HeaderCell>
-            <Table.HeaderCell>Header 3</Table.HeaderCell>
-            <Table.HeaderCell>Header 4</Table.HeaderCell>
-            <Table.HeaderCell>Header 5</Table.HeaderCell>
-            <Table.HeaderCell>Header 6</Table.HeaderCell>
-            <Table.HeaderCell>Header 7</Table.HeaderCell>
-            <Table.HeaderCell>Header 8</Table.HeaderCell>
-            <Table.HeaderCell>Header 9</Table.HeaderCell>
+            <Table.HeaderCell>Fylke</Table.HeaderCell>
+            <Table.HeaderCell>Oppholdsareal per barn</Table.HeaderCell>
+            <Table.HeaderCell>Åpningstid per dag</Table.HeaderCell>
+            <Table.HeaderCell>Kostpenger</Table.HeaderCell>
+            <Table.HeaderCell>Foreldrebetaling under makspris</Table.HeaderCell>
+            <Table.HeaderCell>Hatt tilsyn</Table.HeaderCell>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {rows.map((row) => (
-            <Table.Row key={row}>
-              <Table.HeaderCell scope="row">Row {row}</Table.HeaderCell>
-              <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}3`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}4`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}5`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}6`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}7`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}8`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}9`}</Table.Cell>
-            </Table.Row>
-          ))}
+        <Table.Body style={{ textAlign: 'right' }}>
+          <Table.Row>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              Agder
+            </Table.HeaderCell>
+            <Table.Cell>5.9</Table.Cell>
+            <Table.Cell>9.4</Table.Cell>
+            <Table.Cell>400.6</Table.Cell>
+            <Table.Cell>4</Table.Cell>
+            <Table.Cell>66</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              Akershus
+            </Table.HeaderCell>
+            <Table.Cell>5.5</Table.Cell>
+            <Table.Cell>9.7</Table.Cell>
+            <Table.Cell>419.3</Table.Cell>
+            <Table.Cell>1</Table.Cell>
+            <Table.Cell>87</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              Buskerud
+            </Table.HeaderCell>
+            <Table.Cell>5.7</Table.Cell>
+            <Table.Cell>9.8</Table.Cell>
+            <Table.Cell>377.1</Table.Cell>
+            <Table.Cell>9</Table.Cell>
+            <Table.Cell>18</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              Finnmark
+            </Table.HeaderCell>
+            <Table.Cell>7.7</Table.Cell>
+            <Table.Cell>9.1</Table.Cell>
+            <Table.Cell>357.4</Table.Cell>
+            <Table.Cell>44</Table.Cell>
+            <Table.Cell>11</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              Innlandet
+            </Table.HeaderCell>
+            <Table.Cell>6.4</Table.Cell>
+            <Table.Cell>9.7</Table.Cell>
+            <Table.Cell>380.5</Table.Cell>
+            <Table.Cell>5</Table.Cell>
+            <Table.Cell>74</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              Møre og Romsdal
+            </Table.HeaderCell>
+            <Table.Cell>6.4</Table.Cell>
+            <Table.Cell>9.7</Table.Cell>
+            <Table.Cell>380.5</Table.Cell>
+            <Table.Cell>5</Table.Cell>
+            <Table.Cell>46</Table.Cell>
+          </Table.Row>
         </Table.Body>
       </Table>
     );
@@ -321,97 +456,326 @@ export const WithFormElements: Story = {
                 }
               />
             </Table.HeaderCell>
-            <Table.HeaderCell>Header 1</Table.HeaderCell>
-            <Table.HeaderCell>Header 2</Table.HeaderCell>
-            <Table.HeaderCell>Header 3</Table.HeaderCell>
+            <Table.HeaderCell>#</Table.HeaderCell>
+            <Table.HeaderCell>Spørsmål</Table.HeaderCell>
+            <Table.HeaderCell>Alternativ 1</Table.HeaderCell>
+            <Table.HeaderCell>Alternativ 2</Table.HeaderCell>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {[1, 2, 3].map((row) => (
-            <Table.Row key={row}>
-              <Table.Cell>
-                <Checkbox
-                  aria-label={`Check ${row}`}
-                  {
-                    ...(getCheckboxProps({
-                      id: `${ctx.id}-select${row}`,
-                      value: String(row),
-                    }) as object) /* TODO: remove "as object" after next.49*/
-                  }
-                />
-              </Table.Cell>
-              <Table.Cell style={{ textAlign: 'right' }}>{row}</Table.Cell>
-              <Table.Cell style={{ textAlign: 'right' }}>{row}</Table.Cell>
-              <Table.Cell>
-                <Textfield
-                  data-size="sm"
-                  aria-label={`Textfield ${row}`}
-                  id={`${ctx.id}-textfield${row}`}
-                />
-              </Table.Cell>
-            </Table.Row>
-          ))}
+        <Table.Body
+          style={{
+            alignContent: 'start',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                aria-label={`Check 1`}
+                {
+                  ...(getCheckboxProps({
+                    id: `${ctx.id}-select1`,
+                    value: '1',
+                  }) as object) /* TODO: remove "as object" after next.49*/
+                }
+              />
+            </Table.Cell>
+            <Table.Cell>1.</Table.Cell>
+            <Table.Cell>
+              <Textfield
+                data-size="sm"
+                value="Trives du på skolen?"
+                aria-label={`Textfield 1-1`}
+                id={`${ctx.id}-textfield1-1`}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Textfield
+                data-size="sm"
+                value="Trives ikke noe særlig"
+                aria-label={`Textfield 1-2`}
+                id={`${ctx.id}-textfield1-2`}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Textfield
+                value="Trives godt"
+                data-size="sm"
+                aria-label={`Textfield 1-3`}
+                id={`${ctx.id}-textfield1-3`}
+              />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                aria-label={`Check 1`}
+                {
+                  ...(getCheckboxProps({
+                    id: `${ctx.id}-select1`,
+                    value: '2',
+                  }) as object) /* TODO: remove "as object" after next.49*/
+                }
+              />
+            </Table.Cell>
+            <Table.Cell>2.</Table.Cell>
+            <Table.Cell>
+              <Textfield
+                data-size="sm"
+                value="Har du opplevd mobbing?"
+                aria-label={`Textfield 1-1`}
+                id={`${ctx.id}-textfield1-1`}
+                style={{ width: 250 }}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Textfield
+                data-size="sm"
+                value="Sjelden"
+                aria-label={`Textfield 1-2`}
+                id={`${ctx.id}-textfield1-2`}
+              />
+            </Table.Cell>
+            <Table.Cell>
+              <Textfield
+                cols={3}
+                value="Ofte"
+                data-size="sm"
+                aria-label={`Textfield 1-3`}
+                id={`${ctx.id}-textfield1-3`}
+              />
+            </Table.Cell>
+          </Table.Row>
         </Table.Body>
       </Table>
     );
   },
 };
 
+const dummyDataKommune = [
+  {
+    id: 1,
+    kommune: 'Bjerkreim kommune',
+    tildeling: '330 000',
+  },
+  {
+    id: 2,
+    kommune: 'Færder kommune',
+    tildeling: '750 000',
+  },
+  {
+    id: 3,
+    kommune: 'Gjøvik kommune',
+    tildeling: '150 000',
+  },
+  {
+    id: 4,
+    kommune: 'Hurdal kommune',
+    tildeling: '550 000',
+  },
+  {
+    id: 5,
+    kommune: 'Marker kommune',
+    tildeling: '900 000',
+  },
+  {
+    id: 6,
+    kommune: 'Nordreisa kommune',
+    tildeling: '304 000',
+  },
+  {
+    id: 7,
+    kommune: 'Osen kommune',
+    tildeling: '251 722',
+  },
+  {
+    id: 8,
+    kommune: 'Rana kommune',
+    tildeling: '700 000',
+  },
+  {
+    id: 9,
+    kommune: 'Randaberg kommune',
+    tildeling: '800 000',
+  },
+  {
+    id: 10,
+    kommune: 'Risør kommune',
+    tildeling: '450 000',
+  },
+  {
+    id: 11,
+    kommune: 'Tinn kommune',
+    tildeling: '179 200',
+  },
+  {
+    id: 12,
+    kommune: 'Bømlo kommune',
+    tildeling: '391 500',
+  },
+  {
+    id: 13,
+    kommune: 'Gjesdal kommune',
+    tildeling: '380 000',
+  },
+  {
+    id: 14,
+    kommune: 'Haugesund kommune',
+    tildeling: '3 000 000',
+  },
+  {
+    id: 15,
+    kommune: 'Karmøy kommune',
+    tildeling: '525 000',
+  },
+];
+
 export const FixedTable: Story = {
   render: (args) => {
-    const rows = Array.from({ length: 3 }, (_, i) => i + 1);
+    const [page, setCurrentPage] = useState(1);
+    const { pages, nextButtonProps, prevButtonProps } = usePagination({
+      currentPage: page,
+      totalPages: 3,
+      showPages: 3,
+      setCurrentPage: (page) => {
+        setCurrentPage(page);
+      },
+    });
+    const itemsPerPage = 5;
+
+    // Calculate the start and end index for slicing the data
+    const indexOfLastItem = page * itemsPerPage;
+    const indexOfFirstItem = indexOfLastItem - itemsPerPage;
+    const currentItems = dummyDataKommune.slice(
+      indexOfFirstItem,
+      indexOfLastItem,
+    );
+
     return (
-      <Table
-        {...args}
-        style={{
-          tableLayout: 'fixed',
-        }}
-      >
-        <Table.Head>
-          <Table.Row>
-            <Table.HeaderCell>Header 1</Table.HeaderCell>
-            <Table.HeaderCell>Header 2</Table.HeaderCell>
-            <Table.HeaderCell>Header 3</Table.HeaderCell>
-          </Table.Row>
-        </Table.Head>
-        <Table.Body>
-          {rows.map((row) => (
-            <Table.Row key={row}>
-              <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}3`}</Table.Cell>
+      <div>
+        <Table
+          {...args}
+          id="myTable"
+          style={{
+            tableLayout: 'fixed',
+            marginBottom: '12px',
+          }}
+        >
+          <caption>Tildeling skolebibliotek 2024</caption>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell>Kommune</Table.HeaderCell>
+              <Table.HeaderCell>Tildeling</Table.HeaderCell>
             </Table.Row>
-          ))}
-        </Table.Body>
-      </Table>
+          </Table.Head>
+          <Table.Body>
+            {currentItems.map((item) => (
+              <Table.Row key={item.id}>
+                <Table.Cell>{item.kommune}</Table.Cell>
+                <Table.Cell>{item.tildeling}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+        <Pagination>
+          <Pagination.List>
+            <Pagination.Item>
+              <Pagination.Button aria-label="Forrige side" {...prevButtonProps}>
+                Forrige
+              </Pagination.Button>
+            </Pagination.Item>
+            {pages.map(({ page, itemKey, buttonProps }) => (
+              <Pagination.Item key={itemKey}>
+                {typeof page === 'number' && (
+                  <Pagination.Button
+                    aria-label={`Side ${page}`}
+                    {...buttonProps}
+                  >
+                    {page}
+                  </Pagination.Button>
+                )}
+              </Pagination.Item>
+            ))}
+            <Pagination.Item>
+              <Pagination.Button aria-label="Neste side" {...nextButtonProps}>
+                Neste
+              </Pagination.Button>
+            </Pagination.Item>
+          </Pagination.List>
+        </Pagination>
+      </div>
     );
   },
 };
 
 export const MultipleHeaderRows: Story = {
+  args: {
+    zebra: true,
+    tintedColumnHeader: true,
+    tintedRowHeader: true,
+    'data-color': 'support1',
+  },
   render: (args) => {
-    const rows = Array.from({ length: 50 }, (_, i) => i + 1);
     return (
       <Table {...args}>
         <Table.Head>
           <Table.Row>
-            <Table.HeaderCell>Header 1</Table.HeaderCell>
-            <Table.HeaderCell colSpan={2}>Header 2</Table.HeaderCell>
+            <Table.Cell />
+            <Table.HeaderCell colSpan={5} style={{ textAlign: 'center' }}>
+              Trives du på skolen?
+            </Table.HeaderCell>
           </Table.Row>
           <Table.Row>
-            <Table.HeaderCell>Header 3</Table.HeaderCell>
-            <Table.HeaderCell>Header 4</Table.HeaderCell>
-            <Table.HeaderCell>Header 5</Table.HeaderCell>
+            <Table.Cell />
+            <Table.HeaderCell>Trives ikke i det hele tatt</Table.HeaderCell>
+            <Table.HeaderCell>Trives ikke noe særlig</Table.HeaderCell>
+            <Table.HeaderCell>Trives litt</Table.HeaderCell>
+            <Table.HeaderCell>Trives godt</Table.HeaderCell>
+            <Table.HeaderCell>Trives svært godt</Table.HeaderCell>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          {rows.map((row) => (
-            <Table.Row key={row}>
-              <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-              <Table.Cell>{`Cell ${row}3`}</Table.Cell>
-            </Table.Row>
-          ))}
+        <Table.Body style={{ textAlign: 'right' }}>
+          <Table.Row>
+            <Table.HeaderCell scope={'row'} style={{ textAlign: 'left' }}>
+              Idrettsfag
+            </Table.HeaderCell>
+            <Table.Cell>0.5</Table.Cell>
+            <Table.Cell>1.0</Table.Cell>
+            <Table.Cell>5.7</Table.Cell>
+            <Table.Cell>46.0</Table.Cell>
+            <Table.Cell>46.9</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope={'row'} style={{ textAlign: 'left' }}>
+              Medier og kommunikasjon
+            </Table.HeaderCell>
+            <Table.Cell>1.2</Table.Cell>
+            <Table.Cell>1.9</Table.Cell>
+            <Table.Cell>11.3</Table.Cell>
+            <Table.Cell>49.4</Table.Cell>
+            <Table.Cell>36.1</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope={'row'} style={{ textAlign: 'left' }}>
+              Musikk, dans og drama
+            </Table.HeaderCell>
+            <Table.Cell>-</Table.Cell>
+            <Table.Cell>-</Table.Cell>
+            <Table.Cell>7.0</Table.Cell>
+            <Table.Cell>41.9</Table.Cell>
+            <Table.Cell>49.8</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.HeaderCell scope={'row'} style={{ textAlign: 'left' }}>
+              Studiespesialisering
+            </Table.HeaderCell>
+            <Table.Cell>1.2</Table.Cell>
+            <Table.Cell>1.8</Table.Cell>
+            <Table.Cell>8.9</Table.Cell>
+            <Table.Cell>49.8</Table.Cell>
+            <Table.Cell>38.3</Table.Cell>
+          </Table.Row>
         </Table.Body>
       </Table>
     );
@@ -423,66 +787,46 @@ export const WithBorder: Story = {
     border: true,
     tintedColumnHeader: true,
     tintedRowHeader: true,
+    'data-color': 'support2',
   },
   render: (args) => {
-    const rows = Array.from({ length: 3 }, (_, i) => i + 1);
     return (
       <div style={{ display: 'grid', gap: '1rem' }}>
         <Table {...args}>
-          <Table.Body>
-            {rows.map((row) => (
-              <Table.Row key={row}>
-                <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}3`}</Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-          <Table.Body>
-            {rows.map((row) => (
-              <Table.Row key={row}>
-                <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}3`}</Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-        <Table {...args}>
           <Table.Head>
             <Table.Row>
-              <Table.HeaderCell>Header 3</Table.HeaderCell>
-              <Table.HeaderCell>Header 4</Table.HeaderCell>
-              <Table.HeaderCell>Header 5</Table.HeaderCell>
+              <Table.HeaderCell>Uke</Table.HeaderCell>
+              <Table.HeaderCell>Datoer</Table.HeaderCell>
+              <Table.HeaderCell>Hva</Table.HeaderCell>
             </Table.Row>
           </Table.Head>
           <Table.Body>
-            {rows.map((row) => (
-              <Table.Row key={row}>
-                <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}3`}</Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-        <Table {...args}>
-          <Table.Body>
-            {rows.map((row) => (
-              <Table.Row key={row}>
-                <Table.Cell>{`Cell ${row}1`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}2`}</Table.Cell>
-                <Table.Cell>{`Cell ${row}3`}</Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-          <Table.Foot>
             <Table.Row>
-              <Table.HeaderCell>Footer 1</Table.HeaderCell>
-              <Table.HeaderCell>Footer 2</Table.HeaderCell>
-              <Table.HeaderCell>Footer 3</Table.HeaderCell>
+              <Table.Cell>31</Table.Cell>
+              <Table.Cell>1. august</Table.Cell>
+              <Table.Cell>Påmelding til nasjonale prøver starter</Table.Cell>
             </Table.Row>
-          </Table.Foot>
+            <Table.Row>
+              <Table.Cell>36-39</Table.Cell>
+              <Table.Cell>1. september - 26. september</Table.Cell>
+              <Table.Cell>
+                Gjennomføringsuker for nasjonale prøver 5.trinn i
+                <List.Unordered>
+                  <List.Item>Engelsk</List.Item>
+                  <List.Item>Lesing</List.Item>
+                  <List.Item>Regning</List.Item>
+                </List.Unordered>
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>39</Table.Cell>
+              <Table.Cell>26. september</Table.Cell>
+              <Table.Cell>
+                Frist for registrering av fritatt og ikke deltatt for alle
+                prøvene
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
       </div>
     );

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -27,8 +27,11 @@ export const Preview: Story = {
   args: {
     zebra: true,
     stickyHeader: false,
-    border: true,
-    hover: true,
+    border: false,
+    hover: false,
+    tintedColumnHeader: false,
+    tintedRowHeader: false,
+    'data-color': 'neutral',
   },
   render: (args) => {
     return (
@@ -67,13 +70,15 @@ export const Preview: Story = {
 
 export const ColumnAndRowHeaders: Story = {
   args: {
-    zebra: true,
+    zebra: false,
     stickyHeader: false,
     border: false,
     hover: true,
+    tintedColumnHeader: true,
+    tintedRowHeader: true,
   },
   render: (args) => (
-    <Table {...args}>
+    <Table {...args} data-color="accent">
       <caption
         style={{
           fontSize: 'var(--ds-font-size-3)',
@@ -245,9 +250,15 @@ export const StickyHeader: Story = {
   args: {
     tabIndex: 0,
     stickyHeader: true,
+    zebra: true,
   },
   parameters: {
-    customStyles: { height: '280px', overflow: 'auto', padding: 0 },
+    customStyles: {
+      height: '280px',
+      width: '500px',
+      overflow: 'auto',
+      padding: 0,
+    },
   },
   render: (args) => {
     const rows = Array.from({ length: 50 }, (_, i) => i + 1);
@@ -255,17 +266,31 @@ export const StickyHeader: Story = {
       <Table {...args}>
         <Table.Head>
           <Table.Row>
+            <Table.Cell />
             <Table.HeaderCell>Header 1</Table.HeaderCell>
             <Table.HeaderCell>Header 2</Table.HeaderCell>
             <Table.HeaderCell>Header 3</Table.HeaderCell>
+            <Table.HeaderCell>Header 4</Table.HeaderCell>
+            <Table.HeaderCell>Header 5</Table.HeaderCell>
+            <Table.HeaderCell>Header 6</Table.HeaderCell>
+            <Table.HeaderCell>Header 7</Table.HeaderCell>
+            <Table.HeaderCell>Header 8</Table.HeaderCell>
+            <Table.HeaderCell>Header 9</Table.HeaderCell>
           </Table.Row>
         </Table.Head>
         <Table.Body>
           {rows.map((row) => (
             <Table.Row key={row}>
+              <Table.HeaderCell scope="row">Row {row}</Table.HeaderCell>
               <Table.Cell>{`Cell ${row}1`}</Table.Cell>
               <Table.Cell>{`Cell ${row}2`}</Table.Cell>
               <Table.Cell>{`Cell ${row}3`}</Table.Cell>
+              <Table.Cell>{`Cell ${row}4`}</Table.Cell>
+              <Table.Cell>{`Cell ${row}5`}</Table.Cell>
+              <Table.Cell>{`Cell ${row}6`}</Table.Cell>
+              <Table.Cell>{`Cell ${row}7`}</Table.Cell>
+              <Table.Cell>{`Cell ${row}8`}</Table.Cell>
+              <Table.Cell>{`Cell ${row}9`}</Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>
@@ -396,6 +421,8 @@ export const MultipleHeaderRows: Story = {
 export const WithBorder: Story = {
   args: {
     border: true,
+    tintedColumnHeader: true,
+    tintedRowHeader: true,
   },
   render: (args) => {
     const rows = Array.from({ length: 3 }, (_, i) => i + 1);

--- a/@udir-design/react/src/components/table/Table.tsx
+++ b/@udir-design/react/src/components/table/Table.tsx
@@ -1,32 +1,34 @@
 import {
-  Table,
-  type TableProps,
-  TableBody,
-  type TableBodyProps,
-  TableCell,
-  type TableCellProps,
-  TableHead,
-  type TableHeadProps,
-  TableHeaderCell,
-  type TableHeaderCellProps,
-  TableRow,
-  type TableRowProps,
+  Table as DigdirTable,
+  type TableProps as DigdirTableProps,
 } from '@digdir/designsystemet-react';
+import { forwardRef } from 'react';
 
-// For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
-Table.displayName = 'Table';
-
-export {
-  Table,
-  TableProps,
-  TableBody,
-  TableBodyProps,
-  TableCell,
-  TableCellProps,
-  TableHead,
-  TableHeadProps,
-  TableHeaderCell,
-  TableHeaderCellProps,
-  TableRow,
-  TableRowProps,
+export type TableProps = DigdirTableProps & {
+  /**
+   * Will make the column headers tinted
+   * @default false
+   */
+  tintedColumnHeader?: boolean;
+  /**
+   * Will make the row headers tinted
+   * @default false
+   */
+  tintedRowHeader?: boolean;
 };
+
+export const Table = forwardRef<HTMLTableElement, TableProps>(function Table(
+  { children, tintedColumnHeader = false, tintedRowHeader = false, ...rest },
+  ref,
+) {
+  return (
+    <DigdirTable
+      {...rest}
+      ref={ref}
+      data-tinted-column-header={tintedColumnHeader || undefined}
+      data-tinted-row-header={tintedRowHeader || undefined}
+    >
+      {children}
+    </DigdirTable>
+  );
+});

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -3,7 +3,9 @@
 exports[`Column And Row Headers 1`] = `
 <table
   data-hover="true"
-  data-zebra="true"
+  data-color="accent"
+  data-tinted-column-header="true"
+  data-tinted-row-header="true"
 >
   <caption style="font-size: var(--ds-font-size-3); caption-side: bottom; text-align: center; font-weight: normal; margin-top: var(--ds-size-2);">
     Svarprosent for elevundersøkelsen nasjonalt
@@ -745,9 +747,8 @@ exports[`Multiple Header Rows 1`] = `
 
 exports[`Preview 1`] = `
 <table
-  data-border="true"
-  data-hover="true"
   data-zebra="true"
+  data-color="neutral"
 >
   <caption>
     Table caption
@@ -876,10 +877,13 @@ exports[`Sortable 1`] = `
 exports[`Sticky Header 1`] = `
 <table
   data-sticky-header="true"
+  data-zebra="true"
   tabindex="0"
 >
   <thead>
     <tr>
+      <td>
+      </td>
       <th>
         Header 1
       </th>
@@ -889,10 +893,31 @@ exports[`Sticky Header 1`] = `
       <th>
         Header 3
       </th>
+      <th>
+        Header 4
+      </th>
+      <th>
+        Header 5
+      </th>
+      <th>
+        Header 6
+      </th>
+      <th>
+        Header 7
+      </th>
+      <th>
+        Header 8
+      </th>
+      <th>
+        Header 9
+      </th>
     </tr>
   </thead>
   <tbody>
     <tr>
+      <th scope="row">
+        Row 1
+      </th>
       <td>
         Cell 11
       </td>
@@ -902,8 +927,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 13
       </td>
+      <td>
+        Cell 14
+      </td>
+      <td>
+        Cell 15
+      </td>
+      <td>
+        Cell 16
+      </td>
+      <td>
+        Cell 17
+      </td>
+      <td>
+        Cell 18
+      </td>
+      <td>
+        Cell 19
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 2
+      </th>
       <td>
         Cell 21
       </td>
@@ -913,8 +959,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 23
       </td>
+      <td>
+        Cell 24
+      </td>
+      <td>
+        Cell 25
+      </td>
+      <td>
+        Cell 26
+      </td>
+      <td>
+        Cell 27
+      </td>
+      <td>
+        Cell 28
+      </td>
+      <td>
+        Cell 29
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 3
+      </th>
       <td>
         Cell 31
       </td>
@@ -924,8 +991,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 33
       </td>
+      <td>
+        Cell 34
+      </td>
+      <td>
+        Cell 35
+      </td>
+      <td>
+        Cell 36
+      </td>
+      <td>
+        Cell 37
+      </td>
+      <td>
+        Cell 38
+      </td>
+      <td>
+        Cell 39
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 4
+      </th>
       <td>
         Cell 41
       </td>
@@ -935,8 +1023,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 43
       </td>
+      <td>
+        Cell 44
+      </td>
+      <td>
+        Cell 45
+      </td>
+      <td>
+        Cell 46
+      </td>
+      <td>
+        Cell 47
+      </td>
+      <td>
+        Cell 48
+      </td>
+      <td>
+        Cell 49
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 5
+      </th>
       <td>
         Cell 51
       </td>
@@ -946,8 +1055,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 53
       </td>
+      <td>
+        Cell 54
+      </td>
+      <td>
+        Cell 55
+      </td>
+      <td>
+        Cell 56
+      </td>
+      <td>
+        Cell 57
+      </td>
+      <td>
+        Cell 58
+      </td>
+      <td>
+        Cell 59
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 6
+      </th>
       <td>
         Cell 61
       </td>
@@ -957,8 +1087,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 63
       </td>
+      <td>
+        Cell 64
+      </td>
+      <td>
+        Cell 65
+      </td>
+      <td>
+        Cell 66
+      </td>
+      <td>
+        Cell 67
+      </td>
+      <td>
+        Cell 68
+      </td>
+      <td>
+        Cell 69
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 7
+      </th>
       <td>
         Cell 71
       </td>
@@ -968,8 +1119,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 73
       </td>
+      <td>
+        Cell 74
+      </td>
+      <td>
+        Cell 75
+      </td>
+      <td>
+        Cell 76
+      </td>
+      <td>
+        Cell 77
+      </td>
+      <td>
+        Cell 78
+      </td>
+      <td>
+        Cell 79
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 8
+      </th>
       <td>
         Cell 81
       </td>
@@ -979,8 +1151,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 83
       </td>
+      <td>
+        Cell 84
+      </td>
+      <td>
+        Cell 85
+      </td>
+      <td>
+        Cell 86
+      </td>
+      <td>
+        Cell 87
+      </td>
+      <td>
+        Cell 88
+      </td>
+      <td>
+        Cell 89
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 9
+      </th>
       <td>
         Cell 91
       </td>
@@ -990,8 +1183,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 93
       </td>
+      <td>
+        Cell 94
+      </td>
+      <td>
+        Cell 95
+      </td>
+      <td>
+        Cell 96
+      </td>
+      <td>
+        Cell 97
+      </td>
+      <td>
+        Cell 98
+      </td>
+      <td>
+        Cell 99
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 10
+      </th>
       <td>
         Cell 101
       </td>
@@ -1001,8 +1215,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 103
       </td>
+      <td>
+        Cell 104
+      </td>
+      <td>
+        Cell 105
+      </td>
+      <td>
+        Cell 106
+      </td>
+      <td>
+        Cell 107
+      </td>
+      <td>
+        Cell 108
+      </td>
+      <td>
+        Cell 109
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 11
+      </th>
       <td>
         Cell 111
       </td>
@@ -1012,8 +1247,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 113
       </td>
+      <td>
+        Cell 114
+      </td>
+      <td>
+        Cell 115
+      </td>
+      <td>
+        Cell 116
+      </td>
+      <td>
+        Cell 117
+      </td>
+      <td>
+        Cell 118
+      </td>
+      <td>
+        Cell 119
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 12
+      </th>
       <td>
         Cell 121
       </td>
@@ -1023,8 +1279,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 123
       </td>
+      <td>
+        Cell 124
+      </td>
+      <td>
+        Cell 125
+      </td>
+      <td>
+        Cell 126
+      </td>
+      <td>
+        Cell 127
+      </td>
+      <td>
+        Cell 128
+      </td>
+      <td>
+        Cell 129
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 13
+      </th>
       <td>
         Cell 131
       </td>
@@ -1034,8 +1311,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 133
       </td>
+      <td>
+        Cell 134
+      </td>
+      <td>
+        Cell 135
+      </td>
+      <td>
+        Cell 136
+      </td>
+      <td>
+        Cell 137
+      </td>
+      <td>
+        Cell 138
+      </td>
+      <td>
+        Cell 139
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 14
+      </th>
       <td>
         Cell 141
       </td>
@@ -1045,8 +1343,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 143
       </td>
+      <td>
+        Cell 144
+      </td>
+      <td>
+        Cell 145
+      </td>
+      <td>
+        Cell 146
+      </td>
+      <td>
+        Cell 147
+      </td>
+      <td>
+        Cell 148
+      </td>
+      <td>
+        Cell 149
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 15
+      </th>
       <td>
         Cell 151
       </td>
@@ -1056,8 +1375,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 153
       </td>
+      <td>
+        Cell 154
+      </td>
+      <td>
+        Cell 155
+      </td>
+      <td>
+        Cell 156
+      </td>
+      <td>
+        Cell 157
+      </td>
+      <td>
+        Cell 158
+      </td>
+      <td>
+        Cell 159
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 16
+      </th>
       <td>
         Cell 161
       </td>
@@ -1067,8 +1407,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 163
       </td>
+      <td>
+        Cell 164
+      </td>
+      <td>
+        Cell 165
+      </td>
+      <td>
+        Cell 166
+      </td>
+      <td>
+        Cell 167
+      </td>
+      <td>
+        Cell 168
+      </td>
+      <td>
+        Cell 169
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 17
+      </th>
       <td>
         Cell 171
       </td>
@@ -1078,8 +1439,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 173
       </td>
+      <td>
+        Cell 174
+      </td>
+      <td>
+        Cell 175
+      </td>
+      <td>
+        Cell 176
+      </td>
+      <td>
+        Cell 177
+      </td>
+      <td>
+        Cell 178
+      </td>
+      <td>
+        Cell 179
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 18
+      </th>
       <td>
         Cell 181
       </td>
@@ -1089,8 +1471,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 183
       </td>
+      <td>
+        Cell 184
+      </td>
+      <td>
+        Cell 185
+      </td>
+      <td>
+        Cell 186
+      </td>
+      <td>
+        Cell 187
+      </td>
+      <td>
+        Cell 188
+      </td>
+      <td>
+        Cell 189
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 19
+      </th>
       <td>
         Cell 191
       </td>
@@ -1100,8 +1503,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 193
       </td>
+      <td>
+        Cell 194
+      </td>
+      <td>
+        Cell 195
+      </td>
+      <td>
+        Cell 196
+      </td>
+      <td>
+        Cell 197
+      </td>
+      <td>
+        Cell 198
+      </td>
+      <td>
+        Cell 199
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 20
+      </th>
       <td>
         Cell 201
       </td>
@@ -1111,8 +1535,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 203
       </td>
+      <td>
+        Cell 204
+      </td>
+      <td>
+        Cell 205
+      </td>
+      <td>
+        Cell 206
+      </td>
+      <td>
+        Cell 207
+      </td>
+      <td>
+        Cell 208
+      </td>
+      <td>
+        Cell 209
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 21
+      </th>
       <td>
         Cell 211
       </td>
@@ -1122,8 +1567,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 213
       </td>
+      <td>
+        Cell 214
+      </td>
+      <td>
+        Cell 215
+      </td>
+      <td>
+        Cell 216
+      </td>
+      <td>
+        Cell 217
+      </td>
+      <td>
+        Cell 218
+      </td>
+      <td>
+        Cell 219
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 22
+      </th>
       <td>
         Cell 221
       </td>
@@ -1133,8 +1599,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 223
       </td>
+      <td>
+        Cell 224
+      </td>
+      <td>
+        Cell 225
+      </td>
+      <td>
+        Cell 226
+      </td>
+      <td>
+        Cell 227
+      </td>
+      <td>
+        Cell 228
+      </td>
+      <td>
+        Cell 229
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 23
+      </th>
       <td>
         Cell 231
       </td>
@@ -1144,8 +1631,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 233
       </td>
+      <td>
+        Cell 234
+      </td>
+      <td>
+        Cell 235
+      </td>
+      <td>
+        Cell 236
+      </td>
+      <td>
+        Cell 237
+      </td>
+      <td>
+        Cell 238
+      </td>
+      <td>
+        Cell 239
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 24
+      </th>
       <td>
         Cell 241
       </td>
@@ -1155,8 +1663,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 243
       </td>
+      <td>
+        Cell 244
+      </td>
+      <td>
+        Cell 245
+      </td>
+      <td>
+        Cell 246
+      </td>
+      <td>
+        Cell 247
+      </td>
+      <td>
+        Cell 248
+      </td>
+      <td>
+        Cell 249
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 25
+      </th>
       <td>
         Cell 251
       </td>
@@ -1166,8 +1695,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 253
       </td>
+      <td>
+        Cell 254
+      </td>
+      <td>
+        Cell 255
+      </td>
+      <td>
+        Cell 256
+      </td>
+      <td>
+        Cell 257
+      </td>
+      <td>
+        Cell 258
+      </td>
+      <td>
+        Cell 259
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 26
+      </th>
       <td>
         Cell 261
       </td>
@@ -1177,8 +1727,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 263
       </td>
+      <td>
+        Cell 264
+      </td>
+      <td>
+        Cell 265
+      </td>
+      <td>
+        Cell 266
+      </td>
+      <td>
+        Cell 267
+      </td>
+      <td>
+        Cell 268
+      </td>
+      <td>
+        Cell 269
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 27
+      </th>
       <td>
         Cell 271
       </td>
@@ -1188,8 +1759,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 273
       </td>
+      <td>
+        Cell 274
+      </td>
+      <td>
+        Cell 275
+      </td>
+      <td>
+        Cell 276
+      </td>
+      <td>
+        Cell 277
+      </td>
+      <td>
+        Cell 278
+      </td>
+      <td>
+        Cell 279
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 28
+      </th>
       <td>
         Cell 281
       </td>
@@ -1199,8 +1791,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 283
       </td>
+      <td>
+        Cell 284
+      </td>
+      <td>
+        Cell 285
+      </td>
+      <td>
+        Cell 286
+      </td>
+      <td>
+        Cell 287
+      </td>
+      <td>
+        Cell 288
+      </td>
+      <td>
+        Cell 289
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 29
+      </th>
       <td>
         Cell 291
       </td>
@@ -1210,8 +1823,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 293
       </td>
+      <td>
+        Cell 294
+      </td>
+      <td>
+        Cell 295
+      </td>
+      <td>
+        Cell 296
+      </td>
+      <td>
+        Cell 297
+      </td>
+      <td>
+        Cell 298
+      </td>
+      <td>
+        Cell 299
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 30
+      </th>
       <td>
         Cell 301
       </td>
@@ -1221,8 +1855,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 303
       </td>
+      <td>
+        Cell 304
+      </td>
+      <td>
+        Cell 305
+      </td>
+      <td>
+        Cell 306
+      </td>
+      <td>
+        Cell 307
+      </td>
+      <td>
+        Cell 308
+      </td>
+      <td>
+        Cell 309
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 31
+      </th>
       <td>
         Cell 311
       </td>
@@ -1232,8 +1887,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 313
       </td>
+      <td>
+        Cell 314
+      </td>
+      <td>
+        Cell 315
+      </td>
+      <td>
+        Cell 316
+      </td>
+      <td>
+        Cell 317
+      </td>
+      <td>
+        Cell 318
+      </td>
+      <td>
+        Cell 319
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 32
+      </th>
       <td>
         Cell 321
       </td>
@@ -1243,8 +1919,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 323
       </td>
+      <td>
+        Cell 324
+      </td>
+      <td>
+        Cell 325
+      </td>
+      <td>
+        Cell 326
+      </td>
+      <td>
+        Cell 327
+      </td>
+      <td>
+        Cell 328
+      </td>
+      <td>
+        Cell 329
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 33
+      </th>
       <td>
         Cell 331
       </td>
@@ -1254,8 +1951,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 333
       </td>
+      <td>
+        Cell 334
+      </td>
+      <td>
+        Cell 335
+      </td>
+      <td>
+        Cell 336
+      </td>
+      <td>
+        Cell 337
+      </td>
+      <td>
+        Cell 338
+      </td>
+      <td>
+        Cell 339
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 34
+      </th>
       <td>
         Cell 341
       </td>
@@ -1265,8 +1983,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 343
       </td>
+      <td>
+        Cell 344
+      </td>
+      <td>
+        Cell 345
+      </td>
+      <td>
+        Cell 346
+      </td>
+      <td>
+        Cell 347
+      </td>
+      <td>
+        Cell 348
+      </td>
+      <td>
+        Cell 349
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 35
+      </th>
       <td>
         Cell 351
       </td>
@@ -1276,8 +2015,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 353
       </td>
+      <td>
+        Cell 354
+      </td>
+      <td>
+        Cell 355
+      </td>
+      <td>
+        Cell 356
+      </td>
+      <td>
+        Cell 357
+      </td>
+      <td>
+        Cell 358
+      </td>
+      <td>
+        Cell 359
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 36
+      </th>
       <td>
         Cell 361
       </td>
@@ -1287,8 +2047,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 363
       </td>
+      <td>
+        Cell 364
+      </td>
+      <td>
+        Cell 365
+      </td>
+      <td>
+        Cell 366
+      </td>
+      <td>
+        Cell 367
+      </td>
+      <td>
+        Cell 368
+      </td>
+      <td>
+        Cell 369
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 37
+      </th>
       <td>
         Cell 371
       </td>
@@ -1298,8 +2079,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 373
       </td>
+      <td>
+        Cell 374
+      </td>
+      <td>
+        Cell 375
+      </td>
+      <td>
+        Cell 376
+      </td>
+      <td>
+        Cell 377
+      </td>
+      <td>
+        Cell 378
+      </td>
+      <td>
+        Cell 379
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 38
+      </th>
       <td>
         Cell 381
       </td>
@@ -1309,8 +2111,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 383
       </td>
+      <td>
+        Cell 384
+      </td>
+      <td>
+        Cell 385
+      </td>
+      <td>
+        Cell 386
+      </td>
+      <td>
+        Cell 387
+      </td>
+      <td>
+        Cell 388
+      </td>
+      <td>
+        Cell 389
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 39
+      </th>
       <td>
         Cell 391
       </td>
@@ -1320,8 +2143,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 393
       </td>
+      <td>
+        Cell 394
+      </td>
+      <td>
+        Cell 395
+      </td>
+      <td>
+        Cell 396
+      </td>
+      <td>
+        Cell 397
+      </td>
+      <td>
+        Cell 398
+      </td>
+      <td>
+        Cell 399
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 40
+      </th>
       <td>
         Cell 401
       </td>
@@ -1331,8 +2175,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 403
       </td>
+      <td>
+        Cell 404
+      </td>
+      <td>
+        Cell 405
+      </td>
+      <td>
+        Cell 406
+      </td>
+      <td>
+        Cell 407
+      </td>
+      <td>
+        Cell 408
+      </td>
+      <td>
+        Cell 409
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 41
+      </th>
       <td>
         Cell 411
       </td>
@@ -1342,8 +2207,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 413
       </td>
+      <td>
+        Cell 414
+      </td>
+      <td>
+        Cell 415
+      </td>
+      <td>
+        Cell 416
+      </td>
+      <td>
+        Cell 417
+      </td>
+      <td>
+        Cell 418
+      </td>
+      <td>
+        Cell 419
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 42
+      </th>
       <td>
         Cell 421
       </td>
@@ -1353,8 +2239,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 423
       </td>
+      <td>
+        Cell 424
+      </td>
+      <td>
+        Cell 425
+      </td>
+      <td>
+        Cell 426
+      </td>
+      <td>
+        Cell 427
+      </td>
+      <td>
+        Cell 428
+      </td>
+      <td>
+        Cell 429
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 43
+      </th>
       <td>
         Cell 431
       </td>
@@ -1364,8 +2271,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 433
       </td>
+      <td>
+        Cell 434
+      </td>
+      <td>
+        Cell 435
+      </td>
+      <td>
+        Cell 436
+      </td>
+      <td>
+        Cell 437
+      </td>
+      <td>
+        Cell 438
+      </td>
+      <td>
+        Cell 439
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 44
+      </th>
       <td>
         Cell 441
       </td>
@@ -1375,8 +2303,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 443
       </td>
+      <td>
+        Cell 444
+      </td>
+      <td>
+        Cell 445
+      </td>
+      <td>
+        Cell 446
+      </td>
+      <td>
+        Cell 447
+      </td>
+      <td>
+        Cell 448
+      </td>
+      <td>
+        Cell 449
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 45
+      </th>
       <td>
         Cell 451
       </td>
@@ -1386,8 +2335,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 453
       </td>
+      <td>
+        Cell 454
+      </td>
+      <td>
+        Cell 455
+      </td>
+      <td>
+        Cell 456
+      </td>
+      <td>
+        Cell 457
+      </td>
+      <td>
+        Cell 458
+      </td>
+      <td>
+        Cell 459
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 46
+      </th>
       <td>
         Cell 461
       </td>
@@ -1397,8 +2367,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 463
       </td>
+      <td>
+        Cell 464
+      </td>
+      <td>
+        Cell 465
+      </td>
+      <td>
+        Cell 466
+      </td>
+      <td>
+        Cell 467
+      </td>
+      <td>
+        Cell 468
+      </td>
+      <td>
+        Cell 469
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 47
+      </th>
       <td>
         Cell 471
       </td>
@@ -1408,8 +2399,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 473
       </td>
+      <td>
+        Cell 474
+      </td>
+      <td>
+        Cell 475
+      </td>
+      <td>
+        Cell 476
+      </td>
+      <td>
+        Cell 477
+      </td>
+      <td>
+        Cell 478
+      </td>
+      <td>
+        Cell 479
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 48
+      </th>
       <td>
         Cell 481
       </td>
@@ -1419,8 +2431,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 483
       </td>
+      <td>
+        Cell 484
+      </td>
+      <td>
+        Cell 485
+      </td>
+      <td>
+        Cell 486
+      </td>
+      <td>
+        Cell 487
+      </td>
+      <td>
+        Cell 488
+      </td>
+      <td>
+        Cell 489
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 49
+      </th>
       <td>
         Cell 491
       </td>
@@ -1430,8 +2463,29 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 493
       </td>
+      <td>
+        Cell 494
+      </td>
+      <td>
+        Cell 495
+      </td>
+      <td>
+        Cell 496
+      </td>
+      <td>
+        Cell 497
+      </td>
+      <td>
+        Cell 498
+      </td>
+      <td>
+        Cell 499
+      </td>
     </tr>
     <tr>
+      <th scope="row">
+        Row 50
+      </th>
       <td>
         Cell 501
       </td>
@@ -1441,6 +2495,24 @@ exports[`Sticky Header 1`] = `
       <td>
         Cell 503
       </td>
+      <td>
+        Cell 504
+      </td>
+      <td>
+        Cell 505
+      </td>
+      <td>
+        Cell 506
+      </td>
+      <td>
+        Cell 507
+      </td>
+      <td>
+        Cell 508
+      </td>
+      <td>
+        Cell 509
+      </td>
     </tr>
   </tbody>
 </table>
@@ -1448,7 +2520,11 @@ exports[`Sticky Header 1`] = `
 
 exports[`With Border 1`] = `
 <div style="display: grid; gap: 1rem;">
-  <table data-border="true">
+  <table
+    data-border="true"
+    data-tinted-column-header="true"
+    data-tinted-row-header="true"
+  >
     <tbody>
       <tr>
         <td>
@@ -1520,7 +2596,11 @@ exports[`With Border 1`] = `
       </tr>
     </tbody>
   </table>
-  <table data-border="true">
+  <table
+    data-border="true"
+    data-tinted-column-header="true"
+    data-tinted-row-header="true"
+  >
     <thead>
       <tr>
         <th>
@@ -1570,7 +2650,11 @@ exports[`With Border 1`] = `
       </tr>
     </tbody>
   </table>
-  <table data-border="true">
+  <table
+    data-border="true"
+    data-tinted-column-header="true"
+    data-tinted-row-header="true"
+  >
     <tbody>
       <tr>
         <td>

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -115,630 +115,251 @@ exports[`Column And Row Headers 1`] = `
 `;
 
 exports[`Fixed Table 1`] = `
-<table style="table-layout: fixed;">
-  <thead>
-    <tr>
-      <th>
-        Header 1
-      </th>
-      <th>
-        Header 2
-      </th>
-      <th>
-        Header 3
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        Cell 11
-      </td>
-      <td>
-        Cell 12
-      </td>
-      <td>
-        Cell 13
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 21
-      </td>
-      <td>
-        Cell 22
-      </td>
-      <td>
-        Cell 23
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 31
-      </td>
-      <td>
-        Cell 32
-      </td>
-      <td>
-        Cell 33
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div>
+  <table
+    id="myTable"
+    style="table-layout: fixed; margin-bottom: 12px;"
+  >
+    <caption>
+      Tildeling skolebibliotek 2024
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Kommune
+        </th>
+        <th>
+          Tildeling
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          Bjerkreim kommune
+        </td>
+        <td>
+          330 000
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Færder kommune
+        </td>
+        <td>
+          750 000
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Gjøvik kommune
+        </td>
+        <td>
+          150 000
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Hurdal kommune
+        </td>
+        <td>
+          550 000
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Marker kommune
+        </td>
+        <td>
+          900 000
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <nav aria-label="Sidenavigering">
+    <ul>
+      <li>
+        <button
+          aria-disabled="true"
+          data-variant="tertiary"
+          type="button"
+          aria-label="Forrige side"
+        >
+          Forrige
+        </button>
+      </li>
+      <li>
+        <button
+          data-variant="primary"
+          type="button"
+          aria-label="Side 1"
+          aria-current="page"
+        >
+          1
+        </button>
+      </li>
+      <li>
+        <button
+          data-variant="tertiary"
+          type="button"
+          aria-label="Side 2"
+        >
+          2
+        </button>
+      </li>
+      <li>
+        <button
+          data-variant="tertiary"
+          type="button"
+          aria-label="Side 3"
+        >
+          3
+        </button>
+      </li>
+      <li>
+        <button
+          aria-disabled="false"
+          data-variant="tertiary"
+          type="button"
+          aria-label="Neste side"
+        >
+          Neste
+        </button>
+      </li>
+    </ul>
+  </nav>
+</div>
 `;
 
 exports[`Multiple Header Rows 1`] = `
-<table>
+<table
+  data-zebra="true"
+  data-color="support1"
+  data-tinted-column-header="true"
+  data-tinted-row-header="true"
+>
   <thead>
     <tr>
-      <th>
-        Header 1
-      </th>
-      <th colspan="2">
-        Header 2
+      <td>
+      </td>
+      <th
+        colspan="5"
+        style="text-align: center;"
+      >
+        Trives du på skolen?
       </th>
     </tr>
     <tr>
+      <td>
+      </td>
       <th>
-        Header 3
+        Trives ikke i det hele tatt
       </th>
       <th>
-        Header 4
+        Trives ikke noe særlig
       </th>
       <th>
-        Header 5
+        Trives litt
+      </th>
+      <th>
+        Trives godt
+      </th>
+      <th>
+        Trives svært godt
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody style="text-align: right;">
     <tr>
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Idrettsfag
+      </th>
       <td>
-        Cell 11
+        0.5
       </td>
       <td>
-        Cell 12
+        1.0
       </td>
       <td>
-        Cell 13
+        5.7
+      </td>
+      <td>
+        46.0
+      </td>
+      <td>
+        46.9
       </td>
     </tr>
     <tr>
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Medier og kommunikasjon
+      </th>
       <td>
-        Cell 21
+        1.2
       </td>
       <td>
-        Cell 22
+        1.9
       </td>
       <td>
-        Cell 23
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 31
+        11.3
       </td>
       <td>
-        Cell 32
+        49.4
       </td>
       <td>
-        Cell 33
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 41
-      </td>
-      <td>
-        Cell 42
-      </td>
-      <td>
-        Cell 43
+        36.1
       </td>
     </tr>
     <tr>
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Musikk, dans og drama
+      </th>
       <td>
-        Cell 51
+        -
       </td>
       <td>
-        Cell 52
+        -
       </td>
       <td>
-        Cell 53
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 61
+        7.0
       </td>
       <td>
-        Cell 62
+        41.9
       </td>
       <td>
-        Cell 63
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 71
-      </td>
-      <td>
-        Cell 72
-      </td>
-      <td>
-        Cell 73
+        49.8
       </td>
     </tr>
     <tr>
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Studiespesialisering
+      </th>
       <td>
-        Cell 81
+        1.2
       </td>
       <td>
-        Cell 82
+        1.8
       </td>
       <td>
-        Cell 83
+        8.9
       </td>
-    </tr>
-    <tr>
       <td>
-        Cell 91
+        49.8
       </td>
       <td>
-        Cell 92
-      </td>
-      <td>
-        Cell 93
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 101
-      </td>
-      <td>
-        Cell 102
-      </td>
-      <td>
-        Cell 103
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 111
-      </td>
-      <td>
-        Cell 112
-      </td>
-      <td>
-        Cell 113
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 121
-      </td>
-      <td>
-        Cell 122
-      </td>
-      <td>
-        Cell 123
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 131
-      </td>
-      <td>
-        Cell 132
-      </td>
-      <td>
-        Cell 133
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 141
-      </td>
-      <td>
-        Cell 142
-      </td>
-      <td>
-        Cell 143
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 151
-      </td>
-      <td>
-        Cell 152
-      </td>
-      <td>
-        Cell 153
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 161
-      </td>
-      <td>
-        Cell 162
-      </td>
-      <td>
-        Cell 163
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 171
-      </td>
-      <td>
-        Cell 172
-      </td>
-      <td>
-        Cell 173
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 181
-      </td>
-      <td>
-        Cell 182
-      </td>
-      <td>
-        Cell 183
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 191
-      </td>
-      <td>
-        Cell 192
-      </td>
-      <td>
-        Cell 193
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 201
-      </td>
-      <td>
-        Cell 202
-      </td>
-      <td>
-        Cell 203
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 211
-      </td>
-      <td>
-        Cell 212
-      </td>
-      <td>
-        Cell 213
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 221
-      </td>
-      <td>
-        Cell 222
-      </td>
-      <td>
-        Cell 223
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 231
-      </td>
-      <td>
-        Cell 232
-      </td>
-      <td>
-        Cell 233
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 241
-      </td>
-      <td>
-        Cell 242
-      </td>
-      <td>
-        Cell 243
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 251
-      </td>
-      <td>
-        Cell 252
-      </td>
-      <td>
-        Cell 253
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 261
-      </td>
-      <td>
-        Cell 262
-      </td>
-      <td>
-        Cell 263
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 271
-      </td>
-      <td>
-        Cell 272
-      </td>
-      <td>
-        Cell 273
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 281
-      </td>
-      <td>
-        Cell 282
-      </td>
-      <td>
-        Cell 283
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 291
-      </td>
-      <td>
-        Cell 292
-      </td>
-      <td>
-        Cell 293
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 301
-      </td>
-      <td>
-        Cell 302
-      </td>
-      <td>
-        Cell 303
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 311
-      </td>
-      <td>
-        Cell 312
-      </td>
-      <td>
-        Cell 313
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 321
-      </td>
-      <td>
-        Cell 322
-      </td>
-      <td>
-        Cell 323
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 331
-      </td>
-      <td>
-        Cell 332
-      </td>
-      <td>
-        Cell 333
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 341
-      </td>
-      <td>
-        Cell 342
-      </td>
-      <td>
-        Cell 343
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 351
-      </td>
-      <td>
-        Cell 352
-      </td>
-      <td>
-        Cell 353
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 361
-      </td>
-      <td>
-        Cell 362
-      </td>
-      <td>
-        Cell 363
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 371
-      </td>
-      <td>
-        Cell 372
-      </td>
-      <td>
-        Cell 373
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 381
-      </td>
-      <td>
-        Cell 382
-      </td>
-      <td>
-        Cell 383
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 391
-      </td>
-      <td>
-        Cell 392
-      </td>
-      <td>
-        Cell 393
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 401
-      </td>
-      <td>
-        Cell 402
-      </td>
-      <td>
-        Cell 403
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 411
-      </td>
-      <td>
-        Cell 412
-      </td>
-      <td>
-        Cell 413
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 421
-      </td>
-      <td>
-        Cell 422
-      </td>
-      <td>
-        Cell 423
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 431
-      </td>
-      <td>
-        Cell 432
-      </td>
-      <td>
-        Cell 433
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 441
-      </td>
-      <td>
-        Cell 442
-      </td>
-      <td>
-        Cell 443
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 451
-      </td>
-      <td>
-        Cell 452
-      </td>
-      <td>
-        Cell 453
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 461
-      </td>
-      <td>
-        Cell 462
-      </td>
-      <td>
-        Cell 463
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 471
-      </td>
-      <td>
-        Cell 472
-      </td>
-      <td>
-        Cell 473
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 481
-      </td>
-      <td>
-        Cell 482
-      </td>
-      <td>
-        Cell 483
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 491
-      </td>
-      <td>
-        Cell 492
-      </td>
-      <td>
-        Cell 493
-      </td>
-    </tr>
-    <tr>
-      <td>
-        Cell 501
-      </td>
-      <td>
-        Cell 502
-      </td>
-      <td>
-        Cell 503
+        38.3
       </td>
     </tr>
   </tbody>
@@ -746,60 +367,183 @@ exports[`Multiple Header Rows 1`] = `
 `;
 
 exports[`Preview 1`] = `
-<table
-  data-zebra="true"
-  data-color="neutral"
->
+<table data-color="neutral">
   <caption>
-    Table caption
+    Sensur FSP6236 Tegnspråk III
   </caption>
   <thead>
     <tr>
       <th>
-        Header 1
+        <div>
+          <input
+            aria-label="Velg alle ansatte"
+            id="checkbox-select-all"
+            type="checkbox"
+            value
+            name="my-checkbox"
+          >
+        </div>
+      </th>
+      <th aria-sort="none">
+        <button type="button">
+          Navn
+        </button>
       </th>
       <th>
-        Header 2
+        E-post
       </th>
       <th>
-        Header 3
+        Status
+      </th>
+      <th>
+        Besvarelser
       </th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>
-        Cell 1
+        <div>
+          <input
+            id="checkbox-1"
+            aria-label="Velg [object Object]"
+            type="checkbox"
+            value="1"
+            name="my-checkbox"
+          >
+        </div>
       </td>
       <td>
-        Cell 2
+        Rita Nordmann
       </td>
       <td>
-        Cell 3
+        rita@nordmann.no
+      </td>
+      <td>
+        <span data-color="info">
+          I arbeid
+        </span>
+      </td>
+      <td style="text-align: right;">
+        19
       </td>
     </tr>
     <tr>
       <td>
-        Cell 4
+        <div>
+          <input
+            id="checkbox-2"
+            aria-label="Velg [object Object]"
+            type="checkbox"
+            value="2"
+            name="my-checkbox"
+          >
+        </div>
       </td>
       <td>
-        Cell 5
+        Kari Nordmann
       </td>
       <td>
-        Cell 6
+        kari@nordmann.no
+      </td>
+      <td>
+        <span data-color="success">
+          Ferdig
+        </span>
+      </td>
+      <td style="text-align: right;">
+        0
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div>
+          <input
+            id="checkbox-3"
+            aria-label="Velg [object Object]"
+            type="checkbox"
+            value="3"
+            name="my-checkbox"
+          >
+        </div>
+      </td>
+      <td>
+        Ola Nordmann
+      </td>
+      <td>
+        ola@nordmann.no
+      </td>
+      <td>
+        <span data-color="info">
+          I arbeid
+        </span>
+      </td>
+      <td style="text-align: right;">
+        14
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div>
+          <input
+            id="checkbox-4"
+            aria-label="Velg [object Object]"
+            type="checkbox"
+            value="4"
+            name="my-checkbox"
+          >
+        </div>
+      </td>
+      <td>
+        Kai Nordmann
+      </td>
+      <td>
+        kai@nordmann.no
+      </td>
+      <td>
+        <span data-color="warning">
+          Ikke begynt
+        </span>
+      </td>
+      <td style="text-align: right;">
+        35
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div>
+          <input
+            id="checkbox-5"
+            aria-label="Velg [object Object]"
+            type="checkbox"
+            value="5"
+            name="my-checkbox"
+          >
+        </div>
+      </td>
+      <td>
+        Mateo Nordmann
+      </td>
+      <td>
+        mateo@nordmann.no
+      </td>
+      <td>
+        <span data-color="success">
+          Ferdig
+        </span>
+      </td>
+      <td style="text-align: right;">
+        0
       </td>
     </tr>
   </tbody>
   <tfoot>
     <tr>
-      <td>
-        Footer 1
+      <td colspan="4">
+        Totalt gjenstår
       </td>
-      <td>
-        Footer 2
-      </td>
-      <td>
-        Footer 3
+      <td style="text-align: right;">
+        68
       </td>
     </tr>
   </tfoot>
@@ -823,18 +567,26 @@ exports[`Sortable 1`] = `
           Telefon
         </button>
       </th>
+      <th aria-sort="none">
+        <button type="button">
+          Rolle
+        </button>
+      </th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>
-        Lise Nordmann
+        Rita Nordmann
       </td>
       <td>
-        lise@nordmann.no
+        rita@nordmann.no
       </td>
       <td>
         22345678
+      </td>
+      <td>
+        Rektor
       </td>
     </tr>
     <tr>
@@ -847,6 +599,9 @@ exports[`Sortable 1`] = `
       <td>
         87654321
       </td>
+      <td>
+        Lektor
+      </td>
     </tr>
     <tr>
       <td>
@@ -858,16 +613,36 @@ exports[`Sortable 1`] = `
       <td>
         32345678
       </td>
+      <td>
+        Lektor
+      </td>
     </tr>
     <tr>
       <td>
-        Per Nordmann
+        Kai Nordmann
       </td>
       <td>
-        per@nordmann.no
+        kai@nordmann.no
+      </td>
+      <td>
+        62353278
+      </td>
+      <td>
+        Lektor
+      </td>
+    </tr>
+    <tr>
+      <td>
+        Mateo Nordmann
+      </td>
+      <td>
+        mateo@nordmann.no
       </td>
       <td>
         12345678
+      </td>
+      <td>
+        Ass. rektor
       </td>
     </tr>
   </tbody>
@@ -879,1639 +654,169 @@ exports[`Sticky Header 1`] = `
   data-sticky-header="true"
   data-zebra="true"
   tabindex="0"
+  data-color="support1"
+  data-tinted-column-header="true"
+  data-tinted-row-header="true"
 >
   <thead>
     <tr>
-      <td>
-      </td>
       <th>
-        Header 1
+        Fylke
       </th>
       <th>
-        Header 2
+        Oppholdsareal per barn
       </th>
       <th>
-        Header 3
+        Åpningstid per dag
       </th>
       <th>
-        Header 4
+        Kostpenger
       </th>
       <th>
-        Header 5
+        Foreldrebetaling under makspris
       </th>
       <th>
-        Header 6
-      </th>
-      <th>
-        Header 7
-      </th>
-      <th>
-        Header 8
-      </th>
-      <th>
-        Header 9
+        Hatt tilsyn
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody style="text-align: right;">
     <tr>
-      <th scope="row">
-        Row 1
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Agder
       </th>
       <td>
-        Cell 11
+        5.9
       </td>
       <td>
-        Cell 12
+        9.4
       </td>
       <td>
-        Cell 13
+        400.6
       </td>
       <td>
-        Cell 14
+        4
       </td>
       <td>
-        Cell 15
-      </td>
-      <td>
-        Cell 16
-      </td>
-      <td>
-        Cell 17
-      </td>
-      <td>
-        Cell 18
-      </td>
-      <td>
-        Cell 19
+        66
       </td>
     </tr>
     <tr>
-      <th scope="row">
-        Row 2
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Akershus
       </th>
       <td>
-        Cell 21
+        5.5
       </td>
       <td>
-        Cell 22
+        9.7
       </td>
       <td>
-        Cell 23
+        419.3
       </td>
       <td>
-        Cell 24
+        1
       </td>
       <td>
-        Cell 25
-      </td>
-      <td>
-        Cell 26
-      </td>
-      <td>
-        Cell 27
-      </td>
-      <td>
-        Cell 28
-      </td>
-      <td>
-        Cell 29
+        87
       </td>
     </tr>
     <tr>
-      <th scope="row">
-        Row 3
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Buskerud
       </th>
       <td>
-        Cell 31
+        5.7
       </td>
       <td>
-        Cell 32
+        9.8
       </td>
       <td>
-        Cell 33
+        377.1
       </td>
       <td>
-        Cell 34
+        9
       </td>
       <td>
-        Cell 35
-      </td>
-      <td>
-        Cell 36
-      </td>
-      <td>
-        Cell 37
-      </td>
-      <td>
-        Cell 38
-      </td>
-      <td>
-        Cell 39
+        18
       </td>
     </tr>
     <tr>
-      <th scope="row">
-        Row 4
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Finnmark
       </th>
       <td>
-        Cell 41
+        7.7
       </td>
       <td>
-        Cell 42
+        9.1
       </td>
       <td>
-        Cell 43
+        357.4
       </td>
       <td>
-        Cell 44
+        44
       </td>
       <td>
-        Cell 45
-      </td>
-      <td>
-        Cell 46
-      </td>
-      <td>
-        Cell 47
-      </td>
-      <td>
-        Cell 48
-      </td>
-      <td>
-        Cell 49
+        11
       </td>
     </tr>
     <tr>
-      <th scope="row">
-        Row 5
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Innlandet
       </th>
       <td>
-        Cell 51
+        6.4
       </td>
       <td>
-        Cell 52
+        9.7
       </td>
       <td>
-        Cell 53
+        380.5
       </td>
       <td>
-        Cell 54
+        5
       </td>
       <td>
-        Cell 55
-      </td>
-      <td>
-        Cell 56
-      </td>
-      <td>
-        Cell 57
-      </td>
-      <td>
-        Cell 58
-      </td>
-      <td>
-        Cell 59
+        74
       </td>
     </tr>
     <tr>
-      <th scope="row">
-        Row 6
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        Møre og Romsdal
       </th>
       <td>
-        Cell 61
+        6.4
       </td>
       <td>
-        Cell 62
+        9.7
       </td>
       <td>
-        Cell 63
+        380.5
       </td>
       <td>
-        Cell 64
+        5
       </td>
       <td>
-        Cell 65
-      </td>
-      <td>
-        Cell 66
-      </td>
-      <td>
-        Cell 67
-      </td>
-      <td>
-        Cell 68
-      </td>
-      <td>
-        Cell 69
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 7
-      </th>
-      <td>
-        Cell 71
-      </td>
-      <td>
-        Cell 72
-      </td>
-      <td>
-        Cell 73
-      </td>
-      <td>
-        Cell 74
-      </td>
-      <td>
-        Cell 75
-      </td>
-      <td>
-        Cell 76
-      </td>
-      <td>
-        Cell 77
-      </td>
-      <td>
-        Cell 78
-      </td>
-      <td>
-        Cell 79
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 8
-      </th>
-      <td>
-        Cell 81
-      </td>
-      <td>
-        Cell 82
-      </td>
-      <td>
-        Cell 83
-      </td>
-      <td>
-        Cell 84
-      </td>
-      <td>
-        Cell 85
-      </td>
-      <td>
-        Cell 86
-      </td>
-      <td>
-        Cell 87
-      </td>
-      <td>
-        Cell 88
-      </td>
-      <td>
-        Cell 89
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 9
-      </th>
-      <td>
-        Cell 91
-      </td>
-      <td>
-        Cell 92
-      </td>
-      <td>
-        Cell 93
-      </td>
-      <td>
-        Cell 94
-      </td>
-      <td>
-        Cell 95
-      </td>
-      <td>
-        Cell 96
-      </td>
-      <td>
-        Cell 97
-      </td>
-      <td>
-        Cell 98
-      </td>
-      <td>
-        Cell 99
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 10
-      </th>
-      <td>
-        Cell 101
-      </td>
-      <td>
-        Cell 102
-      </td>
-      <td>
-        Cell 103
-      </td>
-      <td>
-        Cell 104
-      </td>
-      <td>
-        Cell 105
-      </td>
-      <td>
-        Cell 106
-      </td>
-      <td>
-        Cell 107
-      </td>
-      <td>
-        Cell 108
-      </td>
-      <td>
-        Cell 109
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 11
-      </th>
-      <td>
-        Cell 111
-      </td>
-      <td>
-        Cell 112
-      </td>
-      <td>
-        Cell 113
-      </td>
-      <td>
-        Cell 114
-      </td>
-      <td>
-        Cell 115
-      </td>
-      <td>
-        Cell 116
-      </td>
-      <td>
-        Cell 117
-      </td>
-      <td>
-        Cell 118
-      </td>
-      <td>
-        Cell 119
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 12
-      </th>
-      <td>
-        Cell 121
-      </td>
-      <td>
-        Cell 122
-      </td>
-      <td>
-        Cell 123
-      </td>
-      <td>
-        Cell 124
-      </td>
-      <td>
-        Cell 125
-      </td>
-      <td>
-        Cell 126
-      </td>
-      <td>
-        Cell 127
-      </td>
-      <td>
-        Cell 128
-      </td>
-      <td>
-        Cell 129
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 13
-      </th>
-      <td>
-        Cell 131
-      </td>
-      <td>
-        Cell 132
-      </td>
-      <td>
-        Cell 133
-      </td>
-      <td>
-        Cell 134
-      </td>
-      <td>
-        Cell 135
-      </td>
-      <td>
-        Cell 136
-      </td>
-      <td>
-        Cell 137
-      </td>
-      <td>
-        Cell 138
-      </td>
-      <td>
-        Cell 139
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 14
-      </th>
-      <td>
-        Cell 141
-      </td>
-      <td>
-        Cell 142
-      </td>
-      <td>
-        Cell 143
-      </td>
-      <td>
-        Cell 144
-      </td>
-      <td>
-        Cell 145
-      </td>
-      <td>
-        Cell 146
-      </td>
-      <td>
-        Cell 147
-      </td>
-      <td>
-        Cell 148
-      </td>
-      <td>
-        Cell 149
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 15
-      </th>
-      <td>
-        Cell 151
-      </td>
-      <td>
-        Cell 152
-      </td>
-      <td>
-        Cell 153
-      </td>
-      <td>
-        Cell 154
-      </td>
-      <td>
-        Cell 155
-      </td>
-      <td>
-        Cell 156
-      </td>
-      <td>
-        Cell 157
-      </td>
-      <td>
-        Cell 158
-      </td>
-      <td>
-        Cell 159
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 16
-      </th>
-      <td>
-        Cell 161
-      </td>
-      <td>
-        Cell 162
-      </td>
-      <td>
-        Cell 163
-      </td>
-      <td>
-        Cell 164
-      </td>
-      <td>
-        Cell 165
-      </td>
-      <td>
-        Cell 166
-      </td>
-      <td>
-        Cell 167
-      </td>
-      <td>
-        Cell 168
-      </td>
-      <td>
-        Cell 169
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 17
-      </th>
-      <td>
-        Cell 171
-      </td>
-      <td>
-        Cell 172
-      </td>
-      <td>
-        Cell 173
-      </td>
-      <td>
-        Cell 174
-      </td>
-      <td>
-        Cell 175
-      </td>
-      <td>
-        Cell 176
-      </td>
-      <td>
-        Cell 177
-      </td>
-      <td>
-        Cell 178
-      </td>
-      <td>
-        Cell 179
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 18
-      </th>
-      <td>
-        Cell 181
-      </td>
-      <td>
-        Cell 182
-      </td>
-      <td>
-        Cell 183
-      </td>
-      <td>
-        Cell 184
-      </td>
-      <td>
-        Cell 185
-      </td>
-      <td>
-        Cell 186
-      </td>
-      <td>
-        Cell 187
-      </td>
-      <td>
-        Cell 188
-      </td>
-      <td>
-        Cell 189
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 19
-      </th>
-      <td>
-        Cell 191
-      </td>
-      <td>
-        Cell 192
-      </td>
-      <td>
-        Cell 193
-      </td>
-      <td>
-        Cell 194
-      </td>
-      <td>
-        Cell 195
-      </td>
-      <td>
-        Cell 196
-      </td>
-      <td>
-        Cell 197
-      </td>
-      <td>
-        Cell 198
-      </td>
-      <td>
-        Cell 199
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 20
-      </th>
-      <td>
-        Cell 201
-      </td>
-      <td>
-        Cell 202
-      </td>
-      <td>
-        Cell 203
-      </td>
-      <td>
-        Cell 204
-      </td>
-      <td>
-        Cell 205
-      </td>
-      <td>
-        Cell 206
-      </td>
-      <td>
-        Cell 207
-      </td>
-      <td>
-        Cell 208
-      </td>
-      <td>
-        Cell 209
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 21
-      </th>
-      <td>
-        Cell 211
-      </td>
-      <td>
-        Cell 212
-      </td>
-      <td>
-        Cell 213
-      </td>
-      <td>
-        Cell 214
-      </td>
-      <td>
-        Cell 215
-      </td>
-      <td>
-        Cell 216
-      </td>
-      <td>
-        Cell 217
-      </td>
-      <td>
-        Cell 218
-      </td>
-      <td>
-        Cell 219
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 22
-      </th>
-      <td>
-        Cell 221
-      </td>
-      <td>
-        Cell 222
-      </td>
-      <td>
-        Cell 223
-      </td>
-      <td>
-        Cell 224
-      </td>
-      <td>
-        Cell 225
-      </td>
-      <td>
-        Cell 226
-      </td>
-      <td>
-        Cell 227
-      </td>
-      <td>
-        Cell 228
-      </td>
-      <td>
-        Cell 229
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 23
-      </th>
-      <td>
-        Cell 231
-      </td>
-      <td>
-        Cell 232
-      </td>
-      <td>
-        Cell 233
-      </td>
-      <td>
-        Cell 234
-      </td>
-      <td>
-        Cell 235
-      </td>
-      <td>
-        Cell 236
-      </td>
-      <td>
-        Cell 237
-      </td>
-      <td>
-        Cell 238
-      </td>
-      <td>
-        Cell 239
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 24
-      </th>
-      <td>
-        Cell 241
-      </td>
-      <td>
-        Cell 242
-      </td>
-      <td>
-        Cell 243
-      </td>
-      <td>
-        Cell 244
-      </td>
-      <td>
-        Cell 245
-      </td>
-      <td>
-        Cell 246
-      </td>
-      <td>
-        Cell 247
-      </td>
-      <td>
-        Cell 248
-      </td>
-      <td>
-        Cell 249
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 25
-      </th>
-      <td>
-        Cell 251
-      </td>
-      <td>
-        Cell 252
-      </td>
-      <td>
-        Cell 253
-      </td>
-      <td>
-        Cell 254
-      </td>
-      <td>
-        Cell 255
-      </td>
-      <td>
-        Cell 256
-      </td>
-      <td>
-        Cell 257
-      </td>
-      <td>
-        Cell 258
-      </td>
-      <td>
-        Cell 259
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 26
-      </th>
-      <td>
-        Cell 261
-      </td>
-      <td>
-        Cell 262
-      </td>
-      <td>
-        Cell 263
-      </td>
-      <td>
-        Cell 264
-      </td>
-      <td>
-        Cell 265
-      </td>
-      <td>
-        Cell 266
-      </td>
-      <td>
-        Cell 267
-      </td>
-      <td>
-        Cell 268
-      </td>
-      <td>
-        Cell 269
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 27
-      </th>
-      <td>
-        Cell 271
-      </td>
-      <td>
-        Cell 272
-      </td>
-      <td>
-        Cell 273
-      </td>
-      <td>
-        Cell 274
-      </td>
-      <td>
-        Cell 275
-      </td>
-      <td>
-        Cell 276
-      </td>
-      <td>
-        Cell 277
-      </td>
-      <td>
-        Cell 278
-      </td>
-      <td>
-        Cell 279
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 28
-      </th>
-      <td>
-        Cell 281
-      </td>
-      <td>
-        Cell 282
-      </td>
-      <td>
-        Cell 283
-      </td>
-      <td>
-        Cell 284
-      </td>
-      <td>
-        Cell 285
-      </td>
-      <td>
-        Cell 286
-      </td>
-      <td>
-        Cell 287
-      </td>
-      <td>
-        Cell 288
-      </td>
-      <td>
-        Cell 289
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 29
-      </th>
-      <td>
-        Cell 291
-      </td>
-      <td>
-        Cell 292
-      </td>
-      <td>
-        Cell 293
-      </td>
-      <td>
-        Cell 294
-      </td>
-      <td>
-        Cell 295
-      </td>
-      <td>
-        Cell 296
-      </td>
-      <td>
-        Cell 297
-      </td>
-      <td>
-        Cell 298
-      </td>
-      <td>
-        Cell 299
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 30
-      </th>
-      <td>
-        Cell 301
-      </td>
-      <td>
-        Cell 302
-      </td>
-      <td>
-        Cell 303
-      </td>
-      <td>
-        Cell 304
-      </td>
-      <td>
-        Cell 305
-      </td>
-      <td>
-        Cell 306
-      </td>
-      <td>
-        Cell 307
-      </td>
-      <td>
-        Cell 308
-      </td>
-      <td>
-        Cell 309
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 31
-      </th>
-      <td>
-        Cell 311
-      </td>
-      <td>
-        Cell 312
-      </td>
-      <td>
-        Cell 313
-      </td>
-      <td>
-        Cell 314
-      </td>
-      <td>
-        Cell 315
-      </td>
-      <td>
-        Cell 316
-      </td>
-      <td>
-        Cell 317
-      </td>
-      <td>
-        Cell 318
-      </td>
-      <td>
-        Cell 319
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 32
-      </th>
-      <td>
-        Cell 321
-      </td>
-      <td>
-        Cell 322
-      </td>
-      <td>
-        Cell 323
-      </td>
-      <td>
-        Cell 324
-      </td>
-      <td>
-        Cell 325
-      </td>
-      <td>
-        Cell 326
-      </td>
-      <td>
-        Cell 327
-      </td>
-      <td>
-        Cell 328
-      </td>
-      <td>
-        Cell 329
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 33
-      </th>
-      <td>
-        Cell 331
-      </td>
-      <td>
-        Cell 332
-      </td>
-      <td>
-        Cell 333
-      </td>
-      <td>
-        Cell 334
-      </td>
-      <td>
-        Cell 335
-      </td>
-      <td>
-        Cell 336
-      </td>
-      <td>
-        Cell 337
-      </td>
-      <td>
-        Cell 338
-      </td>
-      <td>
-        Cell 339
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 34
-      </th>
-      <td>
-        Cell 341
-      </td>
-      <td>
-        Cell 342
-      </td>
-      <td>
-        Cell 343
-      </td>
-      <td>
-        Cell 344
-      </td>
-      <td>
-        Cell 345
-      </td>
-      <td>
-        Cell 346
-      </td>
-      <td>
-        Cell 347
-      </td>
-      <td>
-        Cell 348
-      </td>
-      <td>
-        Cell 349
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 35
-      </th>
-      <td>
-        Cell 351
-      </td>
-      <td>
-        Cell 352
-      </td>
-      <td>
-        Cell 353
-      </td>
-      <td>
-        Cell 354
-      </td>
-      <td>
-        Cell 355
-      </td>
-      <td>
-        Cell 356
-      </td>
-      <td>
-        Cell 357
-      </td>
-      <td>
-        Cell 358
-      </td>
-      <td>
-        Cell 359
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 36
-      </th>
-      <td>
-        Cell 361
-      </td>
-      <td>
-        Cell 362
-      </td>
-      <td>
-        Cell 363
-      </td>
-      <td>
-        Cell 364
-      </td>
-      <td>
-        Cell 365
-      </td>
-      <td>
-        Cell 366
-      </td>
-      <td>
-        Cell 367
-      </td>
-      <td>
-        Cell 368
-      </td>
-      <td>
-        Cell 369
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 37
-      </th>
-      <td>
-        Cell 371
-      </td>
-      <td>
-        Cell 372
-      </td>
-      <td>
-        Cell 373
-      </td>
-      <td>
-        Cell 374
-      </td>
-      <td>
-        Cell 375
-      </td>
-      <td>
-        Cell 376
-      </td>
-      <td>
-        Cell 377
-      </td>
-      <td>
-        Cell 378
-      </td>
-      <td>
-        Cell 379
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 38
-      </th>
-      <td>
-        Cell 381
-      </td>
-      <td>
-        Cell 382
-      </td>
-      <td>
-        Cell 383
-      </td>
-      <td>
-        Cell 384
-      </td>
-      <td>
-        Cell 385
-      </td>
-      <td>
-        Cell 386
-      </td>
-      <td>
-        Cell 387
-      </td>
-      <td>
-        Cell 388
-      </td>
-      <td>
-        Cell 389
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 39
-      </th>
-      <td>
-        Cell 391
-      </td>
-      <td>
-        Cell 392
-      </td>
-      <td>
-        Cell 393
-      </td>
-      <td>
-        Cell 394
-      </td>
-      <td>
-        Cell 395
-      </td>
-      <td>
-        Cell 396
-      </td>
-      <td>
-        Cell 397
-      </td>
-      <td>
-        Cell 398
-      </td>
-      <td>
-        Cell 399
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 40
-      </th>
-      <td>
-        Cell 401
-      </td>
-      <td>
-        Cell 402
-      </td>
-      <td>
-        Cell 403
-      </td>
-      <td>
-        Cell 404
-      </td>
-      <td>
-        Cell 405
-      </td>
-      <td>
-        Cell 406
-      </td>
-      <td>
-        Cell 407
-      </td>
-      <td>
-        Cell 408
-      </td>
-      <td>
-        Cell 409
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 41
-      </th>
-      <td>
-        Cell 411
-      </td>
-      <td>
-        Cell 412
-      </td>
-      <td>
-        Cell 413
-      </td>
-      <td>
-        Cell 414
-      </td>
-      <td>
-        Cell 415
-      </td>
-      <td>
-        Cell 416
-      </td>
-      <td>
-        Cell 417
-      </td>
-      <td>
-        Cell 418
-      </td>
-      <td>
-        Cell 419
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 42
-      </th>
-      <td>
-        Cell 421
-      </td>
-      <td>
-        Cell 422
-      </td>
-      <td>
-        Cell 423
-      </td>
-      <td>
-        Cell 424
-      </td>
-      <td>
-        Cell 425
-      </td>
-      <td>
-        Cell 426
-      </td>
-      <td>
-        Cell 427
-      </td>
-      <td>
-        Cell 428
-      </td>
-      <td>
-        Cell 429
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 43
-      </th>
-      <td>
-        Cell 431
-      </td>
-      <td>
-        Cell 432
-      </td>
-      <td>
-        Cell 433
-      </td>
-      <td>
-        Cell 434
-      </td>
-      <td>
-        Cell 435
-      </td>
-      <td>
-        Cell 436
-      </td>
-      <td>
-        Cell 437
-      </td>
-      <td>
-        Cell 438
-      </td>
-      <td>
-        Cell 439
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 44
-      </th>
-      <td>
-        Cell 441
-      </td>
-      <td>
-        Cell 442
-      </td>
-      <td>
-        Cell 443
-      </td>
-      <td>
-        Cell 444
-      </td>
-      <td>
-        Cell 445
-      </td>
-      <td>
-        Cell 446
-      </td>
-      <td>
-        Cell 447
-      </td>
-      <td>
-        Cell 448
-      </td>
-      <td>
-        Cell 449
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 45
-      </th>
-      <td>
-        Cell 451
-      </td>
-      <td>
-        Cell 452
-      </td>
-      <td>
-        Cell 453
-      </td>
-      <td>
-        Cell 454
-      </td>
-      <td>
-        Cell 455
-      </td>
-      <td>
-        Cell 456
-      </td>
-      <td>
-        Cell 457
-      </td>
-      <td>
-        Cell 458
-      </td>
-      <td>
-        Cell 459
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 46
-      </th>
-      <td>
-        Cell 461
-      </td>
-      <td>
-        Cell 462
-      </td>
-      <td>
-        Cell 463
-      </td>
-      <td>
-        Cell 464
-      </td>
-      <td>
-        Cell 465
-      </td>
-      <td>
-        Cell 466
-      </td>
-      <td>
-        Cell 467
-      </td>
-      <td>
-        Cell 468
-      </td>
-      <td>
-        Cell 469
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 47
-      </th>
-      <td>
-        Cell 471
-      </td>
-      <td>
-        Cell 472
-      </td>
-      <td>
-        Cell 473
-      </td>
-      <td>
-        Cell 474
-      </td>
-      <td>
-        Cell 475
-      </td>
-      <td>
-        Cell 476
-      </td>
-      <td>
-        Cell 477
-      </td>
-      <td>
-        Cell 478
-      </td>
-      <td>
-        Cell 479
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 48
-      </th>
-      <td>
-        Cell 481
-      </td>
-      <td>
-        Cell 482
-      </td>
-      <td>
-        Cell 483
-      </td>
-      <td>
-        Cell 484
-      </td>
-      <td>
-        Cell 485
-      </td>
-      <td>
-        Cell 486
-      </td>
-      <td>
-        Cell 487
-      </td>
-      <td>
-        Cell 488
-      </td>
-      <td>
-        Cell 489
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 49
-      </th>
-      <td>
-        Cell 491
-      </td>
-      <td>
-        Cell 492
-      </td>
-      <td>
-        Cell 493
-      </td>
-      <td>
-        Cell 494
-      </td>
-      <td>
-        Cell 495
-      </td>
-      <td>
-        Cell 496
-      </td>
-      <td>
-        Cell 497
-      </td>
-      <td>
-        Cell 498
-      </td>
-      <td>
-        Cell 499
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        Row 50
-      </th>
-      <td>
-        Cell 501
-      </td>
-      <td>
-        Cell 502
-      </td>
-      <td>
-        Cell 503
-      </td>
-      <td>
-        Cell 504
-      </td>
-      <td>
-        Cell 505
-      </td>
-      <td>
-        Cell 506
-      </td>
-      <td>
-        Cell 507
-      </td>
-      <td>
-        Cell 508
-      </td>
-      <td>
-        Cell 509
+        46
       </td>
     </tr>
   </tbody>
@@ -2522,187 +827,69 @@ exports[`With Border 1`] = `
 <div style="display: grid; gap: 1rem;">
   <table
     data-border="true"
-    data-tinted-column-header="true"
-    data-tinted-row-header="true"
-  >
-    <tbody>
-      <tr>
-        <td>
-          Cell 11
-        </td>
-        <td>
-          Cell 12
-        </td>
-        <td>
-          Cell 13
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 21
-        </td>
-        <td>
-          Cell 22
-        </td>
-        <td>
-          Cell 23
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 31
-        </td>
-        <td>
-          Cell 32
-        </td>
-        <td>
-          Cell 33
-        </td>
-      </tr>
-    </tbody>
-    <tbody>
-      <tr>
-        <td>
-          Cell 11
-        </td>
-        <td>
-          Cell 12
-        </td>
-        <td>
-          Cell 13
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 21
-        </td>
-        <td>
-          Cell 22
-        </td>
-        <td>
-          Cell 23
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 31
-        </td>
-        <td>
-          Cell 32
-        </td>
-        <td>
-          Cell 33
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <table
-    data-border="true"
+    data-color="support2"
     data-tinted-column-header="true"
     data-tinted-row-header="true"
   >
     <thead>
       <tr>
         <th>
-          Header 3
+          Uke
         </th>
         <th>
-          Header 4
+          Datoer
         </th>
         <th>
-          Header 5
+          Hva
         </th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>
-          Cell 11
+          31
         </td>
         <td>
-          Cell 12
+          1. august
         </td>
         <td>
-          Cell 13
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 21
-        </td>
-        <td>
-          Cell 22
-        </td>
-        <td>
-          Cell 23
+          Påmelding til nasjonale prøver starter
         </td>
       </tr>
       <tr>
         <td>
-          Cell 31
+          36-39
         </td>
         <td>
-          Cell 32
+          1. september - 26. september
         </td>
         <td>
-          Cell 33
+          Gjennomføringsuker for nasjonale prøver 5.trinn i
+          <ul>
+            <li>
+              Engelsk
+            </li>
+            <li>
+              Lesing
+            </li>
+            <li>
+              Regning
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          39
+        </td>
+        <td>
+          26. september
+        </td>
+        <td>
+          Frist for registrering av fritatt og ikke deltatt for alle prøvene
         </td>
       </tr>
     </tbody>
-  </table>
-  <table
-    data-border="true"
-    data-tinted-column-header="true"
-    data-tinted-row-header="true"
-  >
-    <tbody>
-      <tr>
-        <td>
-          Cell 11
-        </td>
-        <td>
-          Cell 12
-        </td>
-        <td>
-          Cell 13
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 21
-        </td>
-        <td>
-          Cell 22
-        </td>
-        <td>
-          Cell 23
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Cell 31
-        </td>
-        <td>
-          Cell 32
-        </td>
-        <td>
-          Cell 33
-        </td>
-      </tr>
-    </tbody>
-    <tfoot>
-      <tr>
-        <th>
-          Footer 1
-        </th>
-        <th>
-          Footer 2
-        </th>
-        <th>
-          Footer 3
-        </th>
-      </tr>
-    </tfoot>
   </table>
 </div>
 `;
@@ -2723,17 +910,20 @@ exports[`With Form Elements 1`] = `
         </div>
       </th>
       <th>
-        Header 1
+        #
       </th>
       <th>
-        Header 2
+        Spørsmål
       </th>
       <th>
-        Header 3
+        Alternativ 1
+      </th>
+      <th>
+        Alternativ 2
       </th>
     </tr>
   </thead>
-  <tbody>
+  <tbody style="place-content: start center; align-items: center;">
     <tr>
       <td>
         <div>
@@ -2746,19 +936,41 @@ exports[`With Form Elements 1`] = `
           >
         </div>
       </td>
-      <td style="text-align: right;">
-        1
-      </td>
-      <td style="text-align: right;">
-        1
+      <td>
+        1.
       </td>
       <td>
         <div data-size="sm">
           <div>
             <input
-              aria-label="Textfield 1"
-              id="components-table--with-form-elements-textfield1"
+              aria-label="Textfield 1-1"
+              id="components-table--with-form-elements-textfield1-1"
               type="text"
+              value="Trives du på skolen?"
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        <div data-size="sm">
+          <div>
+            <input
+              aria-label="Textfield 1-2"
+              id="components-table--with-form-elements-textfield1-2"
+              type="text"
+              value="Trives ikke noe særlig"
+            >
+          </div>
+        </div>
+      </td>
+      <td>
+        <div data-size="sm">
+          <div>
+            <input
+              aria-label="Textfield 1-3"
+              id="components-table--with-form-elements-textfield1-3"
+              type="text"
+              value="Trives godt"
             >
           </div>
         </div>
@@ -2768,8 +980,8 @@ exports[`With Form Elements 1`] = `
       <td>
         <div>
           <input
-            aria-label="Check 2"
-            id="components-table--with-form-elements-select2"
+            aria-label="Check 1"
+            id="components-table--with-form-elements-select1"
             type="checkbox"
             value="2"
             checked
@@ -2777,49 +989,45 @@ exports[`With Form Elements 1`] = `
           >
         </div>
       </td>
-      <td style="text-align: right;">
-        2
-      </td>
-      <td style="text-align: right;">
-        2
+      <td>
+        2.
       </td>
       <td>
-        <div data-size="sm">
+        <div
+          data-size="sm"
+          style="width: 250px;"
+        >
           <div>
             <input
-              aria-label="Textfield 2"
-              id="components-table--with-form-elements-textfield2"
+              aria-label="Textfield 1-1"
+              id="components-table--with-form-elements-textfield1-1"
               type="text"
+              value="Har du opplevd mobbing?"
             >
           </div>
         </div>
       </td>
-    </tr>
-    <tr>
       <td>
-        <div>
-          <input
-            aria-label="Check 3"
-            id="components-table--with-form-elements-select3"
-            type="checkbox"
-            value="3"
-            name="components-table--with-form-elements-checkboxGroup"
-          >
+        <div data-size="sm">
+          <div>
+            <input
+              aria-label="Textfield 1-2"
+              id="components-table--with-form-elements-textfield1-2"
+              type="text"
+              value="Sjelden"
+            >
+          </div>
         </div>
-      </td>
-      <td style="text-align: right;">
-        3
-      </td>
-      <td style="text-align: right;">
-        3
       </td>
       <td>
         <div data-size="sm">
           <div>
             <input
-              aria-label="Textfield 3"
-              id="components-table--with-form-elements-textfield3"
+              cols="3"
+              aria-label="Textfield 1-3"
+              id="components-table--with-form-elements-textfield1-3"
               type="text"
+              value="Ofte"
             >
           </div>
         </div>

--- a/@udir-design/react/src/components/table/index.ts
+++ b/@udir-design/react/src/components/table/index.ts
@@ -1,0 +1,44 @@
+import {
+  Table as DigdirTable,
+  TableBody,
+  type TableBodyProps,
+  TableCell,
+  type TableCellProps,
+  TableHead,
+  type TableHeadProps,
+  TableHeaderCell,
+  type TableHeaderCellProps,
+  TableRow,
+  type TableRowProps,
+  TableFoot,
+  type TableFootProps,
+} from '@digdir/designsystemet-react';
+import { Table as TableRoot, type TableProps } from './Table';
+
+const Table = Object.assign(TableRoot, {
+  Head: DigdirTable.Head,
+  Body: DigdirTable.Body,
+  Row: DigdirTable.Row,
+  Cell: DigdirTable.Cell,
+  HeaderCell: DigdirTable.HeaderCell,
+  Foot: DigdirTable.Foot,
+});
+
+Table.displayName = 'Table';
+
+export {
+  Table,
+  TableProps,
+  TableBody,
+  TableBodyProps,
+  TableCell,
+  TableCellProps,
+  TableHead,
+  TableHeadProps,
+  TableHeaderCell,
+  TableHeaderCellProps,
+  TableRow,
+  TableRowProps,
+  TableFoot,
+  TableFootProps,
+};

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -1,0 +1,40 @@
+.ds-table {
+  --dsc-table-background--zebra: var(--ds-color-neutral-background-tinted);
+  --dsc-table-header-background--sorted: var(--ds-color-surface-active);
+
+  &[data-zebra] > thead > tr > :is(th, td) {
+    background: var(--ds-color-neutral-background-default);
+  }
+
+  &[data-zebra][data-tinted-column-header] > thead > tr > :is(th, td) {
+    background: var(--ds-color-surface-tinted);
+  }
+
+  & > tfoot > tr:first-child > :is(th, td) {
+    background: var(--ds-color-neutral-background-default);
+  }
+
+  &[data-tinted-column-header] {
+    --dsc-table-header-background: var(--ds-color-surface-tinted);
+  }
+
+  &[data-tinted-row-header] th[scope='row'] {
+    background-color: var(--ds-color-surface-tinted);
+  }
+
+  &[data-sticky-header] {
+    th[scope='row'] {
+      background-color: var(--ds-color-neutral-background-default);
+      position: sticky;
+      left: 0;
+    }
+
+    &[data-tinted-column-header] > thead > tr > :is(th, td) {
+      background-color: var(--ds-color-surface-tinted);
+    }
+
+    &[data-tinted-row-header] th[scope='row'] {
+      background-color: var(--ds-color-surface-tinted);
+    }
+  }
+}


### PR DESCRIPTION
## Hva er gjort? 👀 
- Utvidet Table med to nye props for tinted background, begge følger data-color 
  - `tintedColumnHeader` som bestemmer om column headers skal ha backround tint
  - `tintedRowHeader` som bestemmer om row headers skal ha backround tint
- Overridet noe styling i `table.css` for å passe våre designønsker slik de er definert i Figma: 
  - Alltid neutral surface tinted for zebra 
  - Mulighet for tinted header for både row- og column headers 
  - Footer skal ikke ha tinted bakgrunnsfarge 
- Oppdatert default-eksempel for å vise mer realistisk use-case og eksemplifisere hvor fleksibelt tabell kan være (se bilde rad 1 i tabell under) 

| Før | Nå |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/e52d9f59-c817-4ae1-9f31-9dd82fe0319b) | ![image](https://github.com/user-attachments/assets/919dff05-cd5a-409e-917d-b2cf2387bb20) |
| ![image](https://github.com/user-attachments/assets/fc45279a-f0c9-4a8b-b7f2-70b89b9ca8b9) | ![image](https://github.com/user-attachments/assets/31930d34-b597-4530-a188-00e92e7c8436) | 
