### PR TITLE
feat: add alert heading

### DIFF
--- a/@udir-design/react/src/components/alert/Alert.mdx
+++ b/@udir-design/react/src/components/alert/Alert.mdx
@@ -34,7 +34,10 @@ Vi bruker `Alert` til å gi brukeren informasjon som det er ekstra viktig at de 
 ```tsx
 import { Alert } from '@udir-design/react';
 
-<Alert>En beskjed det er viktig at brukeren ser</Alert>;
+<Alert>
+  <Alert.Heading>Overskrift</Alert.Heading>
+  En beskjed det er viktig at brukeren ser
+</Alert>;
 ```
 
 ## Eksempler
@@ -67,7 +70,7 @@ Bruk `danger` for å informere om noe som er kritisk eller som hindrer brukeren 
 
 ### Med og uten overskrift
 
-Hvis meldingen er lenger enn en setning kan det være nyttig å bruke en overskrift til å fremheve det viktigste. Dette kan gjøres ved bruk av [typografi-komponentene](/docs/components-typography--docs). Husk å velge riktig overskriftsnivå ut fra plassen `Alert` har i innholdsstrukturen på siden.
+Hvis meldingen er lenger enn en setning kan det være nyttig å bruke en overskrift til å fremheve det viktigste. Dette kan gjøres ved bruk av subkomponenten `Alert.Heading`. Husk å velge riktig overskriftsnivå ut fra plassen `Alert` har i innholdsstrukturen på siden.
 
 Dersom tittel og beskrivelse gjentar det samme er det bedre å bruke en enkel setning uten overskrift.
 

--- a/@udir-design/react/src/components/alert/Alert.stories.tsx
+++ b/@udir-design/react/src/components/alert/Alert.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
-
 import { Button, Heading, Link, Paragraph } from '@udir-design/react/alpha';
-import { Alert } from './Alert';
+import { Alert } from './';
 import { within, expect } from 'storybook/test';
 import { useState } from 'react';
 import { formatReactSource } from '.storybook/utils/sourceTransformers';
