### PR TITLE
docs: beta-badge for errorsummary

### DIFF
--- a/@udir-design/react/src/components/alpha.ts
+++ b/@udir-design/react/src/components/alpha.ts
@@ -4,7 +4,6 @@
 
 export * from './badge/Badge';
 export * from './dropdown/Dropdown';
-export * from './errorSummary/ErrorSummary';
 export * from './popover/Popover';
 export * from './skipLink/SkipLink';
 export * from './suggestion/Suggestion';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -12,6 +12,7 @@ export * from './checkbox/Checkbox';
 export * from './details/Details';
 export * from './dialog/Dialog';
 export * from './divider/Divider';
+export * from './errorSummary/ErrorSummary';
 export * from './field/Field';
 export * from './fieldset/Fieldset';
 export * from './input/Input';

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
@@ -15,16 +15,16 @@ import * as ErrorSummaryStories from './ErrorSummary.stories';
 `ErrorSummary` er en oppsummering av feil. Det gir brukeren oversikt over feil eller
 mangler som må rettes på en side eller i et steg for å komme videre.
 
-**Passer til**
+**Passer til å**
 
-- å gi brukerne en tydelig oversikt over hvilke feil som må rettes før de kan fortsette
-- skjema med mange felt, der det kan være vanskelig å få oversikt over hvor feilene befinner seg
+- gi brukerne en tydelig oversikt over hvilke feil som må rettes før de kan fortsette
+- brukes i skjema med mange felt, der det kan være vanskelig å få oversikt over hvor feilene befinner seg
 
 **Passer ikke til**
 
-- å vise systemvarsler, bruk [`Alert`](/docs/components-alert--docs)
-- å vise tilbakemeldinger som ikke hindrer innsending, for eksempel advarsler eller anbefalinger
-- å vise feilmeldinger for individuelle felter, bruk heller `error` prop for [`Textfield`](/docs/components-textfield--docs), [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs) og [`Switch`](/docs/components-switch--docs); eller kombiner [`Field`](/docs/components-field--docs) og [`ValidationMessage`](/docs/components-typography--docs#validationmessage) for andre skjemaelementer
+- vise systemvarsler, bruk [`Alert`](/docs/components-alert--docs)
+- vise tilbakemeldinger som ikke hindrer innsending, for eksempel advarsler eller anbefalinger
+- vise feilmeldinger for individuelle felter, bruk heller `error` prop for [`Textfield`](/docs/components-textfield--docs), [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs) og [`Switch`](/docs/components-switch--docs); eller kombiner [`Field`](/docs/components-field--docs) og [`ValidationMessage`](/docs/components-typography--docs#validationmessage) for andre skjemaelementer
 
 ## Slik bruker du ErrorSummary
 

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Button, Textfield } from '@udir-design/react/alpha';
+import { Button, Textfield } from '@udir-design/react/beta';
 import { ErrorSummary } from './ErrorSummary';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, within } from 'storybook/test';
@@ -8,7 +8,7 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 
 const meta: Meta<typeof ErrorSummary> = {
   component: ErrorSummary,
-  tags: ['alpha'],
+  tags: ['beta'],
   parameters: {
     layout: 'centered',
   },


### PR DESCRIPTION
## Hva er gjort? 
- `ErrorSummary` hadde fortsatt alpha-badge selv om den er i beta-versjon, endret dette 
  - Eksporterer også `ErrorSummary` fra `beta.ts` nå 
- Småfiks på format for dokumentasjon som har endret seg siden denne gikk i prod 