### PR TITLE
link underline fix

### DIFF
--- a/@udir-design/react/public/style.css
+++ b/@udir-design/react/public/style.css
@@ -7,4 +7,12 @@
   --dsc-link-color--active: var(--ds-color-text-subtle);
   --dsc-link-color--hover: var(--ds-color-text-subtle);
   --dsc-link-color: var(--ds-color-text-default);
+  /* Set underline only to span if there is a span in link. To avoid underline on space between elements */
+  &:has(span) {
+    text-decoration: none;
+    > span {
+      text-decoration: underline;
+      margin-left: var(--ds-size-1);
+    }
+  }
 }

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -41,7 +41,7 @@ En lenke brukes ofte som en del av en tekst. Teksten som omfattes av lenken bør
 ### Med ikon
 
 Ikonet legges på venstre side. Dette er et funksjonelt ikon som forteller brukerne hva lenken leder dem til.
-Ikonet burde være skjult fra skjermleser, ved å legge på `aria-hidden`.
+Ikonet burde være skjult fra skjermleser, ved å legge på `aria-hidden`. Plasser teksten i `<span>` for å få riktig styling.
 
 <Canvas of={LinkStories.WithIcon} />
 

--- a/@udir-design/react/src/components/link/Link.stories.tsx
+++ b/@udir-design/react/src/components/link/Link.stories.tsx
@@ -42,7 +42,8 @@ export const WithIcon: Story = {
   },
   render: (args) => (
     <Link {...args}>
-      <EnvelopeClosedIcon aria-hidden /> Kontakt oss
+      <EnvelopeClosedIcon aria-hidden />
+      <span>Kontakt oss</span>
     </Link>
   ),
 };
@@ -66,7 +67,8 @@ export const File: Story = {
   },
   render: (args) => (
     <Link {...args}>
-      <FilePdfFillIcon aria-hidden /> Samisk i barnehagen (PDF, 299KB)
+      <FilePdfFillIcon aria-hidden />
+      <span>Samisk i barnehagen (PDF, 299KB)</span>
     </Link>
   ),
 };

--- a/@udir-design/react/src/components/link/__snapshots__/Link.stories.tsx.snap
+++ b/@udir-design/react/src/components/link/__snapshots__/Link.stories.tsx.snap
@@ -20,7 +20,9 @@ exports[`File 1`] = `
     >
     </path>
   </svg>
-  Samisk i barnehagen (PDF, 299KB)
+  <span>
+    Samisk i barnehagen (PDF, 299KB)
+  </span>
 </a>
 `;
 
@@ -74,6 +76,8 @@ exports[`With Icon 1`] = `
     >
     </path>
   </svg>
-  Kontakt oss
+  <span>
+    Kontakt oss
+  </span>
 </a>
 `;


### PR DESCRIPTION
Legger til styling for å fjerne underline på mellomrom på link med ikon. Dersom teksten er wrappet i en `<span>` så vil dette fungere. 

Kan vurdere om det heller burde fikses hos Digdir.