### PR TITLE
fix: update `@digdir/*` to 1.1.5

### DIFF
--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -41,8 +41,8 @@
     "test:storybook": "vitest --project storybook"
   },
   "dependencies": {
-    "@digdir/designsystemet-css": "1.1.4",
-    "@digdir/designsystemet-react": "1.1.4",
+    "@digdir/designsystemet-css": "1.1.5",
+    "@digdir/designsystemet-react": "1.1.5",
     "@navikt/aksel-icons": "^7.25.1",
     "@udir-design/theme": "workspace:*",
     "tslib": "^2.8.1"

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -322,7 +322,6 @@ export const DialogWithSuggestion: Story = {
             <Field>
               <Label>Velg en kommune</Label>
               <Suggestion>
-                <Suggestion.Chips />
                 <Suggestion.Input id={`${ctx.id}-input`} />
                 <Suggestion.Clear />
                 <Suggestion.List>

--- a/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
+++ b/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
@@ -273,13 +273,13 @@ exports[`Dialog With Suggestion 1`] = `
       <u-combobox>
         <input
           placeholder
-          popovertarget="«r0»-list"
           id="undefined-input"
           type="text"
-          list="«r0»-list"
+          list=":u-datalist1"
           aria-label="Velg en kommune, "
+          popovertarget=":u-datalist1"
           aria-autocomplete="list"
-          aria-controls="«r0»-list"
+          aria-controls=":u-datalist1"
           aria-expanded="true"
           autocomplete="off"
           role="combobox"
@@ -296,12 +296,12 @@ exports[`Dialog With Suggestion 1`] = `
           data-nofilter
           data-sr-singular="%d forslag"
           data-sr-plural="%d forslag"
-          id="«r0»-list"
           popover="manual"
           hidden
           role="listbox"
           tabindex="-1"
           aria-multiselectable="false"
+          id=":u-datalist1"
           style="width: 590px; translate: <removed>;"
         >
           <u-option

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -58,7 +58,7 @@ export const Preview: Story = {
         await waitFor(() =>
           expect(input).toHaveAttribute(
             'aria-describedby',
-            validationMessage.id + '  ' + description.id,
+            `${validationMessage.id} ${description.id}`,
           ),
         );
       },

--- a/@udir-design/react/src/components/field/__snapshots__/Field.stories.tsx.snap
+++ b/@udir-design/react/src/components/field/__snapshots__/Field.stories.tsx.snap
@@ -35,7 +35,7 @@ exports[`Counter 1`] = `
   <textarea
     rows="2"
     id="counter"
-    aria-describedby="counter:validation:1  counter:description:1"
+    aria-describedby="counter:validation:1 counter:description:1"
   >
   </textarea>
   <div
@@ -106,7 +106,7 @@ exports[`Preview 1`] = `
     aria-invalid="true"
     type="text"
     value="ola nordmann@udir.no"
-    aria-describedby="preview:validation:1  preview:description:1"
+    aria-describedby="preview:validation:1 preview:description:1"
   >
   <p
     data-field="validation"

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -72,7 +72,6 @@ export const Preview: Story = {
       <Field>
         <Label>Velg en destinasjon</Label>
         <Suggestion {...args}>
-          <Suggestion.Chips />
           <Suggestion.Input id={ctx.id} />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -105,10 +104,11 @@ export const Controlled: Story = {
           <Label>Velg destinasjoner</Label>
           <Suggestion
             {...args}
-            value={value}
-            onValueChange={(items) => setValue(items.map((item) => item.value))}
+            selected={value}
+            onSelectedChange={(items) =>
+              setValue(items.map((item) => item.value))
+            }
           >
-            <Suggestion.Chips />
             <Suggestion.Input id={ctx.id} />
             <Suggestion.Clear />
             <Suggestion.List>
@@ -151,10 +151,11 @@ export const ControlledMultiple: Story = {
           <Suggestion
             {...args}
             multiple
-            value={value}
-            onValueChange={(items) => setValue(items.map((item) => item.value))}
+            selected={value}
+            onSelectedChange={(items) =>
+              setValue(items.map((item) => item.value))
+            }
           >
-            <Suggestion.Chips />
             <Suggestion.Input id={ctx.id} />
             <Suggestion.Clear />
             <Suggestion.List>
@@ -192,7 +193,6 @@ export const DefaultValue: Story = {
       <Field>
         <Label>Velg en destinasjon</Label>
         <Suggestion {...args} defaultValue={['Sogndal']}>
-          <Suggestion.Chips />
           <Suggestion.Input id={ctx.id} />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -218,7 +218,6 @@ export const CustomFilterAlt1: Story = {
             !input.value || index === Number(input.value) - 1
           }
         >
-          <Suggestion.Chips />
           <Suggestion.Input id={ctx.id} />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -243,7 +242,6 @@ export const CustomFilterAlt2: Story = {
       <Field>
         <Label>Skriv inn et tall mellom 1-6</Label>
         <Suggestion {...args} filter={false}>
-          <Suggestion.Chips />
           <Suggestion.Input
             id={ctx.id}
             onInput={({ currentTarget }) => setValue(currentTarget.value)}
@@ -272,11 +270,10 @@ export const AlwaysShowAll: Story = {
         <Label>Viser alle options også når valgt</Label>
         <Suggestion
           {...args}
-          value={value}
+          selected={value}
           filter={false}
-          onValueChange={(values) => setValue(values)}
+          onSelectedChange={(values) => setValue(values)}
         >
-          <Suggestion.Chips />
           <Suggestion.Input id={ctx.id} />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -320,7 +317,6 @@ export const FetchExternal: Story = {
       <Field lang="en">
         <Label>Search for countries (in english)</Label>
         <Suggestion {...args} filter={false}>
-          <Suggestion.Chips />
           <Suggestion.Input id={ctx.id} onInput={handleInput} />
           <Suggestion.Clear />
           <Suggestion.List singular="%d country" plural="%d countries">

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -21,13 +21,13 @@ exports[`Always Show All 1`] = `
     </data>
     <input
       placeholder
-      popovertarget="«r7»-list"
       id="components-suggestion--always-show-all"
       type="text"
-      list="«r7»-list"
+      list=":u-datalist8"
       aria-label="Viser alle options også når valgt, "
+      popovertarget=":u-datalist8"
       aria-autocomplete="list"
-      aria-controls="«r7»-list"
+      aria-controls=":u-datalist8"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -43,11 +43,11 @@ exports[`Always Show All 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r7»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist8"
       aria-labelledby=":label8"
       style="width: 1168px; translate: <removed>;"
     >
@@ -141,13 +141,13 @@ exports[`Controlled 1`] = `
     </data>
     <input
       placeholder
-      popovertarget="«r2»-list"
       id="components-suggestion--controlled"
       type="text"
-      list="«r2»-list"
+      list=":u-datalist3"
       aria-label="Velg destinasjoner, "
+      popovertarget=":u-datalist3"
       aria-autocomplete="list"
-      aria-controls="«r2»-list"
+      aria-controls=":u-datalist3"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -163,11 +163,11 @@ exports[`Controlled 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r2»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist3"
       aria-labelledby=":label3"
       style="width: 1168px; translate: <removed>;"
     >
@@ -176,9 +176,10 @@ exports[`Controlled 1`] = `
         value="Sogndal"
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Sogndal
         <div>
@@ -205,9 +206,10 @@ exports[`Controlled 1`] = `
         value="Brønnøysund"
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Brønnøysund
         <div>
@@ -219,9 +221,10 @@ exports[`Controlled 1`] = `
         value="Stavanger"
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Stavanger
         <div>
@@ -233,9 +236,10 @@ exports[`Controlled 1`] = `
         value="Trondheim"
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Trondheim
         <div>
@@ -247,9 +251,10 @@ exports[`Controlled 1`] = `
         value="Bergen"
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Bergen
         <div>
@@ -261,9 +266,10 @@ exports[`Controlled 1`] = `
         value="Lillestrøm"
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Lillestrøm
         <div>
@@ -312,13 +318,13 @@ exports[`Controlled Multiple 1`] = `
     </data>
     <input
       placeholder
-      popovertarget="«r3»-list"
       id="components-suggestion--controlled-multiple"
       type="text"
-      list="«r3»-list"
+      list=":u-datalist4"
       aria-label="Velg destinasjoner, Navigate left to find 1 selected"
+      popovertarget=":u-datalist4"
       aria-autocomplete="list"
-      aria-controls="«r3»-list"
+      aria-controls=":u-datalist4"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -335,11 +341,11 @@ exports[`Controlled Multiple 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r3»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="true"
+      id=":u-datalist4"
       aria-labelledby=":label4"
       style="width: 1168px; translate: <removed>;"
     >
@@ -475,13 +481,13 @@ exports[`Custom Filter Alt 1 1`] = `
   <u-combobox>
     <input
       placeholder
-      popovertarget="«r5»-list"
       id="components-suggestion--custom-filter-alt-1"
       type="text"
-      list="«r5»-list"
+      list=":u-datalist6"
       aria-label="Skriv inn et tall mellom 1-6, "
+      popovertarget=":u-datalist6"
       aria-autocomplete="list"
-      aria-controls="«r5»-list"
+      aria-controls=":u-datalist6"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -498,11 +504,11 @@ exports[`Custom Filter Alt 1 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r5»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist6"
       aria-labelledby=":label6"
       style="width: 1168px; translate: <removed>;"
     >
@@ -593,13 +599,13 @@ exports[`Custom Filter Alt 2 1`] = `
   <u-combobox>
     <input
       placeholder
-      popovertarget="«r6»-list"
       id="components-suggestion--custom-filter-alt-2"
       type="text"
-      list="«r6»-list"
+      list=":u-datalist7"
       aria-label="Skriv inn et tall mellom 1-6, "
+      popovertarget=":u-datalist7"
       aria-autocomplete="list"
-      aria-controls="«r6»-list"
+      aria-controls=":u-datalist7"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -616,11 +622,11 @@ exports[`Custom Filter Alt 2 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r6»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist7"
       aria-labelledby=":label7"
       style="width: 1168px; translate: <removed>;"
     >
@@ -713,13 +719,13 @@ exports[`Default Value 1`] = `
     </data>
     <input
       placeholder
-      popovertarget="«r4»-list"
       id="components-suggestion--default-value"
       type="text"
-      list="«r4»-list"
+      list=":u-datalist5"
       aria-label="Velg en destinasjon, "
+      popovertarget=":u-datalist5"
       aria-autocomplete="list"
-      aria-controls="«r4»-list"
+      aria-controls=":u-datalist5"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -735,11 +741,11 @@ exports[`Default Value 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r4»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist5"
       aria-labelledby=":label5"
       style="width: 1168px; translate: <removed>;"
     >
@@ -756,54 +762,60 @@ exports[`Default Value 1`] = `
       <u-option
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Oslo
       </u-option>
       <u-option
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Brønnøysund
       </u-option>
       <u-option
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Stavanger
       </u-option>
       <u-option
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Trondheim
       </u-option>
       <u-option
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Bergen
       </u-option>
       <u-option
         tabindex="-1"
         role="option"
-        aria-disabled="false"
+        aria-disabled="true"
         aria-selected="false"
-        aria-hidden="false"
+        disabled
+        aria-hidden="true"
       >
         Lillestrøm
       </u-option>
@@ -824,13 +836,13 @@ exports[`Fetch External 1`] = `
   <u-combobox>
     <input
       placeholder
-      popovertarget="«r8»-list"
       id="components-suggestion--fetch-external"
       type="text"
-      list="«r8»-list"
+      list=":u-datalist9"
       aria-label="Search for countries (in english), "
+      popovertarget=":u-datalist9"
       aria-autocomplete="list"
-      aria-controls="«r8»-list"
+      aria-controls=":u-datalist9"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -847,11 +859,11 @@ exports[`Fetch External 1`] = `
       data-nofilter
       data-sr-singular="%d country"
       data-sr-plural="%d countries"
-      id="«r8»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist9"
       aria-labelledby=":label9"
       style="width: 1168px; translate: <removed>;"
     >
@@ -872,13 +884,13 @@ exports[`Multiple 1`] = `
   <u-combobox data-multiple>
     <input
       placeholder
-      popovertarget="«r1»-list"
       id="components-suggestion--multiple"
       type="text"
-      list="«r1»-list"
+      list=":u-datalist2"
       aria-label="Velg en destinasjon, No selected"
+      popovertarget=":u-datalist2"
       aria-autocomplete="list"
-      aria-controls="«r1»-list"
+      aria-controls=":u-datalist2"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -895,11 +907,11 @@ exports[`Multiple 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r1»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="true"
+      id=":u-datalist2"
       aria-labelledby=":label2"
       style="width: 1168px; translate: <removed>;"
     >
@@ -1018,13 +1030,13 @@ exports[`Preview 1`] = `
   <u-combobox>
     <input
       placeholder
-      popovertarget="«r0»-list"
       id="components-suggestion--preview"
       type="text"
-      list="«r0»-list"
+      list=":u-datalist1"
       aria-label="Velg en destinasjon, "
+      popovertarget=":u-datalist1"
       aria-autocomplete="list"
-      aria-controls="«r0»-list"
+      aria-controls=":u-datalist1"
       aria-expanded="true"
       autocomplete="off"
       role="combobox"
@@ -1041,11 +1053,11 @@ exports[`Preview 1`] = `
       data-nofilter
       data-sr-singular="%d forslag"
       data-sr-plural="%d forslag"
-      id="«r0»-list"
       popover="manual"
       role="listbox"
       tabindex="-1"
       aria-multiselectable="false"
+      id=":u-datalist1"
       aria-labelledby=":label1"
       style="width: 1168px; translate: <removed>;"
     >

--- a/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
+++ b/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
@@ -67,7 +67,7 @@ exports[`Counter 1`] = `
       id="textfield-counter"
       inputmode="numeric"
       type="text"
-      aria-describedby="textfield-counter:validation:1  textfield-counter:description:1"
+      aria-describedby="textfield-counter:validation:1 textfield-counter:description:1"
     >
   </div>
   <div

--- a/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -167,13 +167,13 @@ exports[`Form Story 1`] = `
         <u-combobox id="county">
           <input
             placeholder
-            popovertarget="county-list"
             aria-invalid="false"
             type="text"
-            list="county-list"
+            list=":u-datalist1"
             aria-label=", "
+            popovertarget=":u-datalist1"
             aria-autocomplete="list"
-            aria-controls="county-list"
+            aria-controls=":u-datalist1"
             aria-expanded="true"
             autocomplete="off"
             role="combobox"
@@ -190,12 +190,12 @@ exports[`Form Story 1`] = `
             data-nofilter
             data-sr-singular="%d forslag"
             data-sr-plural="%d forslag"
-            id="county-list"
             popover="manual"
             hidden
             role="listbox"
             tabindex="-1"
             aria-multiselectable="false"
+            id=":u-datalist1"
             style="width: 536px; translate: <removed>;"
           >
             <u-option

--- a/@udir-design/react/src/demo/form-demo/pages/PersonalInfoPage.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/PersonalInfoPage.tsx
@@ -69,15 +69,15 @@ export const PersonalInfoPage = ({ showErrors }: PageProps) => {
           control={control}
           rules={{ required: 'Velg et fylke' }}
           defaultValue=""
-          render={({ field: { onChange, ...field } }) => (
+          render={({ field: { value, onChange, ...field } }) => (
             <Suggestion
               {...field}
               id="county"
-              onValueChange={(v) => {
+              selected={value}
+              onSelectedChange={(v) => {
                 onChange(v.at(0)?.value);
               }}
             >
-              <Suggestion.Chips />
               <Suggestion.Input aria-invalid={!!errors.county} />
               <Suggestion.Clear />
               <Suggestion.List>

--- a/@udir-design/theme/dist/udir.css
+++ b/@udir-design/theme/dist/udir.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 /*
-build: v1.1.4
+build: v1.1.5
 design-tokens: v1.1.0
 */
 

--- a/@udir-design/theme/package.json
+++ b/@udir-design/theme/package.json
@@ -18,7 +18,7 @@
     "./dist"
   ],
   "dependencies": {
-    "@digdir/designsystemet-react": "1.1.4"
+    "@digdir/designsystemet-react": "1.1.5"
   },
   "devDependencies": {
     "@internal/build-tools": "workspace:*",

--- a/design-tokens/package.json
+++ b/design-tokens/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@digdir/designsystemet": "1.1.4",
+    "@digdir/designsystemet": "1.1.5",
     "rimraf": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.8.1
-        version: 19.8.1(@types/node@22.16.3)(typescript@5.8.3)
+        version: 19.8.1(@types/node@22.16.4)(typescript@5.8.3)
       '@commitlint/config-conventional':
         specifier: ^19.8.1
         version: 19.8.1
@@ -56,7 +56,7 @@ importers:
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/node':
         specifier: ^22.16.3
-        version: 22.16.3
+        version: 22.16.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.36.0
         version: 8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
@@ -101,7 +101,7 @@ importers:
         version: 3.6.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.12.11(@swc/helpers@0.5.17))(@types/node@22.16.3)(typescript@5.8.3)
+        version: 10.9.2(@swc/core@1.12.11(@swc/helpers@0.5.17))(@types/node@22.16.4)(typescript@5.8.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -136,11 +136,11 @@ importers:
   '@udir-design/react':
     dependencies:
       '@digdir/designsystemet-css':
-        specifier: 1.1.4
-        version: 1.1.4
+        specifier: 1.1.5
+        version: 1.1.5
       '@digdir/designsystemet-react':
-        specifier: 1.1.4
-        version: 1.1.4(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.1.5
+        version: 1.1.5(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@navikt/aksel-icons':
         specifier: ^7.25.1
         version: 7.25.1
@@ -162,7 +162,7 @@ importers:
         version: 9.0.16(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4)
       '@storybook/react-vite':
         specifier: ^9.0.16
-        version: 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@types/diffable-html':
         specifier: ^5.0.2
         version: 5.0.2
@@ -183,13 +183,13 @@ importers:
         version: 1.0.0
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.6.0(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.6.0(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.2
-        version: 3.10.2(@swc/helpers@0.5.17)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 3.10.2(@swc/helpers@0.5.17)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+        version: 3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -279,22 +279,22 @@ importers:
         version: 5.0.0
       vite:
         specifier: ^7.0.4
-        version: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.16.3)(rollup@4.45.0)(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.5.4(@types/node@22.16.4)(rollup@4.45.0)(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@udir-design/theme':
     dependencies:
       '@digdir/designsystemet-react':
-        specifier: 1.1.4
-        version: 1.1.4(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.1.5
+        version: 1.1.5(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@internal/build-tools':
         specifier: workspace:*
@@ -309,8 +309,8 @@ importers:
   design-tokens:
     devDependencies:
       '@digdir/designsystemet':
-        specifier: 1.1.4
-        version: 1.1.4
+        specifier: 1.1.5
+        version: 1.1.5
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -369,19 +369,19 @@ importers:
         version: 18.3.7(@types/react@18.3.23)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.6.0(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 4.6.0(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitejs/plugin-react-swc':
         specifier: ^3.10.2
-        version: 3.10.2(@swc/helpers@0.5.17)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 3.10.2(@swc/helpers@0.5.17)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       sass:
         specifier: ^1.89.2
         version: 1.89.2
       vite:
         specifier: ^7.0.4
-        version: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+        version: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+        version: 5.1.4(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
 
 packages:
 
@@ -1142,17 +1142,17 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@digdir/designsystemet-css@1.1.4':
-    resolution: {integrity: sha512-lF4Uaqx95RzOXHZLhXrs4xBEvT7pS664PX0DVA8tERui5o/I40AfD0Iy78vYKcEMGmqbd7y38oLV8FFh3Sei5Q==}
+  '@digdir/designsystemet-css@1.1.5':
+    resolution: {integrity: sha512-clpN9V+atF0tcNA+vIPm+Wv7Wc0WvgbkdHvKHXPl34FQjNCHTaoxzqCcioRtEMWNuO8iiavv0EY0uhEeHpfCqg==}
 
-  '@digdir/designsystemet-react@1.1.4':
-    resolution: {integrity: sha512-TKJN8SZSj9jkGFhnoaZVZc1Iysd2p1x4uOr0et4KWDsXg3S3tAh0PmPX/aD/YxcbllFiO59XX7dScvgHWGtUDQ==}
+  '@digdir/designsystemet-react@1.1.5':
+    resolution: {integrity: sha512-lu2/twJyQXRKWumeWm9pGfj1/mZ1eM3Z14+hjs59DZ0jzs3zL3pc/cVdV4pBDIlz41HeiCbnpLFCuMGnOvnxSw==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
 
-  '@digdir/designsystemet@1.1.4':
-    resolution: {integrity: sha512-EzbY05uCJs/dE2308Cp/6c3hWHbIe1Qakv63d/wkaWzQE3HvX+cp0Gw/PJ0z6Vw6+OlgIzq6vudy8M2XL5Bxsw==}
+  '@digdir/designsystemet@1.1.5':
+    resolution: {integrity: sha512-wHGL6kDIpSetL6djt2mgB1IfCfWWub0I6RoMLk5kQ6zcFOjzuaD1FxRynvfuq4bnkqCUcbIqViiXvDmNhl1ueA==}
     engines: {node: '>=22.17.0'}
     hasBin: true
 
@@ -2499,8 +2499,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@22.16.3':
-    resolution: {integrity: sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==}
+  '@types/node@22.16.4':
+    resolution: {integrity: sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2611,8 +2611,8 @@ packages:
     resolution: {integrity: sha512-sOx1PKSuFwnIl7z4RN0Ls7N9AQawmR9r66eI5rFCzLDIs8HTIYrIpH9QjYWoX0lkgGrkLxXhi4QnK7MizPRrIg==}
     engines: {node: '>=20.0.0'}
 
-  '@u-elements/u-combobox@0.0.17':
-    resolution: {integrity: sha512-WjbaiZm8cQLYsgPaqbRPI59DhdvvKA1xa5p8jhNZ3R5683NqziBKnZN2V0RnAxJQBus3s3qXAYoxcjDSWc/18g==}
+  '@u-elements/u-combobox@0.0.18':
+    resolution: {integrity: sha512-0WttCjvLVTmJkEoTx7jkOu2thV3titNrQmo12jeBU/c+uviSAOfh5jMAwUj8ms2sZfvFkRy+d73VxjOHo0Iskw==}
 
   '@u-elements/u-datalist@1.0.10':
     resolution: {integrity: sha512-ctPlx8SL4njfsA0/JINVlVbfBW31HCswj8hDt/SsPUiF89n/fLmTLG49DxOW7RZNcXrWW+AudJy5zsuPCmCGRA==}
@@ -7229,11 +7229,11 @@ snapshots:
     dependencies:
       commander: 14.0.0
 
-  '@commitlint/cli@19.8.1(@types/node@22.16.3)(typescript@5.8.3)':
+  '@commitlint/cli@19.8.1(@types/node@22.16.4)(typescript@5.8.3)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@22.16.3)(typescript@5.8.3)
+      '@commitlint/load': 19.8.1(@types/node@22.16.4)(typescript@5.8.3)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.1
@@ -7280,7 +7280,7 @@ snapshots:
       '@commitlint/rules': 19.8.1
       '@commitlint/types': 19.8.1
 
-  '@commitlint/load@19.8.1(@types/node@22.16.3)(typescript@5.8.3)':
+  '@commitlint/load@19.8.1(@types/node@22.16.4)(typescript@5.8.3)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
@@ -7288,7 +7288,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.16.3)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.16.4)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -7363,16 +7363,16 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@digdir/designsystemet-css@1.1.4': {}
+  '@digdir/designsystemet-css@1.1.5': {}
 
-  '@digdir/designsystemet-react@1.1.4(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@digdir/designsystemet-react@1.1.5(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/dom': 1.7.2
       '@floating-ui/react': 0.26.23(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@navikt/aksel-icons': 7.25.1
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@u-elements/u-combobox': 0.0.17
+      '@u-elements/u-combobox': 0.0.18
       '@u-elements/u-datalist': 1.0.10
       '@u-elements/u-details': 0.1.1
       clsx: 2.1.1
@@ -7381,7 +7381,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@digdir/designsystemet@1.1.4':
+  '@digdir/designsystemet@1.1.5':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.0)
       '@tokens-studio/sd-transforms': 1.3.0(style-dictionary@5.0.1)
@@ -7579,18 +7579,18 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/confirm@5.1.13(@types/node@22.16.3)':
+  '@inquirer/confirm@5.1.13(@types/node@22.16.4)':
     dependencies:
-      '@inquirer/core': 10.1.14(@types/node@22.16.3)
-      '@inquirer/type': 3.0.7(@types/node@22.16.3)
+      '@inquirer/core': 10.1.14(@types/node@22.16.4)
+      '@inquirer/type': 3.0.7(@types/node@22.16.4)
     optionalDependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
     optional: true
 
-  '@inquirer/core@10.1.14(@types/node@22.16.3)':
+  '@inquirer/core@10.1.14(@types/node@22.16.4)':
     dependencies:
       '@inquirer/figures': 1.0.12
-      '@inquirer/type': 3.0.7(@types/node@22.16.3)
+      '@inquirer/type': 3.0.7(@types/node@22.16.4)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -7598,15 +7598,15 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
     optional: true
 
   '@inquirer/figures@1.0.12':
     optional: true
 
-  '@inquirer/type@3.0.7(@types/node@22.16.3)':
+  '@inquirer/type@3.0.7(@types/node@22.16.4)':
     optionalDependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
     optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -7630,12 +7630,12 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -7686,23 +7686,23 @@ snapshots:
       '@types/react': 19.1.8
       react: 19.1.0
 
-  '@microsoft/api-extractor-model@7.30.6(@types/node@22.16.3)':
+  '@microsoft/api-extractor-model@7.30.6(@types/node@22.16.4)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.1(@types/node@22.16.3)
+      '@rushstack/node-core-library': 5.13.1(@types/node@22.16.4)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.52.8(@types/node@22.16.3)':
+  '@microsoft/api-extractor@7.52.8(@types/node@22.16.4)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.30.6(@types/node@22.16.3)
+      '@microsoft/api-extractor-model': 7.30.6(@types/node@22.16.4)
       '@microsoft/tsdoc': 0.15.1
       '@microsoft/tsdoc-config': 0.17.1
-      '@rushstack/node-core-library': 5.13.1(@types/node@22.16.3)
+      '@rushstack/node-core-library': 5.13.1(@types/node@22.16.4)
       '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.3(@types/node@22.16.3)
-      '@rushstack/ts-command-line': 5.0.1(@types/node@22.16.3)
+      '@rushstack/terminal': 0.15.3(@types/node@22.16.4)
+      '@rushstack/ts-command-line': 5.0.1(@types/node@22.16.4)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -7813,7 +7813,7 @@ snapshots:
       ignore: 5.3.2
       minimatch: 9.0.3
       nx: 21.1.2(@swc-node/register@1.10.10(@swc/core@1.12.11(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.12.11(@swc/helpers@0.5.17))
-      semver: 7.5.4
+      semver: 7.7.2
       tmp: 0.2.3
       tslib: 2.8.1
       yargs-parser: 21.1.1
@@ -8275,7 +8275,7 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
-  '@rushstack/node-core-library@5.13.1(@types/node@22.16.3)':
+  '@rushstack/node-core-library@5.13.1(@types/node@22.16.4)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -8286,23 +8286,23 @@ snapshots:
       resolve: 1.22.10
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
 
   '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.15.3(@types/node@22.16.3)':
+  '@rushstack/terminal@0.15.3(@types/node@22.16.4)':
     dependencies:
-      '@rushstack/node-core-library': 5.13.1(@types/node@22.16.3)
+      '@rushstack/node-core-library': 5.13.1(@types/node@22.16.4)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
 
-  '@rushstack/ts-command-line@5.0.1(@types/node@22.16.3)':
+  '@rushstack/ts-command-line@5.0.1(@types/node@22.16.4)':
     dependencies:
-      '@rushstack/terminal': 0.15.3(@types/node@22.16.3)
+      '@rushstack/terminal': 0.15.3(@types/node@22.16.4)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -8338,19 +8338,19 @@ snapshots:
       storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@storybook/builder-vite@9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@storybook/csf-plugin': 9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))
       storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@storybook/csf-plugin@9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))':
     dependencies:
@@ -8370,11 +8370,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
 
-  '@storybook/react-vite@9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@storybook/react-vite@9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@rollup/pluginutils': 5.2.0(rollup@4.45.0)
-      '@storybook/builder-vite': 9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@storybook/builder-vite': 9.0.16(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@storybook/react': 9.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       find-up: 7.0.0
       magic-string: 0.30.17
@@ -8384,7 +8384,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 9.0.16(@testing-library/dom@10.4.0)(prettier@3.6.2)
       tsconfig-paths: 4.2.0
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -8591,7 +8591,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
 
   '@types/cookie@0.6.0':
     optional: true
@@ -8630,7 +8630,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@22.16.3':
+  '@types/node@22.16.4':
     dependencies:
       undici-types: 6.21.0
 
@@ -8779,7 +8779,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@u-elements/u-combobox@0.0.17': {}
+  '@u-elements/u-combobox@0.0.18': {}
 
   '@u-elements/u-datalist@1.0.10': {}
 
@@ -8846,15 +8846,15 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react-swc@3.10.2(@swc/helpers@0.5.17)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitejs/plugin-react-swc@3.10.2(@swc/helpers@0.5.17)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.11
       '@swc/core': 1.12.11(@swc/helpers@0.5.17)
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.6.0(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitejs/plugin-react@4.6.0(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -8862,20 +8862,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.54.1
@@ -8900,9 +8900,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -8914,14 +8914,14 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.3(@types/node@22.16.3)(typescript@5.8.3)
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      msw: 2.7.3(@types/node@22.16.4)(typescript@5.8.3)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -8952,7 +8952,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.16.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9523,9 +9523,9 @@ snapshots:
     dependencies:
       browserslist: 4.25.1
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.16.3)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.16.4)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.4.2
       typescript: 5.8.3
@@ -10837,7 +10837,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.5.4
+      semver: 7.7.2
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -11400,12 +11400,12 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3):
+  msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.13(@types/node@22.16.3)
+      '@inquirer/confirm': 5.1.13(@types/node@22.16.4)
       '@mswjs/interceptors': 0.37.6
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -11626,7 +11626,7 @@ snapshots:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.6.1
+      cli-spinners: 2.9.2
       is-interactive: 1.0.0
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
@@ -12446,7 +12446,7 @@ snapshots:
       '@bundled-es-modules/deepmerge': 4.3.1
       '@bundled-es-modules/glob': 10.4.2
       '@bundled-es-modules/memfs': 4.17.0
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
       '@zip.js/zip.js': 2.7.63
       chalk: 5.4.1
       change-case: 5.4.4
@@ -12601,14 +12601,14 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-node@10.9.2(@swc/core@1.12.11(@swc/helpers@0.5.17))(@types/node@22.16.3)(typescript@5.8.3):
+  ts-node@10.9.2(@swc/core@1.12.11(@swc/helpers@0.5.17))(@types/node@22.16.4)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -12864,13 +12864,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+  vite-node@3.2.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -12885,9 +12885,9 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@22.16.3)(rollup@4.45.0)(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)):
+  vite-plugin-dts@4.5.4(@types/node@22.16.4)(rollup@4.45.0)(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
-      '@microsoft/api-extractor': 7.52.8(@types/node@22.16.3)
+      '@microsoft/api-extractor': 7.52.8(@types/node@22.16.4)
       '@rollup/pluginutils': 5.2.0(rollup@4.45.0)
       '@volar/typescript': 2.4.18
       '@vue/language-core': 2.2.0(typescript@5.8.3)
@@ -12898,24 +12898,24 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+  vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.6
       fdir: 6.4.6(picomatch@4.0.2)
@@ -12924,7 +12924,7 @@ snapshots:
       rollup: 4.44.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 22.16.3
+      '@types/node': 22.16.4
       fsevents: 2.3.3
       jiti: 2.4.2
       less: 4.1.3
@@ -12934,11 +12934,11 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.0
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.16.3)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.16.4)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(less@4.1.3)(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -12956,13 +12956,13 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
-      vite-node: 3.2.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@types/node': 22.16.3
-      '@vitest/browser': 3.2.4(msw@2.7.3(@types/node@22.16.3)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.3)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@types/node': 22.16.4
+      '@vitest/browser': 3.2.4(msw@2.7.3(@types/node@22.16.4)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.4(@types/node@22.16.4)(jiti@2.4.2)(less@4.1.3)(sass@1.89.2)(stylus@0.64.0)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/ui': 3.2.4(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:


### PR DESCRIPTION
This includes [bugfixes for several components](https://github.com/digdir/designsystemet/releases/tag/v1.1.5), and notable changes to **Suggestion**:
- Fix controlled value being cleared if edited in React 18 strict mode
- Deprecated `value`, use `selected` instead
- Deprecated `defaultValue`, use `defaultSelected` instead
- Deprecated `onValueChange`, use `onSelectedChange` instead
- Deprecated `Suggestion.Chips`, use `renderSelected` on `Suggestion` instead
- Add `onBeforeMatch` to `Suggestion` for custom matching
- Revert input `value` to current `selected` when no match