### PR TITLE
Fail build if there are .d.ts generation errors + Fix errors for Popover and Table

### DIFF
--- a/@udir-design/react/src/components/popover/Popover.tsx
+++ b/@udir-design/react/src/components/popover/Popover.tsx
@@ -7,7 +7,7 @@ import {
   type PopoverTriggerProps,
 } from '@digdir/designsystemet-react';
 
-const Popover = Object.assign(DigdirPopover, {
+const Popover: typeof DigdirPopover = Object.assign(DigdirPopover, {
   Trigger: DigdirPopover.Trigger,
   TriggerContext: DigdirPopover.TriggerContext,
 });

--- a/@udir-design/react/src/components/table/Table.tsx
+++ b/@udir-design/react/src/components/table/Table.tsx
@@ -2,7 +2,7 @@ import {
   Table as DigdirTable,
   type TableProps as DigdirTableProps,
 } from '@digdir/designsystemet-react';
-import { forwardRef } from 'react';
+import { forwardRef, ForwardRefExoticComponent } from 'react';
 
 export type TableProps = DigdirTableProps & {
   /**
@@ -17,7 +17,10 @@ export type TableProps = DigdirTableProps & {
   tintedRowHeader?: boolean;
 };
 
-export const Table = forwardRef<HTMLTableElement, TableProps>(function Table(
+export const Table: ForwardRefExoticComponent<TableProps> = forwardRef<
+  HTMLTableElement,
+  TableProps
+>(function Table(
   { children, tintedColumnHeader = false, tintedRowHeader = false, ...rest },
   ref,
 ) {

--- a/@udir-design/react/vite.config.ts
+++ b/@udir-design/react/vite.config.ts
@@ -6,6 +6,7 @@ import tsConfigPaths from 'vite-tsconfig-paths';
 import * as path from 'path';
 import pkg from './package.json';
 import * as R from 'ramda';
+import ts from 'typescript';
 
 const resolveAlias = (alias: string): string =>
   path.resolve(import.meta.dirname, alias);
@@ -43,6 +44,16 @@ export default defineConfig({
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      afterDiagnostic: (diagnostics) => {
+        const errors = diagnostics.filter(
+          (x) => x.category === ts.DiagnosticCategory.Error,
+        );
+        if (errors.length > 0) {
+          throw new Error(
+            'Type error during .d.ts generation! See errors above.',
+          );
+        }
+      },
     }),
   ],
 


### PR DESCRIPTION

<img width="1133" height="693" alt="image" src="https://github.com/user-attachments/assets/df905190-16f4-4bb5-8387-4a98d2392bec" />

Disse typescript-feila førte ikkje til byggefeil pga korleis `vite-plugin-dts` funker. Eg la til litt kode for å faktisk feile bygget, med meldinga nederst i skjermbildet, og fiksa feila.