### PR TITLE
build: add a serve:storybook script for easier debugging of errors in the published Storybook

### DIFF
--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -34,6 +34,7 @@
     "typecheck": "tsc --build",
     "dev": "storybook dev --port 6006",
     "build:storybook": "storybook build --stats-json",
+    "serve:storybook": "pnpm dlx http-server ./storybook-static",
     "test:storybook": "vitest --project storybook"
   },
   "dependencies": {

--- a/@udir-design/react/project.json
+++ b/@udir-design/react/project.json
@@ -7,6 +7,7 @@
   "// targets": "to see all targets run: nx show project @udir-design/react --web",
   "targets": {
     "dev": {
+      "continuous": true,
       "dependsOn": ["^build"]
     },
     "build:storybook": {
@@ -14,6 +15,10 @@
       "dependsOn": ["build"],
       "cache": true,
       "outputs": ["{projectRoot}/storybook-static"]
+    },
+    "serve:storybook": {
+      "continuous": true,
+      "dependsOn": ["build:storybook"]
     },
     "test:storybook": {
       "dependsOn": ["build"]


### PR DESCRIPTION
Run it with `pnpm nx serve:storybook`, which also automatically builds the storybook first.