@@ -18,10 +17,14 @@ export default meta;
 export const Preview: Story = {
   args: {
     'data-color': 'info',
-    children: 'En beskjed det er viktig at brukeren ser',
   },
-  render: (args) => <Alert data-testid="alert-preview" {...args} />,
-  play: async ({ canvasElement, args, step }) => {
+  render: (args) => (
+    <Alert data-testid="alert-preview" {...args}>
+      <Alert.Heading level={3}>Overskrift</Alert.Heading>
+      En beskjed det er viktig at brukeren ser
+    </Alert>
+  ),
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const alert = canvas.getByTestId('alert-preview');
     await step('Alert is rendered ', async () => {
@@ -31,7 +34,9 @@ export const Preview: Story = {
       await expect(alert).toHaveAttribute('data-color', 'info');
     });
     await step('Alert has correct text', async () => {
-      await expect(alert).toHaveTextContent(args.children as string);
+      await expect(alert).toHaveTextContent(
+        'En beskjed det er viktig at brukeren ser',
+      );
     });
   },
 };
@@ -39,114 +44,76 @@ export const Preview: Story = {
 export const VariantInfo: Story = {
   args: {
     'data-color': 'info',
-    children: [
-      <Heading
-        level={2}
-        data-size="xs"
-        style={{
-          marginBottom: 'var(--ds-size-2)',
-        }}
-      >
-        Har du husket å melde deg på privatisteksamen?
-      </Heading>,
-      <Paragraph>
-        Du må melde deg på innen 1. februar for våreksamen.
-      </Paragraph>,
-    ],
   },
+  render: (args) => (
+    <Alert {...args}>
+      <Alert.Heading level={2}>
+        Har du husket å melde deg på privatisteksamen?
+      </Alert.Heading>
+      Du må melde deg på innen 1. februar for våreksamen.
+    </Alert>
+  ),
 };
 
 export const VariantSuccess: Story = {
   args: {
     'data-color': 'success',
-    children: [
-      <Heading
-        level={2}
-        data-size="xs"
-        style={{
-          marginBottom: 'var(--ds-size-2)',
-        }}
-      >
-        Du har levert søknaden din!
-      </Heading>,
-      <Paragraph>
-        Vi har mottatt søknaden din, og vil behandle den i løpet av få dager.
-      </Paragraph>,
-    ],
   },
+  render: (args) => (
+    <Alert {...args}>
+      <Alert.Heading level={2}>Du har levert søknaden din!</Alert.Heading>
+      Vi har mottatt søknaden din, og vil behandle den i løpet av få dager.
+    </Alert>
+  ),
 };
 
 export const VariantWarning: Story = {
   args: {
     'data-color': 'warning',
-    children: [
-      <Heading
-        level={2}
-        data-size="xs"
-        style={{
-          marginBottom: 'var(--ds-size-2)',
-        }}
-      >
-        Vi har tekniske problemer
-      </Heading>,
-      <Paragraph>
-        Det gjør at du kan bli avbrutt mens du fyller ut skjemaet. Vi jobber med
-        å rette problemene.
-      </Paragraph>,
-    ],
   },
+  render: (args) => (
+    <Alert {...args}>
+      <Alert.Heading level={2}>Vi har tekniske problemer</Alert.Heading>
+      Det gjør at du kan bli avbrutt mens du fyller ut skjemaet. Vi jobber med å
+      rette problemene.
+    </Alert>
+  ),
 };
 
 export const VariantDanger: Story = {
   args: {
     'data-color': 'danger',
-    children: [
-      <Heading
-        level={2}
-        data-size="xs"
-        style={{
-          marginBottom: 'var(--ds-size-2)',
-        }}
-      >
-        Det har skjedd en feil
-      </Heading>,
-      <Paragraph>
-        Vi klarer ikke å hente informasjonen du ser etter akkurat nå. Prøv igjen
-        litt senere. Hvis vi fortsatt ikke klarer å vise informasjonen du
-        trenger, tar du kontakt med kundeservice på telefon 85 44 32 66.
-      </Paragraph>,
-    ],
   },
+  render: (args) => (
+    <Alert {...args}>
+      <Alert.Heading level={2}>Det har skjedd en feil</Alert.Heading>
+      Vi klarer ikke å hente informasjonen du ser etter akkurat nå. Prøv igjen
+      litt senere. Hvis vi fortsatt ikke klarer å vise informasjonen du trenger,
+      tar du kontakt med kundeservice på telefon 85 44 32 66.
+    </Alert>
+  ),
 };
 
 export const NoHeading: Story = {
   args: {
     'data-color': 'warning',
-    children: [
-      <Paragraph>Du har 7 dager igjen på å fullføre søknaden.</Paragraph>,
-    ],
   },
+  render: (args) => (
+    <Alert {...args}>Du har 7 dager igjen på å fullføre søknaden.</Alert>
+  ),
 };
 
 export const WithLink: Story = {
   args: {
     'data-color': 'warning',
-    children: [
-      <Heading
-        level={2}
-        data-size="xs"
-        style={{
-          marginBottom: 'var(--ds-size-2)',
-        }}
-      >
-        Søknadsfristen går ut om 3 dager
-      </Heading>,
-      <Paragraph>
-        Fristen for å søke opptak til utdanning er 15. april.{' '}
-        <Link href="https://udir.no/">Søk nå</Link>
-      </Paragraph>,
-    ],
   },
+  render: (args) => (
+    <Alert {...args}>
+      <Alert.Heading level={2}>Søknadsfristen går ut om 3 dager</Alert.Heading>
+      Fristen for å søke opptak til utdanning er 15. april.{' '}
+      <Link href="https://udir.no/">Søk nå</Link>
+    </Alert>
+  ),
 };
 
 export const WrongLiveRegion: StoryFn<typeof Alert> = () => {
@@ -159,15 +126,7 @@ export const WrongLiveRegion: StoryFn<typeof Alert> = () => {
           // Feil bruk: role="alert" ligger på selve varselet
           role="alert"
         >
-          <Heading
-            level={2}
-            data-size="xs"
-            style={{
-              marginBottom: 'var(--ds-size-2)',
-            }}
-          >
-            Vi klarer ikke lagre skjemaet
-          </Heading>
+          <Heading level={2}>Vi klarer ikke lagre skjemaet</Heading>
           <Paragraph>
             Vi har mistet forbindelsen med serveren og får ikke lagret skjemaet.
             Vent litt og prøv en gang til.
@@ -211,15 +170,9 @@ export const CorrectLiveRegion: StoryFn<typeof Alert> = () => {
       <div role="alert">
         {showAlert && (
           <Alert data-color="warning">
-            <Heading
-              level={2}
-              data-size="xs"
-              style={{
-                marginBottom: 'var(--ds-size-2)',
-              }}
-            >
+            <Alert.Heading level={2}>
               Vi klarer ikke lagre skjemaet
-            </Heading>
+            </Alert.Heading>
             <Paragraph>
               Vi har mistet forbindelsen med serveren og får ikke lagret
               skjemaet. Vent litt og prøv en gang til.

--- a/@udir-design/react/src/components/alert/AlertHeading.tsx
+++ b/@udir-design/react/src/components/alert/AlertHeading.tsx
@@ -1,0 +1,18 @@
+import { forwardRef } from 'react';
+import { Heading, type HeadingProps } from '../typography';
+
+export type AlertHeadingProps = HeadingProps;
+
+/**
+ * AlertHeading component, used to display a heading in the Alert.
+ *
+ * @example
+ * <Alert>
+ *  <Alert.Heading>Heading</Alert.Heading>
+ * </Alert>
+ */
+export const AlertHeading = forwardRef<HTMLHeadingElement, AlertHeadingProps>(
+  function AlertHeading({ className, ...rest }, ref) {
+    return <Heading ref={ref} data-size="xs" {...rest} />;
+  },
+);

--- a/@udir-design/react/src/components/alert/__snapshots__/Alert.stories.tsx.snap
+++ b/@udir-design/react/src/components/alert/__snapshots__/Alert.stories.tsx.snap
@@ -14,88 +14,64 @@ exports[`Correct Live Region 1`] = `
 
 exports[`No Heading 1`] = `
 <div data-color="warning">
-  <p data-variant="default">
-    Du har 7 dager igjen på å fullføre søknaden.
-  </p>
+  Du har 7 dager igjen på å fullføre søknaden.
 </div>
 `;
 
 exports[`Preview 1`] = `
 <div data-color="info">
+  <h3 data-size="xs">
+    Overskrift
+  </h3>
   En beskjed det er viktig at brukeren ser
 </div>
 `;
 
 exports[`Variant Danger 1`] = `
 <div data-color="danger">
-  <h2
-    data-size="xs"
-    style="margin-bottom: var(--ds-size-2);"
-  >
+  <h2 data-size="xs">
     Det har skjedd en feil
   </h2>
-  <p data-variant="default">
-    Vi klarer ikke å hente informasjonen du ser etter akkurat nå. Prøv igjen litt senere. Hvis vi fortsatt ikke klarer å vise informasjonen du trenger, tar du kontakt med kundeservice på telefon 85 44 32 66.
-  </p>
+  Vi klarer ikke å hente informasjonen du ser etter akkurat nå. Prøv igjen litt senere. Hvis vi fortsatt ikke klarer å vise informasjonen du trenger, tar du kontakt med kundeservice på telefon 85 44 32 66.
 </div>
 `;
 
 exports[`Variant Info 1`] = `
 <div data-color="info">
-  <h2
-    data-size="xs"
-    style="margin-bottom: var(--ds-size-2);"
-  >
+  <h2 data-size="xs">
     Har du husket å melde deg på privatisteksamen?
   </h2>
-  <p data-variant="default">
-    Du må melde deg på innen 1. februar for våreksamen.
-  </p>
+  Du må melde deg på innen 1. februar for våreksamen.
 </div>
 `;
 
 exports[`Variant Success 1`] = `
 <div data-color="success">
-  <h2
-    data-size="xs"
-    style="margin-bottom: var(--ds-size-2);"
-  >
+  <h2 data-size="xs">
     Du har levert søknaden din!
   </h2>
-  <p data-variant="default">
-    Vi har mottatt søknaden din, og vil behandle den i løpet av få dager.
-  </p>
+  Vi har mottatt søknaden din, og vil behandle den i løpet av få dager.
 </div>
 `;
 
 exports[`Variant Warning 1`] = `
 <div data-color="warning">
-  <h2
-    data-size="xs"
-    style="margin-bottom: var(--ds-size-2);"
-  >
+  <h2 data-size="xs">
     Vi har tekniske problemer
   </h2>
-  <p data-variant="default">
-    Det gjør at du kan bli avbrutt mens du fyller ut skjemaet. Vi jobber med å rette problemene.
-  </p>
+  Det gjør at du kan bli avbrutt mens du fyller ut skjemaet. Vi jobber med å rette problemene.
 </div>
 `;
 
 exports[`With Link 1`] = `
 <div data-color="warning">
-  <h2
-    data-size="xs"
-    style="margin-bottom: var(--ds-size-2);"
-  >
+  <h2 data-size="xs">
     Søknadsfristen går ut om 3 dager
   </h2>
-  <p data-variant="default">
-    Fristen for å søke opptak til utdanning er 15. april.
-    <a href="https://udir.no/">
-      Søk nå
-    </a>
-  </p>
+  Fristen for å søke opptak til utdanning er 15. april.
+  <a href="https://udir.no/">
+    Søk nå
+  </a>
 </div>
 `;
 

--- a/@udir-design/react/src/components/alert/alert.css
+++ b/@udir-design/react/src/components/alert/alert.css
@@ -1,0 +1,5 @@
+.ds-alert {
+  :is(h1, h2, h3, h4, h5, h6) {
+    margin-bottom: var(--ds-size-2);
+  }
+}

--- a/@udir-design/react/src/components/alert/index.ts
+++ b/@udir-design/react/src/components/alert/index.ts
@@ -1,0 +1,17 @@
+import { Alert as AlertRoot } from './Alert';
+import { AlertHeading } from './AlertHeading';
+
+type Alert = typeof AlertRoot & {
+  Heading: typeof AlertHeading;
+};
+
+const AlertComponent: Alert = Object.assign(AlertRoot, {
+  Heading: AlertHeading,
+});
+
+AlertComponent.displayName = 'Alert';
+AlertComponent.Heading.displayName = 'Alert.Heading';
+
+export type { AlertProps } from './Alert';
+export type { AlertHeadingProps } from './AlertHeading';
+export { AlertComponent as Alert, AlertHeading };


### PR DESCRIPTION
## Hva er gjort? 👀 
- Egen subkomponent for `Heading` i `Alert` så den blir enklere/raskere å ta i bruk (mer styling out of the box) 

```
<Alert data-color="info">
  <Heading
    level={2}
    data-size="xs"
    style={{
      marginBottom: 'var(--ds-size-2)',
    }}
  >
    Har du husket å bestille passtime?
  </Heading>
  <Paragraph>
    Det er lange køer for å bestille pass om dagen, det kan være lurt å
    bestille i god tid før du skal reise.
  </Paragraph>
</Alert> 
```

blir når 

```
<Alert data-color="info">
  <Alert.Heading level={2}>
    Har du husket å bestille passtime?
  </Alert.Heading>
  <Paragraph>
    Det er lange køer for å bestille pass om dagen, det kan være lurt å
    bestille i god tid før du skal reise.
  </Paragraph>
</Alert> 
```