### PR TITLE
docs: component-origin information

### DIFF
--- a/@udir-design/react/.storybook/doc-blocks/DocsContainer.tsx
+++ b/@udir-design/react/.storybook/doc-blocks/DocsContainer.tsx
@@ -1,0 +1,41 @@
+import {
+  ComponentOrigin,
+  ComponentOriginParameters,
+} from '.storybook/types/parameters';
+import {
+  DocsContainer as OriginalDocsContainer,
+  type DocsContainerProps,
+} from '@storybook/addon-docs/blocks';
+import { ComponentType, useState } from 'react';
+import { OriginText } from './Origin';
+
+export const DocsContainer = ({
+  children,
+  ...props
+}: React.PropsWithChildren<DocsContainerProps>) => {
+  const [componentName, setComponentName] = useState<string>('');
+  const [componentOrigin, setComponentOrigin] = useState<ComponentOrigin>();
+
+  // Wait for docs to render before retrieving stories, as they are not available until at first render.
+  props.context.channel.addListener('docsRendered', () => {
+    // Get the component name and origin information from parameters of the first story,
+    // inherited from the stories file meta properties
+    const firstStory = props.context.componentStories().at(0);
+    if (!firstStory) {
+      return;
+    }
+    setComponentName((firstStory.component as ComponentType).displayName ?? '');
+    setComponentOrigin(
+      (firstStory.parameters as ComponentOriginParameters).componentOrigin,
+    );
+  });
+
+  return (
+    <OriginalDocsContainer {...props}>
+      {children}
+      {componentOrigin && (
+        <OriginText component={componentName} {...componentOrigin} />
+      )}
+    </OriginalDocsContainer>
+  );
+};

--- a/@udir-design/react/.storybook/doc-blocks/Origin.tsx
+++ b/@udir-design/react/.storybook/doc-blocks/Origin.tsx
@@ -1,0 +1,35 @@
+import { ComponentOrigin } from '.storybook/types/parameters';
+import { Heading, Paragraph } from '../../src/components/typography';
+
+export interface OriginProps extends ComponentOrigin {
+  component: string;
+}
+
+export function OriginText({ component, originator, details }: OriginProps) {
+  const baseText =
+    originator === 'digdir'
+      ? ' bygger på en komponent fra Digdirs designsystem.'
+      : ' er egenutviklet.';
+
+  const fullText = details ? `${baseText} ${details}` : baseText;
+
+  return (
+    <>
+      <Heading
+        level={2}
+        data-size="md"
+        className="sb-unstyled"
+        style={{
+          marginTop: 'var(--ds-size-5)',
+          marginBottom: 'var(--ds-size-2)',
+        }}
+      >
+        Kilde
+      </Heading>
+      <Paragraph className="sb-unstyled">
+        <code className="css-b5rkn5">{component}</code>
+        {fullText}
+      </Paragraph>
+    </>
+  );
+}

