### PR TITLE
fix: remove unused prop for skeleton

### DIFF
--- a/@udir-design/react/src/components/skeleton/Skeleton.tsx
+++ b/@udir-design/react/src/components/skeleton/Skeleton.tsx
@@ -1,2 +1,12 @@
-import { Skeleton, type SkeletonProps } from '@digdir/designsystemet-react';
+import {
+  Skeleton as DigdirSkeleton,
+  type SkeletonProps as DigdirSkeletonProps,
+} from '@digdir/designsystemet-react';
+
+type SkeletonProps = Omit<DigdirSkeletonProps, 'characters'>;
+
+const Skeleton: React.ForwardRefExoticComponent<
+  SkeletonProps & React.RefAttributes<HTMLSpanElement>
+> = DigdirSkeleton;
+
 export { Skeleton, SkeletonProps };


### PR DESCRIPTION
## Hva er gjort? 
- Omitted `characters` for skeleton siden den ikke gjør noe, bruker `width` i stedet til å bestemme lengde for `variant="text"`