### PR TITLE
docs: info about future components

### DIFF
--- a/@udir-design/react/src/Introduksjon.mdx
+++ b/@udir-design/react/src/Introduksjon.mdx
@@ -7,15 +7,17 @@ import { HideToc } from '../.storybook/utils/HideToc';
 
 # Designsystem for Utdanningsdirektoratet
 
-Udirs designsystem skal bidra til å skape og opprettholde helhetlig design slik at Udir har:
+Udirs designsystem skal bidra til å skape og opprettholde helhetlig design i tråd med [designprofilen](https://www.udir.no/om-udir/designprofil/) slik at Udir har:
 
 - tydelig identitet
 - brukervennlige løsninger
 - effektiv utvikling
 
-Udirs designsystem tar utgangspunkt i [Digdirs felles designsystem](https://www.designsystemet.no/). Designsystemet skal brukes for å oppnå helhetlig design i Udirs digitale tjenester og i andre kommunikasjonsflater i tråd med Udirs [designprofil](https://www.udir.no/om-udir/designprofil/).
+Systemet er for tiden i beta-versjon. Dette betyr blant annet at komponentene er tilpasset bruk i Udir og at det er skrevet tester for dem, det finnes mer info om dette [her](/docs/components-introduksjon--docs#livsfaser-for-en-komponent). Vi ønsker at systemteamene tar det i bruk og gir oss tilbakemelding både om det som fungerer godt og om noe mangler eller bør endres. Vi trenger tilbakemeldingene for å kunne gjøre endringer før designsystemet lanseres i stabil versjon. Kontakt oss gjerne på [designteamet@udir.no](mailto:designteamet@udir.no) eller i slack-kanalen [#designsystem-udir](https://udir.slack.com/archives/C06G2E50HF0).
 
-Dersom du har forslag til designendringer, nye features, oppdater en bug, eller har andre henvendelser knyttet til designsystemet kan teamet nås på [designteamet@udir.no](mailto:designteamet@udir.no) eller i slack-kanalen [#designsystem-udir](https://udir.slack.com/archives/C06G2E50HF0). De viktigste tilbakemeldingene vi får er erfaringer fra bruk, det er slik vi oppdager nye behov.
+Designsystemet består av komponentene som ligger her i Storybook og vi har også en oversikt over [kommende komponenter](https://confluence.udir.no/spaces/DESIGN/pages/348980841/Fremtidige+komponenter). I tillegg jobber vi med [mønstre for interaksjon](https://confluence.udir.no/spaces/DESIGN/pages/364578698/Fremtidige+m%C3%B8nstre).
+
+Udirs designsystem tar utgangspunkt i [Digdirs felles designsystem](https://www.designsystemet.no/).
 
 <Unstyled>
   <LandingResourceLinks />

--- a/@udir-design/react/src/ResourceLinks.module.css
+++ b/@udir-design/react/src/ResourceLinks.module.css
@@ -4,6 +4,23 @@
   grid-template-columns: 1fr;
   margin-top: var(--ds-size-6);
   margin-bottom: var(--ds-size-10);
+
+  @media (min-width: 600px) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (min-width: 900px) {
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+}
+
+.horisontalWrapper {
+  margin-top: var(--ds-size-6);
+  margin-bottom: var(--ds-size-10);
+  display: flex;
+  flex-wrap: wrap;
+  flex: 0 1 70%;
+  gap: var(--ds-size-4);
 }
 
 .illustration {
@@ -14,14 +31,8 @@
   padding: var(--ds-size-10);
 }
 
-@media (min-width: 600px) {
-  .wrapper {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-
-@media (min-width: 900px) {
-  .wrapper {
-    grid-template-columns: 1fr 1fr 1fr;
-  }
+.icon {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
 }

--- a/@udir-design/react/src/ResourceLinks.tsx
+++ b/@udir-design/react/src/ResourceLinks.tsx
@@ -3,6 +3,7 @@ import { Card } from './components/card/Card';
 import { Heading, HeadingProps } from './components/typography/heading/Heading';
 import { Paragraph } from './components/typography/paragraph/Paragraph';
 import styles from './ResourceLinks.module.css';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 
 export function LandingResourceLinks() {
   const domainUrl = window.location.origin;
@@ -55,16 +56,29 @@ export function LandingResourceLinks() {
   );
 }
 
-export function ComponentResourceLinks() {
+export function ComponentResourceLink() {
   return (
-    <div className={styles.wrapper}>
-      <ResourceLink
-        href="https://www.figma.com/design/6cS3POn7y9Zost26ofJh0a/Komponentbibliotek--beta-?m=auto&node-id=4-476&t=m9jA1aHGUTH3tuve-1"
-        illustration={figmaIllustration}
-        headingLevel={2}
-        heading="Komponenter i Figma"
-        paragraph="Oversikten over komponentene finnes også tilgjengelig i Figma."
-      />
+    <div className={styles.horisontalWrapper}>
+      <Card style={{ display: 'flex', width: 'fit-content' }}>
+        <Card.Block className={styles.illustration} style={{ height: 150 }}>
+          {figmaIllustration}
+        </Card.Block>
+        <Card.Block>
+          <Heading level={2}>
+            <a href="https://www.figma.com/design/6cS3POn7y9Zost26ofJh0a/Komponentbibliotek--beta-?m=auto&node-id=4-476&t=m9jA1aHGUTH3tuve-1">
+              Komponenter i Figma
+            </a>
+          </Heading>
+          <Paragraph style={{ lineBreak: 'auto' }}>
+            Oversikten over komponentene finnes også tilgjengelig i Figma.
+          </Paragraph>
+          <ArrowRightIcon
+            title="a11y-title"
+            fontSize="1.5rem"
+            className={styles.icon}
+          />
+        </Card.Block>
+      </Card>
     </div>
   );
 }

--- a/@udir-design/react/src/components/Introduksjon.mdx
+++ b/@udir-design/react/src/components/Introduksjon.mdx
@@ -1,7 +1,7 @@
 import README from '../../../../README.md?raw';
 import { IncludeMarkdown } from '.storybook/doc-blocks/IncludeMarkdown';
 import { Unstyled } from '@storybook/addon-docs/blocks';
-import { ComponentResourceLinks } from '../ResourceLinks';
+import { ComponentResourceLink } from '../ResourceLinks';
 
 import { HideToc } from '../../.storybook/utils/HideToc';
 
@@ -16,17 +16,9 @@ Overskriften "Demosider" inneholder eksempler som viser komponenter brukt sammen
 Komponenter er markert med "Alpha" eller "Beta" dersom de ikke er stabile (les mer om livsfaser lenger ned).
 
 <Unstyled>
-  <ComponentResourceLinks />
+  <ComponentResourceLink />
 </Unstyled>
 
-<IncludeMarkdown
-  markdown={README}
-  sectionId="livsfaser-for-en-komponent"
-  increaseHeadingDepthBy={1}
-/>
+<IncludeMarkdown markdown={README} sectionId="livsfaser-for-en-komponent" />
 
-<IncludeMarkdown
-  markdown={README}
-  sectionId="hva-tester-vi"
-  increaseHeadingDepthBy={1}
-/>
+<IncludeMarkdown markdown={README} sectionId="hva-tester-vi" />


### PR DESCRIPTION
## Hva er gjort? 👀 
- Oppdatert introduksjon til å blant annet inkludere informasjon om egne komponenter og mønstre vi jobber med eller planlegger å implementere
- Endret styling for card-link siden det så litt corny ut med vertikalt design når det bare er ett kort 
- Fikset levels for headings fra Markdown, siden de tidligere gikk fra `H1` til `H3`

| Før    | Etter |
| -------- | ------- |
| <img width="1152" height="835" alt="image" src="https://github.com/user-attachments/assets/a62d1c24-15a5-4f0f-beb6-e3c4475ad6f1" />  | <img width="1079" height="879" alt="image" src="https://github.com/user-attachments/assets/0e67d84f-22c4-426e-880d-373059754392" />  |