--- a/@udir-design/react/.storybook/manager.tsx
+++ b/@udir-design/react/.storybook/manager.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { addons } from 'storybook/manager-api';
 import {
   defaultConfig,

--- a/@udir-design/react/.storybook/manager.tsx
+++ b/@udir-design/react/.storybook/manager.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { addons } from 'storybook/manager-api';
 import {
   defaultConfig,
@@ -21,7 +22,8 @@ addons.setConfig({
         text: 'Alpha',
         style: {
           backgroundColor: 'var(--ds-color-danger-surface-tinted)',
-          borderColor: 'var(--ds-color-danger-border-subtle)',
+          borderColor: 'var(--ds-color-danger-surface-tinted)',
+          borderRadius: 'var(--ds-border-radius-sm)',
           color: 'var(--ds-color-danger-text-default)',
         },
       },
@@ -32,7 +34,8 @@ addons.setConfig({
         text: 'Beta',
         style: {
           backgroundColor: 'var(--ds-color-warning-surface-tinted)',
-          borderColor: 'var(--ds-color-warning-border-subtle)',
+          borderColor: 'var(--ds-color-warning-surface-tinted)',
+          borderRadius: 'var(--ds-border-radius-sm)',
           color: 'var(--ds-color-warning-text-default)',
         },
       },

--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -11,6 +11,7 @@ import { MdxComponentOverrides } from './types/parameters';
 import { Children, MouseEventHandler } from 'react';
 import { LinkIcon } from '@navikt/aksel-icons';
 import { hideTocForIds } from './utils/HideToc';
+import { DocsContainer } from './doc-blocks/DocsContainer';
 
 // See the complete list of available devices in INITIAL_VIEWPORTS here:
 // https://storybook.js.org/docs/essentials/viewport#use-a-detailed-set-of-devices
@@ -152,6 +153,7 @@ const preview: Preview = {
     },
 
     docs: {
+      container: DocsContainer,
       // Configure the table of contents
       toc: {
         title: 'På denne siden',

--- a/@udir-design/react/.storybook/types/parameters.ts
+++ b/@udir-design/react/.storybook/types/parameters.ts
@@ -7,7 +7,10 @@
  * See https://github.com/microsoft/TypeScript/issues/30511 for details.
  */
 
-import type { Addon_OptionsParameter } from 'storybook/internal/types';
+import type {
+  Addon_OptionsParameter,
+  Parameters,
+} from 'storybook/internal/types';
 import type { DocsTypes } from '@storybook/addon-docs';
 import type { A11yParameters } from '@storybook/addon-a11y';
 import type { CSSProperties, ReactNode } from 'react';
@@ -49,6 +52,22 @@ type DocsSourceParams = Partial<Omit<SourceBlockParameters, 'transform'>> & {
     storyContext: StoryContext,
   ) => string | Promise<string>; // original type doesn't allow Promise, although support for this was added in 9.0.0. See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#parametersdocssourceformat-removal
 };
+
+export type ComponentOrigin = {
+  originator: 'self' | 'digdir';
+  details?: string;
+};
+export type ComponentOriginParameters = {
+  componentOrigin: ComponentOrigin;
+};
+
+declare module 'storybook/internal/csf' {
+  interface ComponentAnnotations {
+    parameters?: Parameters & Partial<ComponentOriginParameters>;
+    // TODO: should just be this when all story files are updated
+    // parameters: Parameters & ComponentOriginParameters;
+  }
+}
 
 declare module 'storybook/internal/types' {
   interface Parameters extends A11yParameters, DocsParameters {

--- a/@udir-design/react/src/components/alert/Alert.stories.tsx
+++ b/@udir-design/react/src/components/alert/Alert.stories.tsx
@@ -9,7 +9,10 @@ type Story = StoryObj<typeof Alert>;
 
 const meta: Meta<typeof Alert> = {
   component: Alert,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: { originator: 'digdir' },
+  },
 };
 
 export default meta;

--- a/@udir-design/react/src/components/avatar/Avatar.stories.tsx
+++ b/@udir-design/react/src/components/avatar/Avatar.stories.tsx
@@ -4,8 +4,13 @@ import { BriefcaseIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
 const meta: Meta<typeof Avatar> = {
   component: Avatar,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details:
+        'Vi har fjernet muligheten til å endre formen for en mer konsekvent brukeropplevelse på tvers av tjenester.',
+    },
     layout: 'padded',
     customStyles: {
       display: 'flex',

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -14,8 +14,13 @@ import { CSSProperties } from 'react';
 
 const meta: Meta<typeof Badge> = {
   component: Badge,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details:
+        'Vi har begrenset fargevalg til semantiske farger og Udirs hovedfarger.',
+    },
     customStyles: {
       display: 'flex',
       flexDirection: 'row',

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -4,7 +4,12 @@ import { expect, within } from 'storybook/test';
 
 export default {
   component: Breadcrumbs,
-  tags: ['beta'],
+  tags: ['beta', 'udir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
 } as Meta<typeof Breadcrumbs>;
 
 type Story = StoryObj<typeof Breadcrumbs>;

--- a/@udir-design/react/src/components/button/Button.stories.tsx
+++ b/@udir-design/react/src/components/button/Button.stories.tsx
@@ -19,7 +19,12 @@ export type Story = StoryObj<typeof Button>;
 
 const meta: Meta<typeof Button> = {
   component: Button,
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har begrenset fargevalg til neutral og danger.',
+    },
     customStyles: {
       display: 'flex',
       flexDirection: 'row',
@@ -29,7 +34,6 @@ const meta: Meta<typeof Button> = {
       gap: 'var(--ds-size-4)',
     },
   },
-  tags: ['beta'],
 };
 
 export default meta;

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -21,8 +21,11 @@ const schoolSuppliesImg =
 
 const meta: Meta<typeof Card> = {
   component: Card,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     customStyles: {
       width: '100%',
       maxWidth: 800,

--- a/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
@@ -17,7 +17,13 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
+  },
 };
 
 export default meta;

--- a/@udir-design/react/src/components/chip/Chip.stories.tsx
+++ b/@udir-design/react/src/components/chip/Chip.stories.tsx
@@ -7,8 +7,11 @@ import { Paragraph } from '../alpha';
 
 const meta: Meta<typeof Chip.Radio> = {
   component: Chip.Radio,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     customStyles: {
       display: 'flex',
       gap: 'var(--ds-size-2)',

--- a/@udir-design/react/src/components/details/Details.stories.tsx
+++ b/@udir-design/react/src/components/details/Details.stories.tsx
@@ -17,7 +17,12 @@ import { ChevronDownUpIcon, ChevronUpDownIcon } from '@navikt/aksel-icons';
 
 export default {
   component: Details,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
 } as Meta<typeof Details>;
 
 type Story = StoryObj<typeof Details>;

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -16,8 +16,12 @@ import { useRef, useState } from 'react';
 
 const meta: Meta<typeof Dialog> = {
   component: Dialog,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     customStyles: {
       display: 'grid',
       alignItems: 'start',

--- a/@udir-design/react/src/components/divider/Divider.stories.tsx
+++ b/@udir-design/react/src/components/divider/Divider.stories.tsx
@@ -11,7 +11,12 @@ import {
 
 const meta: Meta<typeof Divider> = {
   component: Divider,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
 };
 
 export default meta;

--- a/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
@@ -18,8 +18,12 @@ import { Button, Dropdown, Avatar, Divider } from '../beta';
 
 const meta: Meta<typeof Dropdown> = {
   component: Dropdown,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'fullscreen',
     customStyles: {
       alignItems: 'start',

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
@@ -8,8 +8,11 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 
 const meta: Meta<typeof ErrorSummary> = {
   component: ErrorSummary,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     layout: 'centered',
   },
   decorators: [withScrollHashBehavior],

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -10,8 +10,12 @@ import { expect, waitFor } from 'storybook/test';
 
 const meta: Meta<typeof Field> = {
   component: Field,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/fieldset/Fieldset.stories.tsx
+++ b/@udir-design/react/src/components/fieldset/Fieldset.stories.tsx
@@ -9,8 +9,12 @@ import {
 
 const meta: Meta<typeof Fieldset> = {
   component: Fieldset,
-  tags: ['beta'],
+  tags: ['beta', 'didir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/input/Input.stories.tsx
+++ b/@udir-design/react/src/components/input/Input.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof Input>;
 
 export default {
   component: Input,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   argTypes: {
     role: {
       control: 'radio',
@@ -27,6 +27,10 @@ export default {
     },
   },
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 } satisfies Meta;

--- a/@udir-design/react/src/components/link/Link.stories.tsx
+++ b/@udir-design/react/src/components/link/Link.stories.tsx
@@ -6,8 +6,12 @@ EnvelopeClosedIcon.displayName = 'EnvelopeClosedIcon';
 
 const meta: Meta<typeof Link> = {
   component: Link,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/list/List.stories.tsx
+++ b/@udir-design/react/src/components/list/List.stories.tsx
@@ -3,7 +3,13 @@ import { List, Heading, Link } from '@udir-design/react/alpha';
 
 const meta: Meta<typeof List.Unordered> = {
   component: List.Unordered,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
+  },
 };
 
 export default meta;

--- a/@udir-design/react/src/components/pagination/Pagination.stories.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.stories.tsx
@@ -11,8 +11,12 @@ import { expect, userEvent, within } from 'storybook/test';
 
 const meta: Meta<typeof Pagination> = {
   component: Pagination,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/popover/Popover.stories.tsx
+++ b/@udir-design/react/src/components/popover/Popover.stories.tsx
@@ -8,8 +8,11 @@ import { Paragraph } from '../alpha';
 
 const meta: Meta<typeof Popover> = {
   component: Popover,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     customStyles: {
       display: 'flex',
       justifyContent: 'center',

--- a/@udir-design/react/src/components/radio/Radio.stories.tsx
+++ b/@udir-design/react/src/components/radio/Radio.stories.tsx
@@ -15,7 +15,13 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 
 const meta: Meta<typeof Radio> = {
   component: Radio,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
+  },
 };
 
 export default meta;

--- a/@udir-design/react/src/components/search/Search.stories.tsx
+++ b/@udir-design/react/src/components/search/Search.stories.tsx
@@ -16,8 +16,12 @@ import { useDebounceCallback } from '@digdir/designsystemet-react';
 
 const meta: Meta<typeof Search> = {
   component: Search,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/select/Select.stories.tsx
+++ b/@udir-design/react/src/components/select/Select.stories.tsx
@@ -8,8 +8,11 @@ import { useState } from 'react';
 
 const meta: Meta<typeof Select> = {
   component: Select,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/skeleton/Skeleton.stories.tsx
+++ b/@udir-design/react/src/components/skeleton/Skeleton.stories.tsx
@@ -10,8 +10,11 @@ import { Heading, Paragraph } from '../../alpha';
 
 const meta: Meta<typeof Skeleton> = {
   component: Skeleton,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     layout: 'centered',
     a11y: {
       config: {

--- a/@udir-design/react/src/components/skipLink/SkipLink.stories.tsx
+++ b/@udir-design/react/src/components/skipLink/SkipLink.stories.tsx
@@ -6,7 +6,13 @@ import { withScrollHashBehavior } from '.storybook/decorators/withScrollHashBeha
 
 const meta: Meta<typeof SkipLink> = {
   component: SkipLink,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
+  },
   decorators: [withScrollHashBehavior],
 };
 

--- a/@udir-design/react/src/components/spinner/Spinner.stories.tsx
+++ b/@udir-design/react/src/components/spinner/Spinner.stories.tsx
@@ -3,8 +3,11 @@ import { Spinner } from './Spinner';
 
 const meta: Meta<typeof Spinner> = {
   component: Spinner,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     customStyles: {
       display: 'flex',
       gap: '1rem',

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -18,8 +18,12 @@ import { useDebounceCallback } from '@digdir/designsystemet-react';
 
 const meta: Meta<typeof Suggestion> = {
   component: Suggestion,
-  tags: ['alpha'],
+  tags: ['alpha', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
     customStyles: {
       /* add height by default */

--- a/@udir-design/react/src/components/switch/Switch.stories.tsx
+++ b/@udir-design/react/src/components/switch/Switch.stories.tsx
@@ -8,8 +8,12 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 
 const meta: Meta<typeof Switch> = {
   component: Switch,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -8,8 +8,13 @@ import { Pagination, usePagination } from '@digdir/designsystemet-react';
 
 const meta: Meta<typeof Table> = {
   component: Table,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details:
+        'Vi har lagt til mulighet for bakgrunnsfarge på overskriftsrader og kolonner, samt andre mindre designjusteringer.',
+    },
     customStyles: {
       width: 'fit-content',
       margin: '0 auto',

--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -27,8 +27,11 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 
 const meta: Meta<typeof Tabs> = {
   component: Tabs,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/tag/Tag.stories.tsx
+++ b/@udir-design/react/src/components/tag/Tag.stories.tsx
@@ -6,8 +6,11 @@ import { Avatar } from '../beta';
 
 const meta: Meta<typeof Tag> = {
   component: Tag,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     customStyles: {
       display: 'flex',
       flexDirection: 'row',

--- a/@udir-design/react/src/components/textarea/Textarea.stories.tsx
+++ b/@udir-design/react/src/components/textarea/Textarea.stories.tsx
@@ -6,8 +6,11 @@ import { expect, userEvent, within } from 'storybook/test';
 
 const meta: Meta<typeof Textarea> = {
   component: Textarea,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     layout: 'centered',
     customStyles: {
       display: 'flex',

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -6,7 +6,7 @@ import { Button, Divider, Paragraph } from '@udir-design/react/alpha';
 
 const meta: Meta<typeof Textfield> = {
   component: Textfield,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   argTypes: {
     multiline: {
       type: 'boolean',
@@ -41,6 +41,9 @@ const meta: Meta<typeof Textfield> = {
     },
   },
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -25,8 +25,12 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 
 const meta: Meta<typeof ToggleGroup> = {
   component: ToggleGroup,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+      details: 'Vi har fjernet mulighet for fargevalg.',
+    },
     layout: 'centered',
   },
 };

--- a/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
@@ -12,8 +12,11 @@ import {
 
 const meta: Meta<typeof Tooltip> = {
   component: Tooltip,
-  tags: ['beta'],
+  tags: ['beta', 'digdir'],
   parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
     customStyles: {
       margin: '2rem',
       display: 'flex',

--- a/@udir-design/react/src/components/typography/heading/Heading.stories.tsx
+++ b/@udir-design/react/src/components/typography/heading/Heading.stories.tsx
@@ -3,7 +3,12 @@ import { Heading } from './Heading';
 
 const meta: Meta<typeof Heading> = {
   component: Heading,
-  tags: ['alpha', '!autodocs'],
+  tags: ['alpha', '!autodocs', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
   title: 'Components/Typography/Heading',
 };
 

--- a/@udir-design/react/src/components/typography/label/Label.stories.tsx
+++ b/@udir-design/react/src/components/typography/label/Label.stories.tsx
@@ -3,7 +3,12 @@ import { Label } from './Label';
 
 const meta: Meta<typeof Label> = {
   component: Label,
-  tags: ['alpha', '!autodocs'],
+  tags: ['alpha', '!autodocs', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
   title: 'Components/Typography/Label',
 };
 

--- a/@udir-design/react/src/components/typography/paragraph/Paragraph.stories.tsx
+++ b/@udir-design/react/src/components/typography/paragraph/Paragraph.stories.tsx
@@ -3,7 +3,12 @@ import { Paragraph } from './Paragraph';
 
 const meta: Meta<typeof Paragraph> = {
   component: Paragraph,
-  tags: ['alpha', '!autodocs'],
+  tags: ['alpha', '!autodocs', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
   title: 'Components/Typography/Paragraph',
 };
 

--- a/@udir-design/react/src/components/typography/validationMessage/ValidationMessage.stories.tsx
+++ b/@udir-design/react/src/components/typography/validationMessage/ValidationMessage.stories.tsx
@@ -3,7 +3,12 @@ import { ValidationMessage } from './ValidationMessage';
 
 const meta: Meta<typeof ValidationMessage> = {
   component: ValidationMessage,
-  tags: ['alpha', '!autodocs'],
+  tags: ['alpha', '!autodocs', 'digdir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'digdir',
+    },
+  },
   title: 'Components/Typography/ValidationMessage',
 };
 


### PR DESCRIPTION
## Hva er gjort? 👀 
- Endret design for tags som kommer fra Storybook så de ligner mer på våre egne `Tags`
- Lagt til tags for alle stories -> `digdir` eller `udir` basert på om det er komponenter vi har lånt derfra eller utviklet selv
  - Dette gjør søk/filtrering i storybook lettere  
- Utvidet params i `.stories.tsx`-filer for å gjøre opphavsinfo mer robust, dette vil blant annet si at: 
  - Det bare må endres ett sted `DocsContainer.tsx` om vi vil flytte på plasseringen til `OriginText`
  - Vi kan gjøre informasjonen required for å garantere at det er inkludert på alle sider 

### Til info: 
For å gjøre den enklere å gi review, her er alle unike formuleringer lagt til som `details`: 
- Vi har fjernet muligheten til å endre formen for en mer konsekvent brukeropplevelse på tvers av tjenester. (Om `Avatar`)
- Vi har begrenset fargevalg til semantiske farger og Udirs hovedfarger. (Om `Badge`)
- Vi har begrenset fargevalg til neutral og danger. (Om `Button`)
- Vi har fjernet mulighet for fargevalg. (Om veeeldig mange) 
- Vi har lagt til mulighet for bakgrunnsfarge på overskriftsrader og kolonner, samt andre mindre designjusteringer. (Om `Table`)