### PR TITLE
docs: minor changes to introduction and new bottom margin

### DIFF
--- a/@udir-design/react/.storybook/componentOverrides.module.scss
+++ b/@udir-design/react/.storybook/componentOverrides.module.scss
@@ -30,6 +30,16 @@
   visibility: hidden;
 }
 
+.paragraph {
+  margin-bottom: var(--ds-size-6);
+  background-color: transparent;
+
+  &:has(+ ul),
+  &:has(+ ol) {
+    margin-bottom: var(--ds-size-2);
+  }
+}
+
 .code {
   background-color: var(--ds-color-background-tinted);
   font-size: var(--ds-font-size-minus-1);

--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -84,24 +84,20 @@ export const componentOverrides: MdxComponentOverrides = {
   p: (props) => (
     <Paragraph
       {...props}
-      className="sb-unstyled"
-      style={{
-        backgroundColor: 'transparent',
-        marginBottom: 'var(--ds-size-2)',
-      }}
+      className={`sb-unstyled ${componentStyles.paragraph}`}
     />
   ),
   ol: (props) => (
     <List.Ordered
       {...props}
-      style={{ maxWidth: '70ch', marginBottom: 'var(--ds-size-2)' }}
+      style={{ maxWidth: '70ch', marginBottom: 'var(--ds-size-6)' }}
       className="sb-unstyled"
     />
   ),
   ul: (props) => (
     <List.Unordered
       {...props}
-      style={{ maxWidth: '70ch', marginBottom: 'var(--ds-size-2)' }}
+      style={{ maxWidth: '70ch', marginBottom: 'var(--ds-size-6)' }}
       className="sb-unstyled"
     />
   ),

--- a/@udir-design/react/src/Introduksjon.mdx
+++ b/@udir-design/react/src/Introduksjon.mdx
@@ -13,11 +13,9 @@ Udirs designsystem skal bidra til å skape og opprettholde helhetlig design i tr
 - brukervennlige løsninger
 - effektiv utvikling
 
-Systemet er for tiden i beta-versjon. Dette betyr blant annet at komponentene er tilpasset bruk i Udir og at det er skrevet tester for dem. Vi ønsker at systemteamene tar det i bruk og gir oss tilbakemelding både om det som fungerer godt og om noe mangler eller bør endres. Vi trenger tilbakemeldingene for å kunne gjøre endringer før designsystemet lanseres i stabil versjon. Les om [overgang fra betaversjon til stabil versjon](/docs/components-introduksjon--docs#livsfaser-for-en-komponent). Kontakt oss gjerne på [designteamet@udir.no](mailto:designteamet@udir.no) eller i slack-kanalen [#designsystem-udir](https://udir.slack.com/archives/C06G2E50HF0).
+Systemet er for tiden i beta-versjon. Vi ønsker at systemteamene tar det i bruk og gir oss tilbakemelding både om det som fungerer godt og om noe mangler eller bør endres. Vi trenger tilbakemeldingene for å kunne gjøre endringer før designsystemet lanseres i stabil versjon. Les om [overgang fra betaversjon til stabil versjon](/docs/components-introduksjon--docs#livsfaser-for-en-komponent). Kontakt oss gjerne på [designteamet@udir.no](mailto:designteamet@udir.no) eller i slack-kanalen [#designsystem-udir](https://udir.slack.com/archives/C06G2E50HF0).
 
-Designsystemet består av komponentene som ligger her i Storybook og vi har også en oversikt over [kommende komponenter](https://confluence.udir.no/spaces/DESIGN/pages/348980841/Fremtidige+komponenter). I tillegg jobber vi med [mønstre for interaksjon](https://confluence.udir.no/spaces/DESIGN/pages/364578698/Fremtidige+m%C3%B8nstre).
-
-Udirs designsystem tar utgangspunkt i [Digdirs felles designsystem](https://www.designsystemet.no/).
+Designsystemet består av komponentene som ligger her i Storybook og vi har også en oversikt over [kommende komponenter](https://confluence.udir.no/spaces/DESIGN/pages/348980841/Fremtidige+komponenter). I tillegg jobber vi med [mønstre for interaksjon](https://confluence.udir.no/spaces/DESIGN/pages/364578698/Fremtidige+m%C3%B8nstre). Udirs designsystem tar utgangspunkt i [Digdirs felles designsystem](https://www.designsystemet.no/).
 
 <Unstyled>
   <LandingResourceLinks />


### PR DESCRIPTION
## Hva er gjort? 👀 
- Mindre omfurmuleringer i introduksjonsdokumentasjon basert på feedback 
- Endret `marginBottom` for større avstand mellom avsnitt i Storybook 
  - Tok utgangspunkt i retningslinjer fra Figma  

<img width="346" height="353" alt="Screenshot 2025-09-12 at 10 17 06" src="https://github.com/user-attachments/assets/d060c4ff-faf7-4137-83bc-5da5ddef1e81" />
