### PR TITLE
test: wait for to avoid unpredictable results 

### DIFF
--- a/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
@@ -53,7 +53,7 @@ export const Preview: Story = {
         expect(tooltip).toBeVisible();
       });
       await userEvent.unhover(trigger);
-      expect(tooltip).not.toBeVisible();
+      await waitFor(() => expect(tooltip).not.toBeVisible());
     });
 
     await step('Focus on the button displays the tooltip', async () => {
@@ -63,7 +63,7 @@ export const Preview: Story = {
         expect(tooltip).toBeVisible();
       });
       await userEvent.tab();
-      expect(tooltip).not.toBeVisible();
+      await waitFor(() => expect(tooltip).not.toBeVisible());
     });
   },
 };


### PR DESCRIPTION
Interaksjonstester for `Tooltip` feilet noen ganger pga timing med f.eks. unhover. Lagt til en `waitFor()` for å komme rundt dette 