### PR TITLE
style: darker text button and tabs

### DIFF
--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -32,7 +32,8 @@
     "./dist"
   ],
   "scripts": {
-    "build": "vite build && pnpm i",
+    "build": "vite build",
+    "inject": "pnpm i",
     "test": "vitest --project unit",
     "typecheck": "tsc --build",
     "dev": "storybook dev --port 6006",

--- a/@udir-design/react/src/components/button/button.css
+++ b/@udir-design/react/src/components/button/button.css
@@ -1,0 +1,6 @@
+.ds-button {
+  &[data-variant='tertiary']:not([data-color='danger']),
+  &[data-variant='secondary']:not([data-color='danger']) {
+    --dsc-button-color: var(--ds-color-text-default);
+  }
+}

--- a/@udir-design/react/src/components/tabs/tabs.css
+++ b/@udir-design/react/src/components/tabs/tabs.css
@@ -1,0 +1,11 @@
+.ds-tabs {
+  --dsc-tabs-tab-color: var(--ds-color-text-default);
+  --dsc-tabs-tab-color--hover: var(--ds-color-text-sublte);
+  --dsc-tabs-list-border-color: var(--ds-color-border-subtle);
+  --dsc-tabs-tab-color--selected: var(--ds-color-text-default);
+
+  &[data-color='accent'] {
+    --dsc-tabs-tab-color: var(--ds-color-text-subtle);
+    --dsc-tabs-tab-color--hover: var(--ds-color-border-default);
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -31,9 +31,12 @@
     },
     "build": {
       "cache": true,
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^inject"],
       "inputs": ["default", "^default"],
       "outputs": ["{projectRoot}/dist"]
+    },
+    "inject": {
+      "dependsOn": ["build"]
     },
     "test": {
       "dependsOn": ["build"]


### PR DESCRIPTION
## Hva er gjort? 
- `<Button>` sin secondary og tertiary variant har fått text-default som farge og text-subtle som hover/active farge for `neutral` varianten
- gjort det samme for tabs som bruker "standard" `<button>` og derfor ikke treffes av samme styling som `Button`