### PR TITLE
feat: expandable and drilldown table

### DIFF
--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -127,6 +127,21 @@ Det er spesielt nyttig i tabeller med paginering eller annen dynamisk oppdaterin
 
 <Canvas of={TableStories.WithBorder} />
 
+### Table med skjulte/ekspanderbare rader
+
+Du kan bruke `Table` til å vise hierarkiske data med skjulte eller ekspanderbare rader, for eksempel når en overordnet rad kan åpne undernivåer med mer detaljert informasjon.
+Dette kan fungere greit når brukeren først og fremst trenger å sammenligne verdier i en tabell, men også av og til se mer detaljer.
+
+Legg ekspanderingsknappen i radoverskriften, slik at det er tydelig hvilken rad som åpnes eller lukkes.
+Knappen bør kunne brukes med tastatur og ha `aria-expanded`, og teksten bør gjøre det klart hva som skjer når raden åpnes eller skjules.
+Hold strukturen så grunn som mulig, og vær varsom med mange nivåer, siden tabellen fort blir vanskeligere å lese og navigere.
+
+Dette er ikke en perfekt løsning for universell utforming, fordi en vanlig tabell ikke er laget for å uttrykke hierarki og utvidbar struktur.
+For enkle og moderate behov fungerer mønsteret likevel greit, så lenge det testes godt med tastatur og skjermleser.
+Hvis hierarkiet er dypt, eller brukeren må gjøre mange handlinger per rad, bør du vurdere om en annen presentasjonsform er bedre.
+
+<Canvas of={TableStories.TreeStructuredTable} />
+
 ## Retningslinjer
 
 Vi bruker `Table` når vi skal organisere og vise data på en strukturert måte i rader og kolonner for brukerne.
@@ -158,6 +173,8 @@ For å sikre at tabeller fungerer optimalt for alle brukere er det viktig å fø
   Tomme celler skal være `Table.Cell`. Dette er viktig for å sikre at skjermlesere kan navigere riktig i tabellen.
 - **Tastaturnavigering:**
   Sjekk at du kan velge ulik sortering med tastatur. Test med skjermleser at du hører hva som er sorterbart, typer sortering og at du ikke mister fokus når du endrer sortering.
+- **Ekspanderbare rader:**
+  Hvis du bruker skjulte eller ekspanderbare rader, må ekspanderingsknappen være tilgjengelig med tastatur og ha tydelig tilstand med `aria-expanded`. Vær oppmerksom på at dette fortsatt ikke gir en fullverdig hierarkisk tabellsemantikk, så løsningen må vurderes pragmatisk og testes med skjermleser.
 - **Tilpasning for mobil:**
   Det kan være vanskelig å vise tabeller på mobil, siden det ikke finnes et felles design som fungerer i alle sammenhenger.
   De vanligste alternativene for mobil er en tabell som ruller horisontalt eller omgjøring til listevisning.

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -161,12 +161,12 @@ Drilldown er en måte å vise hierarkiske data i en tabell, der brukerne kan utv
 
 #### Struktur
 
-- Sett `aria-level` på hver `<Table.Row>` (1 for toppnivå, 2 for første undernivå osv.). CSS-en beregner innrykk automatisk opp til nivå 5.
+- Sett `data-level` på hver `<Table.Row>` (1 for toppnivå, 2 for første undernivå osv.). CSS-en beregner innrykk automatisk opp til nivå 5.
 - Bruk `<Table.HeaderCell scope="row">` i første kolonne med en `<button aria-expanded>` for rader som har barn.
 - Vis og skjul underrader med betinget rendering.
 
 ```jsx
-<Table.Row aria-level={1}>
+<Table.Row data-level={1}>
   <Table.HeaderCell scope="row">
     <button type="button" aria-expanded={isOpen} onClick={() => toggle(id)}>
       {label}
@@ -177,7 +177,7 @@ Drilldown er en måte å vise hierarkiske data i en tabell, der brukerne kan utv
 {
   isOpen &&
     children.map((child) => (
-      <Table.Row key={child.id} aria-level={2}>
+      <Table.Row key={child.id} data-level={2}>
         <Table.HeaderCell scope="row">{child.label}</Table.HeaderCell>
         <Table.Cell>{child.verdi1}</Table.Cell>
       </Table.Row>

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -127,18 +127,69 @@ Det er spesielt nyttig i tabeller med paginering eller annen dynamisk oppdaterin
 
 <Canvas of={TableStories.WithBorder} />
 
-### Table med skjulte/ekspanderbare rader
+### Ekspanderbare rader
 
-Du kan bruke `Table` til å vise hierarkiske data med skjulte eller ekspanderbare rader, for eksempel når en overordnet rad kan åpne undernivåer med mer detaljert informasjon.
-Dette kan fungere greit når brukeren først og fremst trenger å sammenligne verdier i en tabell, men også av og til se mer detaljer.
+Ekspanderbare rader kan brukes for ekstra informasjon som ikke er nødvendig for å skanne tabellen, men som kan være nyttig for brukerne å ha tilgang til.
 
-Legg ekspanderingsknappen i radoverskriften, slik at det er tydelig hvilken rad som åpnes eller lukkes.
-Knappen bør kunne brukes med tastatur og ha `aria-expanded`, og teksten bør gjøre det klart hva som skjer når raden åpnes eller skjules.
-Hold strukturen så grunn som mulig, og vær varsom med mange nivåer, siden tabellen fort blir vanskeligere å lese og navigere.
+Legg en `<button>` med `aria-expanded` i første celle på raden som skal kunne utvides.
+Rett etter legger du en detaljrad med `hidden`-attributt og en `<Table.Cell colSpan={...}>`.
+CSS-en legger til chevron-ikon og gjør hele cellen klikkbar automatisk.
 
-Dette er ikke en perfekt løsning for universell utforming, fordi en vanlig tabell ikke er laget for å uttrykke hierarki og utvidbar struktur.
-For enkle og moderate behov fungerer mønsteret likevel greit, så lenge det testes godt med tastatur og skjermleser.
-Hvis hierarkiet er dypt, eller brukeren må gjøre mange handlinger per rad, bør du vurdere om en annen presentasjonsform er bedre.
+```jsx
+<Table.Row>
+  <Table.Cell>
+    <button
+      type="button"
+      aria-expanded={expanded}
+      onClick={() => setExpanded(!expanded)}
+    >
+      {navn}
+    </button>
+  </Table.Cell>
+  <Table.Cell>{rolle}</Table.Cell>
+</Table.Row>
+<Table.Row hidden={!expanded}>
+  <Table.Cell colSpan={2}>{detaljer}</Table.Cell>
+</Table.Row>
+```
+
+<Canvas of={TableStories.ExpandableRows} />
+
+### Hierarkiske data (drilldown)
+
+Drilldown er en måte å vise hierarkiske data i en tabell, der brukerne kan utvide og skjule undernivåer av informasjon. Dette kan være nyttig for å organisere og presentere store datamengder på en oversiktlig måte, samtidig som det gir brukerne muligheten til å utforske dataene i dybden.
+
+#### Struktur
+
+- Sett `aria-level` på hver `<Table.Row>` (1 for toppnivå, 2 for første undernivå osv.). CSS-en beregner innrykk automatisk opp til nivå 5.
+- Bruk `<Table.HeaderCell scope="row">` i første kolonne med en `<button aria-expanded>` for rader som har barn.
+- Vis og skjul underrader med betinget rendering.
+
+```jsx
+<Table.Row aria-level={1}>
+  <Table.HeaderCell scope="row">
+    <button type="button" aria-expanded={isOpen} onClick={() => toggle(id)}>
+      {label}
+    </button>
+  </Table.HeaderCell>
+  <Table.Cell>{verdi1}</Table.Cell>
+</Table.Row>;
+{
+  isOpen &&
+    children.map((child) => (
+      <Table.Row key={child.id} aria-level={2}>
+        <Table.HeaderCell scope="row">{child.label}</Table.HeaderCell>
+        <Table.Cell>{child.verdi1}</Table.Cell>
+      </Table.Row>
+    ));
+}
+```
+
+#### Begrensninger
+
+Vanlige HTML-tabeller er ikke laget for å uttrykke hierarki.
+Hold strukturen grunn og test med tastatur og skjermleser.
+Hvis hierarkiet er dypt, vurder om en annen presentasjonsform passer bedre.
 
 <Canvas of={TableStories.TreeStructuredTable} />
 
@@ -173,8 +224,6 @@ For å sikre at tabeller fungerer optimalt for alle brukere er det viktig å fø
   Tomme celler skal være `Table.Cell`. Dette er viktig for å sikre at skjermlesere kan navigere riktig i tabellen.
 - **Tastaturnavigering:**
   Sjekk at du kan velge ulik sortering med tastatur. Test med skjermleser at du hører hva som er sorterbart, typer sortering og at du ikke mister fokus når du endrer sortering.
-- **Ekspanderbare rader:**
-  Hvis du bruker skjulte eller ekspanderbare rader, må ekspanderingsknappen være tilgjengelig med tastatur og ha tydelig tilstand med `aria-expanded`. Vær oppmerksom på at dette fortsatt ikke gir en fullverdig hierarkisk tabellsemantikk, så løsningen må vurderes pragmatisk og testes med skjermleser.
 - **Tilpasning for mobil:**
   Det kan være vanskelig å vise tabeller på mobil, siden det ikke finnes et felles design som fungerer i alle sammenhenger.
   De vanligste alternativene for mobil er en tabell som ruller horisontalt eller omgjøring til listevisning.

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -1,6 +1,7 @@
 import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 
 import * as TableStories from './Table.stories';
+import * as useDrilldownTableStories from '../../utilities/hooks/useDrilldownTable/useDrilldownTable.stories';
 
 <Meta of={TableStories} />
 
@@ -126,6 +127,84 @@ Det er spesielt nyttig i tabeller med paginering eller annen dynamisk oppdaterin
 ### Med border
 
 <Canvas of={TableStories.WithBorder} />
+
+### Ekspanderbare rader
+
+Ekspanderbare rader kan brukes for ekstra informasjon som ikke er nødvendig for å skanne tabellen, men som kan være nyttig for brukerne å ha tilgang til.
+
+Legg en `<button>` med `aria-expanded` i første celle på raden som skal kunne utvides.
+Rett etter legger du en detaljrad med `hidden`-attributt og en `<Table.Cell colSpan={...}>`.
+CSS-en legger til chevron-ikon og gjør hele cellen klikkbar automatisk.
+
+```jsx
+<Table.Row>
+  <Table.Cell>
+    <button
+      type="button"
+      aria-expanded={expanded}
+      onClick={() => setExpanded(!expanded)}
+    >
+      {navn}
+    </button>
+  </Table.Cell>
+  <Table.Cell>{rolle}</Table.Cell>
+</Table.Row>
+<Table.Row hidden={!expanded}>
+  <Table.Cell colSpan={2}>{detaljer}</Table.Cell>
+</Table.Row>
+```
+
+<Canvas of={TableStories.ExpandableRows} />
+
+### Hierarkiske data (drilldown)
+
+Drilldown er en måte å vise hierarkiske data i en tabell, der brukerne kan utvide og skjule undernivåer av informasjon. Dette kan være nyttig for å organisere og presentere store datamengder på en oversiktlig måte, samtidig som det gir brukerne muligheten til å utforske dataene i dybden.
+
+Vi bruker [hooken `useDrilldownTable`](/docs/utilities-usedrilldowntable--docs) for å automatisk legge til skjermleserstøtte for hierarkiske data.
+
+#### Struktur
+
+- Bruk `useDrilldownTable(tbodyRef)` på `<Table.Body>`. Hooken sørger for at skjermlesere annonserer hvilket nivå raden befinner seg på.
+- Sett `data-level` på hver `<Table.Row>` (1 for toppnivå, 2 for første undernivå osv.). CSS-en beregner innrykk automatisk opp til nivå 5.
+- Bruk `<Table.HeaderCell scope="row">` i første kolonne.
+  - Dersom raden kan ekspanderes må denne cellen inneholde en knapp med `aria-expanded`.
+  - Dersom raden er dypeste nivå legges teksten direkte i cellen.
+- Vis og skjul underrader med betinget rendering.
+
+Et forenklet eksempel:
+
+```jsx
+const tbodyRef = useRef(null);
+useDrilldownTable(tbodyRef); // legger til skjermleserstøtte for nivå
+
+// ...
+
+<Table.Body ref={tbodyRef}>
+  <Table.Row id={id} data-level={depth}>
+    <Table.HeaderCell scope="row">
+      <button type="button" aria-expanded={isOpen} onClick={() => toggle(id)}>
+        {label}
+      </button>
+    </Table.HeaderCell>
+    <Table.Cell>{verdi1}</Table.Cell>
+  </Table.Row>
+  {isOpen &&
+    children.map((child) => (
+      <Table.Row key={child.id} id={child.id} data-level={depth + 1}>
+        <Table.HeaderCell scope="row">{child.label}</Table.HeaderCell>
+        <Table.Cell>{child.verdi1}</Table.Cell>
+      </Table.Row>
+    ))}
+</Table.Body>;
+```
+
+#### Begrensninger
+
+Vanlige HTML-tabeller er ikke laget for å uttrykke hierarki.
+Hold strukturen grunn og test med tastatur og skjermleser.
+Hvis hierarkiet er dypt, vurder om en annen presentasjonsform passer bedre.
+
+<Canvas of={useDrilldownTableStories.Preview} />
 
 ## Retningslinjer
 

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -1,7 +1,7 @@
 import { Pagination, usePagination } from '@digdir/designsystemet-react';
+import type React from 'react';
 import { useMemo, useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
-import { ChevronDownIcon, ChevronRightIcon } from '@udir-design/icons';
 import preview from '.storybook/preview';
 import { useCheckboxGroup } from 'src/utilities/hooks/useCheckboxGroup/useCheckboxGroup';
 import { Checkbox } from '../checkbox/Checkbox';
@@ -835,82 +835,147 @@ export const WithBorder = meta.story({
   },
 });
 
-type Node = {
+const expandableData = [
+  {
+    id: 1,
+    navn: 'Rita Nordmann',
+    rolle: 'Rektor',
+    epost: 'rita@nordmann.no',
+    detaljer:
+      'Rita har vært rektor i 12 år og har ansvar for 45 ansatte. Hun leder skolens pedagogiske utviklingsarbeid.',
+  },
+  {
+    id: 2,
+    navn: 'Kari Nordmann',
+    rolle: 'Lektor',
+    epost: 'kari@nordmann.no',
+    detaljer:
+      'Kari underviser i norsk og samfunnsfag for 8.–10. trinn. Hun er også kontaktlærer for 9A.',
+  },
+  {
+    id: 3,
+    navn: 'Ola Nordmann',
+    rolle: 'Lektor',
+    epost: 'ola@nordmann.no',
+    detaljer:
+      'Ola underviser i matematikk og naturfag. Han er ansvarlig for skolens realfagssatsing.',
+  },
+];
+
+export const ExpandableRows = meta.story({
+  render: (args) => (
+    <Table {...args} style={{ tableLayout: 'fixed', width: '600px' }}>
+      <Table.Head>
+        <Table.Row>
+          <Table.HeaderCell>Navn</Table.HeaderCell>
+          <Table.HeaderCell>Rolle</Table.HeaderCell>
+          <Table.HeaderCell>Epost</Table.HeaderCell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {expandableData.map((row) => (
+          <ExpandableTableRow key={row.id} row={row} />
+        ))}
+      </Table.Body>
+    </Table>
+  ),
+  async play({ canvasElement, step }) {
+    const canvas = within(canvasElement);
+
+    await step('Detail row is hidden when collapsed', () => {
+      const button = canvas.getAllByRole('button')[0];
+      expect(button).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    await step('Detail row is shown when expanded', async () => {
+      const button = canvas.getAllByRole('button')[0];
+      await userEvent.click(button);
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+  },
+});
+
+function ExpandableTableRow({ row }: { row: (typeof expandableData)[number] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      <Table.Row>
+        <Table.Cell>
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {row.navn}
+          </button>
+        </Table.Cell>
+        <Table.Cell>{row.rolle}</Table.Cell>
+        <Table.Cell>{row.epost}</Table.Cell>
+      </Table.Row>
+      <Table.Row hidden={!expanded}>
+        <Table.Cell colSpan={3}>{row.detaljer}</Table.Cell>
+      </Table.Row>
+    </>
+  );
+}
+
+type TreeNode = {
   id: string;
   label: string;
   values: React.ReactNode[];
-  children?: Node[];
+  children?: TreeNode[];
 };
 
-const caption = 'Svarprosent for elevundersøkelsen nasjonalt';
-const rowHeaderLabel = 'Elevgruppe';
-const columns = ['2022–23', '2023–24', '2024–25'];
+/* ─── Nasjonale prøver – tree table ─── */
 
-const data: Node[] = [
-  {
-    id: '8trinn',
-    label: '8. trinn',
-    values: ['88,5%', '86,3%', '85,3%'],
-    children: [
-      {
-        id: '8trinn-oslo',
-        label: 'Fra Oslo',
-        values: ['30,5%', '1,3%', '23,3%'],
-        children: [
-          {
-            id: '8trinn-oslo-sentrum',
-            label: 'Sentrum',
-            values: ['15,1%', '0,7%', '11,0%'],
-          },
-          {
-            id: '8trinn-oslo-ost',
-            label: 'Øst',
-            values: ['15,4%', '0,6%', '12,3%'],
-          },
+type NpNode = [label: string, values: string[], children?: NpNode[]];
+
+const toTree = (nodes: NpNode[], prefix = 'np'): TreeNode[] =>
+  nodes.map(([label, values, children]) => {
+    const id = `${prefix}-${label.toLowerCase().replace(/[^a-zæøå0-9]/g, '')}`;
+    return {
+      id,
+      label,
+      values,
+      ...(children && { children: toTree(children, id) }),
+    };
+  });
+
+const nasjonalePrøverData = toTree([
+  [
+    'Nasjonalt',
+    ['50', '50', '50'],
+    [
+      ['Akershus', ['52', '52', '53'], [['…', ['…', '…', '…']]]],
+      [
+        'Oslo',
+        ['53', '52', '54'],
+        [
+          ['Frogner', ['55', '53', '56'], [['…', ['…', '…', '…']]]],
+          [
+            'Gamle Oslo',
+            ['52', '50', '52'],
+            [
+              ['Gamlebyen skole', ['51', '49', '51']],
+              ['Kampen skole', ['54', '52', '55']],
+              ['Tøyen skole', ['53', '51', '53']],
+              ['Vahl skole', ['52', '50', '52']],
+            ],
+          ],
+          ['Grünerløkka', ['54', '52', '55'], [['…', ['…', '…', '…']]]],
+          ['Nordre Aker', ['53', '52', '54'], [['…', ['…', '…', '…']]]],
+          ['St. Hanshaugen', ['54', '53', '55'], [['…', ['…', '…', '…']]]],
+          ['Søndre Nordstrand', ['50', '48', '50'], [['…', ['…', '…', '…']]]],
         ],
-      },
-      {
-        id: '8trinn-drobak',
-        label: 'Fra Drøbak',
-        values: ['28,5%', '0,9%', '20,3%'],
-      },
+      ],
+      ['Rogaland', ['50', '51', '51'], [['…', ['…', '…', '…']]]],
+      ['Trøndelag', ['50', '51', '50'], [['…', ['…', '…', '…']]]],
+      ['Vestland', ['51', '51', '50'], [['…', ['…', '…', '…']]]],
+      ['…', ['…', '…', '…']],
     ],
-  },
-  {
-    id: '9trinn',
-    label: '9. trinn',
-    values: ['88,7%', '86,3%', '84,9%'],
-    children: [
-      {
-        id: '9trinn-oslo',
-        label: 'Fra Oslo',
-        values: ['31,5%', '1,0%', '24,3%'],
-      },
-      {
-        id: '9trinn-drobak',
-        label: 'Fra Drøbak',
-        values: ['27,5%', '0,8%', '19,3%'],
-      },
-    ],
-  },
-  {
-    id: '10trinn',
-    label: '10. trinn',
-    values: ['89,7%', '87,3%', '85,7%'],
-    children: [
-      {
-        id: '10trinn-oslo',
-        label: 'Fra Oslo',
-        values: ['32,5%', '1,1%', '25,3%'],
-      },
-      {
-        id: '10trinn-drobak',
-        label: 'Fra Drøbak',
-        values: ['29,5%', '0,9%', '21,3%'],
-      },
-    ],
-  },
-];
+  ],
+]);
 
 export const TreeStructuredTable = meta.story({
   args: {
@@ -920,7 +985,13 @@ export const TreeStructuredTable = meta.story({
     'data-color': 'support1',
   },
   render: (args) => {
-    const [open, setOpen] = useState<Set<string>>(new Set());
+    const [open, setOpen] = useState<Set<string>>(
+      new Set([
+        'np-nasjonalt',
+        'np-nasjonalt-oslo',
+        'np-nasjonalt-oslo-gamleoslo',
+      ]),
+    );
 
     const toggle = (id: string) => {
       setOpen((prev) => {
@@ -931,56 +1002,36 @@ export const TreeStructuredTable = meta.story({
     };
 
     const rows = useMemo(() => {
-      const renderRows = (node: Node, depth = 0): React.ReactNode[] => {
+      const renderRows = (node: TreeNode, depth = 0): React.ReactNode[] => {
         const isOpen = open.has(node.id);
         const children = node.children ?? [];
         const hasChildren = children.length > 0;
 
-        const labelContent = (
-          <span
-            className="treeStructuredTable-label"
-            style={{ '--tree-depth': depth } as React.CSSProperties}
-          >
-            <span className="treeStructuredTable-icon" aria-hidden="true">
-              {hasChildren ? (
-                isOpen ? (
-                  <ChevronDownIcon />
-                ) : (
-                  <ChevronRightIcon />
-                )
-              ) : null}
-            </span>
-            <span>{node.label}</span>
-          </span>
-        );
-
         const currentRow = (
-          <Table.Row key={node.id} data-testid={`tree-row-${node.id}`}>
+          <Table.Row
+            key={node.id}
+            data-testid={`row-${node.id}`}
+            aria-level={depth + 1}
+          >
             <Table.HeaderCell scope="row">
               {hasChildren ? (
                 <button
                   type="button"
                   onClick={() => toggle(node.id)}
                   aria-expanded={isOpen}
-                  aria-label={
-                    isOpen
-                      ? `Skjul undernivå for ${node.label}`
-                      : `Vis undernivå for ${node.label}`
-                  }
-                  data-testid={`tree-toggle-${node.id}`}
-                  className="treeStructuredTable-button"
+                  data-testid={`toggle-${node.id}`}
                 >
-                  {labelContent}
+                  {node.label}
                 </button>
               ) : (
-                labelContent
+                node.label
               )}
             </Table.HeaderCell>
 
             {node.values.map((value, index) => (
               <Table.Cell
                 key={`${node.id}-c${index}`}
-                className="treeStructuredTable-valueCell"
+                style={{ textAlign: 'right' }}
               >
                 {value}
               </Table.Cell>
@@ -998,128 +1049,82 @@ export const TreeStructuredTable = meta.story({
         ];
       };
 
-      return data.flatMap((node) => renderRows(node));
+      return nasjonalePrøverData.flatMap((node) => renderRows(node));
     }, [open]);
 
     return (
-      <>
-        <style>
-          {`
-            /* Styles defined in application-specific css */
-            .treeStructuredTable-caption {
-              font-size: var(--ds-font-size-3);
-              caption-side: bottom;
-              text-align: center;
-              font-weight: normal;
-              margin-top: var(--ds-size-2);
-            }
+      <Table
+        {...args}
+        style={{
+          tableLayout: 'fixed',
+          width: '550px',
+        }}
+      >
+        <caption
+          style={{
+            fontSize: 'var(--ds-font-size-3)',
+            captionSide: 'bottom',
+            textAlign: 'center',
+            fontWeight: 'normal',
+            marginTop: 'var(--ds-size-2)',
+          }}
+        >
+          Nasjonale prøver 5. trinn – skoleåret 2024–25, snitt skalapoeng
+        </caption>
 
-            .treeStructuredTable-valueCell {
-              text-align: right;
-            }
+        <Table.Head>
+          <Table.Row>
+            <Table.HeaderCell scope="col">Område</Table.HeaderCell>
+            <Table.HeaderCell scope="col" style={{ width: '4rem' }}>
+              Lesing
+            </Table.HeaderCell>
+            <Table.HeaderCell scope="col" style={{ width: '4rem' }}>
+              Regning
+            </Table.HeaderCell>
+            <Table.HeaderCell scope="col" style={{ width: '4rem' }}>
+              Engelsk
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Head>
 
-            .treeStructuredTable-button {
-              background: none;
-              border: 0;
-              margin: 0;
-              padding: 0;
-              font: inherit;
-              color: inherit;
-              cursor: pointer;
-            }
-
-            .treeStructuredTable-label {
-              display: grid;
-              grid-template-columns: var(--ds-size-5) auto;
-              align-items: center;
-              column-gap: 0.5rem;
-              padding-inline-start: calc(var(--ds-size-3) * var(--tree-depth));
-            }
-
-            .treeStructuredTable-icon {
-              display: inline-flex;
-              align-items: center;
-              justify-content: center;
-              width: var(--ds-size-5);
-            }
-          `}
-        </style>
-
-        <Table {...args}>
-          <caption className="treeStructuredTable-caption">{caption}</caption>
-
-          <Table.Head>
-            <Table.Row>
-              <Table.HeaderCell
-                scope="col"
-                className="treeStructuredTable-rowHeader"
-              >
-                {rowHeaderLabel}
-              </Table.HeaderCell>
-
-              {columns.map((column) => (
-                <Table.HeaderCell key={column} scope="col">
-                  {column}
-                </Table.HeaderCell>
-              ))}
-            </Table.Row>
-          </Table.Head>
-
-          <Table.Body>{rows}</Table.Body>
-        </Table>
-      </>
+        <Table.Body>{rows}</Table.Body>
+      </Table>
     );
   },
   async play({ canvasElement, step }) {
     const canvas = within(canvasElement);
 
-    await step(
-      'Expandable rows expose clear button names and collapsed state',
-      async () => {
-        const topLevelToggle = canvas.getByTestId('tree-toggle-8trinn');
-
-        expect(topLevelToggle).toHaveAccessibleName(
-          'Vis undernivå for 8. trinn',
-        );
-        expect(topLevelToggle).toHaveAttribute('aria-expanded', 'false');
-        expect(
-          canvas.queryByTestId('tree-row-8trinn-oslo'),
-        ).not.toBeInTheDocument();
-      },
-    );
-
-    await step('Top-level row can be expanded with keyboard', async () => {
-      await userEvent.tab();
-
-      const topLevelToggle = canvas.getByTestId('tree-toggle-8trinn');
-      expect(topLevelToggle).toHaveFocus();
-
-      await userEvent.keyboard(' ');
-
-      expect(topLevelToggle).toHaveAttribute('aria-expanded', 'true');
-      expect(topLevelToggle).toHaveAccessibleName(
-        'Skjul undernivå for 8. trinn',
+    await step('Nasjonalt, Oslo and Gamle Oslo are expanded by default', () => {
+      expect(canvas.getByTestId('toggle-np-nasjonalt')).toHaveAttribute(
+        'aria-expanded',
+        'true',
       );
-      expect(canvas.getByTestId('tree-row-8trinn-oslo')).toBeInTheDocument();
-      expect(canvas.getByTestId('tree-row-8trinn-drobak')).toBeInTheDocument();
+      expect(canvas.getByTestId('toggle-np-nasjonalt-oslo')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      );
+      expect(
+        canvas.getByTestId('toggle-np-nasjonalt-oslo-gamleoslo'),
+      ).toHaveAttribute('aria-expanded', 'true');
+      expect(
+        canvas.getByTestId('row-np-nasjonalt-oslo-gamleoslo-tøyenskole'),
+      ).toBeInTheDocument();
+      expect(
+        canvas.getByTestId('row-np-nasjonalt-oslo-gamleoslo-kampenskole'),
+      ).toBeInTheDocument();
     });
 
-    await step('Nested row can be expanded with keyboard', async () => {
-      await userEvent.tab();
+    await step('Collapsing Gamle Oslo hides schools', async () => {
+      await userEvent.click(
+        canvas.getByTestId('toggle-np-nasjonalt-oslo-gamleoslo'),
+      );
 
-      const nestedToggle = canvas.getByTestId('tree-toggle-8trinn-oslo');
-      expect(nestedToggle).toHaveFocus();
-      expect(nestedToggle).toHaveAccessibleName('Vis undernivå for Fra Oslo');
-
-      await userEvent.keyboard('{Enter}');
-
-      expect(nestedToggle).toHaveAttribute('aria-expanded', 'true');
       expect(
-        canvas.getByTestId('tree-row-8trinn-oslo-sentrum'),
-      ).toBeInTheDocument();
+        canvas.getByTestId('toggle-np-nasjonalt-oslo-gamleoslo'),
+      ).toHaveAttribute('aria-expanded', 'false');
       expect(
-        canvas.getByTestId('tree-row-8trinn-oslo-ost'),
-      ).toBeInTheDocument();
+        canvas.queryByTestId('row-np-nasjonalt-oslo-gamleoslo-tøyenskole'),
+      ).not.toBeInTheDocument();
     });
   },
 });

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -1,6 +1,6 @@
 import { Pagination, usePagination } from '@digdir/designsystemet-react';
-import { useCallback, useMemo, useState } from 'react';
-import { expect, within } from 'storybook/test';
+import { useMemo, useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 import { ChevronDownIcon, ChevronRightIcon } from '@udir-design/icons';
 import preview from '.storybook/preview';
 import { useCheckboxGroup } from 'src/utilities/hooks/useCheckboxGroup/useCheckboxGroup';
@@ -837,121 +837,13 @@ export const WithBorder = meta.story({
 
 type Node = {
   id: string;
-  label: string; // e.g. "8. trinn", "Fra Oslo"
-  values: React.ReactNode[]; // per-column values (excluding the row header cell)
+  label: string;
+  values: React.ReactNode[];
   children?: Node[];
 };
 
-type TreeTableProps = {
-  columns: string[]; // headers for the non-header columns
-  data: Node[]; // tree data
-};
-
-export function TreeTable({ columns, data, ...args }: TreeTableProps) {
-  const [open, setOpen] = useState<Set<string>>(new Set());
-
-  const toggle = useCallback(
-    (id: string) =>
-      setOpen((prev) => {
-        const next = new Set(prev);
-        next.has(id) ? next.delete(id) : next.add(id);
-        return next;
-      }),
-    [],
-  );
-
-  const rows = useMemo(() => {
-    const renderRows = (node: Node, depth = 0): React.ReactNode => {
-      const isOpen = open.has(node.id);
-      const hasChildren = !!node.children?.length;
-
-      return (
-        <>
-          <Table.Row key={node.id}>
-            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
-              {hasChildren ? (
-                <button
-                  type="button"
-                  onClick={() => hasChildren && toggle(node.id)}
-                  aria-expanded={hasChildren ? isOpen : undefined}
-                  aria-controls={
-                    hasChildren ? `rowgroup-${node.id}` : undefined
-                  }
-                  style={{
-                    all: 'unset',
-                    cursor: hasChildren ? 'pointer' : 'default',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: '0.5rem',
-                    paddingLeft: `calc(var(--ds-size-3) * ${depth})`,
-                  }}
-                >
-                  {isOpen ? (
-                    <ChevronDownIcon aria-hidden />
-                  ) : (
-                    <ChevronRightIcon aria-hidden />
-                  )}
-                  {node.label}
-                </button>
-              ) : (
-                <span
-                  style={{ paddingLeft: `calc(var(--ds-size-7) * ${depth})` }}
-                >
-                  {node.label}
-                </span>
-              )}
-            </Table.HeaderCell>
-
-            {node.values.map((v, i) => (
-              <Table.Cell
-                key={`${node.id}-c${i}`}
-                style={{ textAlign: 'right' }}
-              >
-                {v}
-              </Table.Cell>
-            ))}
-          </Table.Row>
-
-          {hasChildren && isOpen && node.children && (
-            <>{node.children.map((child) => renderRows(child, depth + 1))}</>
-          )}
-        </>
-      );
-    };
-
-    return data?.map((node) => renderRows(node)) || [];
-  }, [data, open, toggle]);
-
-  return (
-    <Table data-color="accent" {...args}>
-      <caption
-        style={{
-          fontSize: 'var(--ds-font-size-3)',
-          captionSide: 'bottom',
-          textAlign: 'center',
-          fontWeight: 'normal',
-          marginTop: 'var(--ds-size-2)',
-        }}
-      >
-        Svarprosent for elevundersøkelsen nasjonalt
-      </caption>
-
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell />
-          {columns?.map((c, i) => (
-            <Table.HeaderCell key={i} scope="col">
-              {c}
-            </Table.HeaderCell>
-          ))}
-        </Table.Row>
-      </Table.Head>
-
-      <Table.Body style={{ textAlign: 'right' }}>{rows}</Table.Body>
-    </Table>
-  );
-}
-
+const caption = 'Svarprosent for elevundersøkelsen nasjonalt';
+const rowHeaderLabel = 'Elevgruppe';
 const columns = ['2022–23', '2023–24', '2024–25'];
 
 const data: Node[] = [
@@ -971,11 +863,16 @@ const data: Node[] = [
             values: ['15,1%', '0,7%', '11,0%'],
           },
           {
-            id: '8trinn-oslo-øst',
+            id: '8trinn-oslo-ost',
             label: 'Øst',
             values: ['15,4%', '0,6%', '12,3%'],
           },
         ],
+      },
+      {
+        id: '8trinn-drobak',
+        label: 'Fra Drøbak',
+        values: ['28,5%', '0,9%', '20,3%'],
       },
     ],
   },
@@ -983,6 +880,35 @@ const data: Node[] = [
     id: '9trinn',
     label: '9. trinn',
     values: ['88,7%', '86,3%', '84,9%'],
+    children: [
+      {
+        id: '9trinn-oslo',
+        label: 'Fra Oslo',
+        values: ['31,5%', '1,0%', '24,3%'],
+      },
+      {
+        id: '9trinn-drobak',
+        label: 'Fra Drøbak',
+        values: ['27,5%', '0,8%', '19,3%'],
+      },
+    ],
+  },
+  {
+    id: '10trinn',
+    label: '10. trinn',
+    values: ['89,7%', '87,3%', '85,7%'],
+    children: [
+      {
+        id: '10trinn-oslo',
+        label: 'Fra Oslo',
+        values: ['32,5%', '1,1%', '25,3%'],
+      },
+      {
+        id: '10trinn-drobak',
+        label: 'Fra Drøbak',
+        values: ['29,5%', '0,9%', '21,3%'],
+      },
+    ],
   },
 ];
 
@@ -993,5 +919,207 @@ export const TreeStructuredTable = meta.story({
     tintedRowHeader: true,
     'data-color': 'support1',
   },
-  render: (args) => <TreeTable columns={columns} data={data} {...args} />,
+  render: (args) => {
+    const [open, setOpen] = useState<Set<string>>(new Set());
+
+    const toggle = (id: string) => {
+      setOpen((prev) => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      });
+    };
+
+    const rows = useMemo(() => {
+      const renderRows = (node: Node, depth = 0): React.ReactNode[] => {
+        const isOpen = open.has(node.id);
+        const children = node.children ?? [];
+        const hasChildren = children.length > 0;
+
+        const labelContent = (
+          <span
+            className="treeStructuredTable-label"
+            style={{ '--tree-depth': depth } as React.CSSProperties}
+          >
+            <span className="treeStructuredTable-icon" aria-hidden="true">
+              {hasChildren ? (
+                isOpen ? (
+                  <ChevronDownIcon />
+                ) : (
+                  <ChevronRightIcon />
+                )
+              ) : null}
+            </span>
+            <span>{node.label}</span>
+          </span>
+        );
+
+        const currentRow = (
+          <Table.Row key={node.id} data-testid={`tree-row-${node.id}`}>
+            <Table.HeaderCell scope="row">
+              {hasChildren ? (
+                <button
+                  type="button"
+                  onClick={() => toggle(node.id)}
+                  aria-expanded={isOpen}
+                  aria-label={
+                    isOpen
+                      ? `Skjul undernivå for ${node.label}`
+                      : `Vis undernivå for ${node.label}`
+                  }
+                  data-testid={`tree-toggle-${node.id}`}
+                  className="treeStructuredTable-button"
+                >
+                  {labelContent}
+                </button>
+              ) : (
+                labelContent
+              )}
+            </Table.HeaderCell>
+
+            {node.values.map((value, index) => (
+              <Table.Cell
+                key={`${node.id}-c${index}`}
+                className="treeStructuredTable-valueCell"
+              >
+                {value}
+              </Table.Cell>
+            ))}
+          </Table.Row>
+        );
+
+        if (!hasChildren || !isOpen) {
+          return [currentRow];
+        }
+
+        return [
+          currentRow,
+          ...children.flatMap((child) => renderRows(child, depth + 1)),
+        ];
+      };
+
+      return data.flatMap((node) => renderRows(node));
+    }, [open]);
+
+    return (
+      <>
+        <style>
+          {`
+            /* Styles defined in application-specific css */
+            .treeStructuredTable-caption {
+              font-size: var(--ds-font-size-3);
+              caption-side: bottom;
+              text-align: center;
+              font-weight: normal;
+              margin-top: var(--ds-size-2);
+            }
+
+            .treeStructuredTable-valueCell {
+              text-align: right;
+            }
+
+            .treeStructuredTable-button {
+              background: none;
+              border: 0;
+              margin: 0;
+              padding: 0;
+              font: inherit;
+              color: inherit;
+              cursor: pointer;
+            }
+
+            .treeStructuredTable-label {
+              display: grid;
+              grid-template-columns: var(--ds-size-5) auto;
+              align-items: center;
+              column-gap: 0.5rem;
+              padding-inline-start: calc(var(--ds-size-3) * var(--tree-depth));
+            }
+
+            .treeStructuredTable-icon {
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              width: var(--ds-size-5);
+            }
+          `}
+        </style>
+
+        <Table {...args}>
+          <caption className="treeStructuredTable-caption">{caption}</caption>
+
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell
+                scope="col"
+                className="treeStructuredTable-rowHeader"
+              >
+                {rowHeaderLabel}
+              </Table.HeaderCell>
+
+              {columns.map((column) => (
+                <Table.HeaderCell key={column} scope="col">
+                  {column}
+                </Table.HeaderCell>
+              ))}
+            </Table.Row>
+          </Table.Head>
+
+          <Table.Body>{rows}</Table.Body>
+        </Table>
+      </>
+    );
+  },
+  async play({ canvasElement, step }) {
+    const canvas = within(canvasElement);
+
+    await step(
+      'Expandable rows expose clear button names and collapsed state',
+      async () => {
+        const topLevelToggle = canvas.getByTestId('tree-toggle-8trinn');
+
+        expect(topLevelToggle).toHaveAccessibleName(
+          'Vis undernivå for 8. trinn',
+        );
+        expect(topLevelToggle).toHaveAttribute('aria-expanded', 'false');
+        expect(
+          canvas.queryByTestId('tree-row-8trinn-oslo'),
+        ).not.toBeInTheDocument();
+      },
+    );
+
+    await step('Top-level row can be expanded with keyboard', async () => {
+      await userEvent.tab();
+
+      const topLevelToggle = canvas.getByTestId('tree-toggle-8trinn');
+      expect(topLevelToggle).toHaveFocus();
+
+      await userEvent.keyboard(' ');
+
+      expect(topLevelToggle).toHaveAttribute('aria-expanded', 'true');
+      expect(topLevelToggle).toHaveAccessibleName(
+        'Skjul undernivå for 8. trinn',
+      );
+      expect(canvas.getByTestId('tree-row-8trinn-oslo')).toBeInTheDocument();
+      expect(canvas.getByTestId('tree-row-8trinn-drobak')).toBeInTheDocument();
+    });
+
+    await step('Nested row can be expanded with keyboard', async () => {
+      await userEvent.tab();
+
+      const nestedToggle = canvas.getByTestId('tree-toggle-8trinn-oslo');
+      expect(nestedToggle).toHaveFocus();
+      expect(nestedToggle).toHaveAccessibleName('Vis undernivå for Fra Oslo');
+
+      await userEvent.keyboard('{Enter}');
+
+      expect(nestedToggle).toHaveAttribute('aria-expanded', 'true');
+      expect(
+        canvas.getByTestId('tree-row-8trinn-oslo-sentrum'),
+      ).toBeInTheDocument();
+      expect(
+        canvas.getByTestId('tree-row-8trinn-oslo-ost'),
+      ).toBeInTheDocument();
+    });
+  },
 });

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -1,6 +1,7 @@
 import { Pagination, usePagination } from '@digdir/designsystemet-react';
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { expect, within } from 'storybook/test';
+import { ChevronDownIcon, ChevronRightIcon } from '@udir-design/icons';
 import preview from '.storybook/preview';
 import { useCheckboxGroup } from 'src/utilities/hooks/useCheckboxGroup/useCheckboxGroup';
 import { Checkbox } from '../checkbox/Checkbox';
@@ -832,4 +833,165 @@ export const WithBorder = meta.story({
       </div>
     );
   },
+});
+
+type Node = {
+  id: string;
+  label: string; // e.g. "8. trinn", "Fra Oslo"
+  values: React.ReactNode[]; // per-column values (excluding the row header cell)
+  children?: Node[];
+};
+
+type TreeTableProps = {
+  columns: string[]; // headers for the non-header columns
+  data: Node[]; // tree data
+};
+
+export function TreeTable({ columns, data, ...args }: TreeTableProps) {
+  const [open, setOpen] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback(
+    (id: string) =>
+      setOpen((prev) => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      }),
+    [],
+  );
+
+  const rows = useMemo(() => {
+    const renderRows = (node: Node, depth = 0): React.ReactNode => {
+      const isOpen = open.has(node.id);
+      const hasChildren = !!node.children?.length;
+
+      return (
+        <>
+          <Table.Row key={node.id}>
+            <Table.HeaderCell scope="row" style={{ textAlign: 'left' }}>
+              {hasChildren ? (
+                <button
+                  type="button"
+                  onClick={() => hasChildren && toggle(node.id)}
+                  aria-expanded={hasChildren ? isOpen : undefined}
+                  aria-controls={
+                    hasChildren ? `rowgroup-${node.id}` : undefined
+                  }
+                  style={{
+                    all: 'unset',
+                    cursor: hasChildren ? 'pointer' : 'default',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    paddingLeft: `calc(var(--ds-size-3) * ${depth})`,
+                  }}
+                >
+                  {isOpen ? (
+                    <ChevronDownIcon aria-hidden />
+                  ) : (
+                    <ChevronRightIcon aria-hidden />
+                  )}
+                  {node.label}
+                </button>
+              ) : (
+                <span
+                  style={{ paddingLeft: `calc(var(--ds-size-7) * ${depth})` }}
+                >
+                  {node.label}
+                </span>
+              )}
+            </Table.HeaderCell>
+
+            {node.values.map((v, i) => (
+              <Table.Cell
+                key={`${node.id}-c${i}`}
+                style={{ textAlign: 'right' }}
+              >
+                {v}
+              </Table.Cell>
+            ))}
+          </Table.Row>
+
+          {hasChildren && isOpen && node.children && (
+            <>{node.children.map((child) => renderRows(child, depth + 1))}</>
+          )}
+        </>
+      );
+    };
+
+    return data?.map((node) => renderRows(node)) || [];
+  }, [data, open, toggle]);
+
+  return (
+    <Table data-color="accent" {...args}>
+      <caption
+        style={{
+          fontSize: 'var(--ds-font-size-3)',
+          captionSide: 'bottom',
+          textAlign: 'center',
+          fontWeight: 'normal',
+          marginTop: 'var(--ds-size-2)',
+        }}
+      >
+        Svarprosent for elevundersøkelsen nasjonalt
+      </caption>
+
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell />
+          {columns?.map((c, i) => (
+            <Table.HeaderCell key={i} scope="col">
+              {c}
+            </Table.HeaderCell>
+          ))}
+        </Table.Row>
+      </Table.Head>
+
+      <Table.Body style={{ textAlign: 'right' }}>{rows}</Table.Body>
+    </Table>
+  );
+}
+
+const columns = ['2022–23', '2023–24', '2024–25'];
+
+const data: Node[] = [
+  {
+    id: '8trinn',
+    label: '8. trinn',
+    values: ['88,5%', '86,3%', '85,3%'],
+    children: [
+      {
+        id: '8trinn-oslo',
+        label: 'Fra Oslo',
+        values: ['30,5%', '1,3%', '23,3%'],
+        children: [
+          {
+            id: '8trinn-oslo-sentrum',
+            label: 'Sentrum',
+            values: ['15,1%', '0,7%', '11,0%'],
+          },
+          {
+            id: '8trinn-oslo-øst',
+            label: 'Øst',
+            values: ['15,4%', '0,6%', '12,3%'],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: '9trinn',
+    label: '9. trinn',
+    values: ['88,7%', '86,3%', '84,9%'],
+  },
+];
+
+export const TreeStructuredTable = meta.story({
+  args: {
+    zebra: true,
+    tintedColumnHeader: true,
+    tintedRowHeader: true,
+    'data-color': 'support1',
+  },
+  render: (args) => <TreeTable columns={columns} data={data} {...args} />,
 });

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -1011,7 +1011,7 @@ export const TreeStructuredTable = meta.story({
           <Table.Row
             key={node.id}
             data-testid={`row-${node.id}`}
-            aria-level={depth + 1}
+            data-level={depth + 1}
           >
             <Table.HeaderCell scope="row">
               {hasChildren ? (

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -1,6 +1,7 @@
 import { Pagination, usePagination } from '@digdir/designsystemet-react';
+import type React from 'react';
 import { useState } from 'react';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { useCheckboxGroup } from 'src/utilities/hooks/useCheckboxGroup/useCheckboxGroup';
 import { Checkbox } from '../checkbox/Checkbox';
@@ -848,3 +849,88 @@ export const WithBorder = meta.story({
     );
   },
 });
+
+const expandableData = [
+  {
+    id: 1,
+    navn: 'Rita Nordmann',
+    rolle: 'Rektor',
+    epost: 'rita@nordmann.no',
+    detaljer:
+      'Rita har vært rektor i 12 år og har ansvar for 45 ansatte. Hun leder skolens pedagogiske utviklingsarbeid.',
+  },
+  {
+    id: 2,
+    navn: 'Kari Nordmann',
+    rolle: 'Lektor',
+    epost: 'kari@nordmann.no',
+    detaljer:
+      'Kari underviser i norsk og samfunnsfag for 8.–10. trinn. Hun er også kontaktlærer for 9A.',
+  },
+  {
+    id: 3,
+    navn: 'Ola Nordmann',
+    rolle: 'Lektor',
+    epost: 'ola@nordmann.no',
+    detaljer:
+      'Ola underviser i matematikk og naturfag. Han er ansvarlig for skolens realfagssatsing.',
+  },
+];
+
+export const ExpandableRows = meta.story({
+  render: (args) => (
+    <Table {...args} style={{ tableLayout: 'fixed', width: '600px' }}>
+      <Table.Head>
+        <Table.Row>
+          <Table.HeaderCell>Navn</Table.HeaderCell>
+          <Table.HeaderCell>Rolle</Table.HeaderCell>
+          <Table.HeaderCell>Epost</Table.HeaderCell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {expandableData.map((row) => (
+          <ExpandableTableRow key={row.id} row={row} />
+        ))}
+      </Table.Body>
+    </Table>
+  ),
+  async play({ canvasElement, step }) {
+    const canvas = within(canvasElement);
+
+    await step('Detail row is hidden when collapsed', () => {
+      const button = canvas.getAllByRole('button')[0];
+      expect(button).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    await step('Detail row is shown when expanded', async () => {
+      const button = canvas.getAllByRole('button')[0];
+      await userEvent.click(button);
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+  },
+});
+
+function ExpandableTableRow({ row }: { row: (typeof expandableData)[number] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      <Table.Row>
+        <Table.Cell>
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded(!expanded)}
+          >
+            {row.navn}
+          </button>
+        </Table.Cell>
+        <Table.Cell>{row.rolle}</Table.Cell>
+        <Table.Cell>{row.epost}</Table.Cell>
+      </Table.Row>
+      <Table.Row hidden={!expanded}>
+        <Table.Cell colSpan={3}>{row.detaljer}</Table.Cell>
+      </Table.Row>
+    </>
+  );
+}

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -986,7 +986,7 @@ exports[`Tree Structured Table 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr aria-level="1">
+    <tr data-level="1">
       <th scope="row">
         <button
           type="button"
@@ -1005,7 +1005,7 @@ exports[`Tree Structured Table 1`] = `
         50
       </td>
     </tr>
-    <tr aria-level="2">
+    <tr data-level="2">
       <th scope="row">
         <button
           type="button"
@@ -1024,7 +1024,7 @@ exports[`Tree Structured Table 1`] = `
         53
       </td>
     </tr>
-    <tr aria-level="2">
+    <tr data-level="2">
       <th scope="row">
         <button
           type="button"
@@ -1043,7 +1043,7 @@ exports[`Tree Structured Table 1`] = `
         54
       </td>
     </tr>
-    <tr aria-level="3">
+    <tr data-level="3">
       <th scope="row">
         <button
           type="button"
@@ -1062,7 +1062,7 @@ exports[`Tree Structured Table 1`] = `
         56
       </td>
     </tr>
-    <tr aria-level="3">
+    <tr data-level="3">
       <th scope="row">
         <button
           type="button"
@@ -1081,7 +1081,7 @@ exports[`Tree Structured Table 1`] = `
         52
       </td>
     </tr>
-    <tr aria-level="3">
+    <tr data-level="3">
       <th scope="row">
         <button
           type="button"
@@ -1100,7 +1100,7 @@ exports[`Tree Structured Table 1`] = `
         55
       </td>
     </tr>
-    <tr aria-level="3">
+    <tr data-level="3">
       <th scope="row">
         <button
           type="button"
@@ -1119,7 +1119,7 @@ exports[`Tree Structured Table 1`] = `
         54
       </td>
     </tr>
-    <tr aria-level="3">
+    <tr data-level="3">
       <th scope="row">
         <button
           type="button"
@@ -1138,7 +1138,7 @@ exports[`Tree Structured Table 1`] = `
         55
       </td>
     </tr>
-    <tr aria-level="3">
+    <tr data-level="3">
       <th scope="row">
         <button
           type="button"
@@ -1157,7 +1157,7 @@ exports[`Tree Structured Table 1`] = `
         50
       </td>
     </tr>
-    <tr aria-level="2">
+    <tr data-level="2">
       <th scope="row">
         <button
           type="button"
@@ -1176,7 +1176,7 @@ exports[`Tree Structured Table 1`] = `
         51
       </td>
     </tr>
-    <tr aria-level="2">
+    <tr data-level="2">
       <th scope="row">
         <button
           type="button"
@@ -1195,7 +1195,7 @@ exports[`Tree Structured Table 1`] = `
         50
       </td>
     </tr>
-    <tr aria-level="2">
+    <tr data-level="2">
       <th scope="row">
         <button
           type="button"
@@ -1214,7 +1214,7 @@ exports[`Tree Structured Table 1`] = `
         50
       </td>
     </tr>
-    <tr aria-level="2">
+    <tr data-level="2">
       <th scope="row">
         …
       </th>

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -867,19 +867,59 @@ exports[`Sticky Header 1`] = `
 `;
 
 exports[`Tree Structured Table 1`] = `
+<style>
+  /* Styles defined in application-specific css */
+            .treeStructuredTable-caption {
+              font-size: var(--ds-font-size-3);
+              caption-side: bottom;
+              text-align: center;
+              font-weight: normal;
+              margin-top: var(--ds-size-2);
+            }
+
+            .treeStructuredTable-valueCell {
+              text-align: right;
+            }
+
+            .treeStructuredTable-button {
+              background: none;
+              border: 0;
+              margin: 0;
+              padding: 0;
+              font: inherit;
+              color: inherit;
+              cursor: pointer;
+            }
+
+            .treeStructuredTable-label {
+              display: grid;
+              grid-template-columns: var(--ds-size-5) auto;
+              align-items: center;
+              column-gap: 0.5rem;
+              padding-inline-start: calc(var(--ds-size-3) * var(--tree-depth));
+            }
+
+            .treeStructuredTable-icon {
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              width: var(--ds-size-5);
+            }
+</style>
 <table
   data-zebra="true"
   data-color="support1"
   data-tinted-column-header="true"
   data-tinted-row-header="true"
 >
-  <caption style="font-size: var(--ds-font-size-3); caption-side: bottom; text-align: center; font-weight: normal; margin-top: var(--ds-size-2);">
+  <caption>
     Svarprosent for elevundersøkelsen nasjonalt
   </caption>
   <thead>
     <tr>
-      <td>
-      </td>
+      <th scope="col">
+        Elevgruppe
+      </th>
       <th scope="col">
         2022–23
       </th>
@@ -891,66 +931,237 @@ exports[`Tree Structured Table 1`] = `
       </th>
     </tr>
   </thead>
-  <tbody style="text-align: right;">
+  <tbody>
     <tr>
-      <th
-        scope="row"
-        style="text-align: left;"
-      >
+      <th scope="row">
         <button
           type="button"
-          aria-expanded="false"
-          aria-controls="rowgroup-8trinn"
-          style="color-scheme: unset; forced-color-adjust: unset; mask: unset; math-depth: unset; position: unset; position-anchor: unset; text-size-adjust: unset; appearance: unset; color: unset; font: unset; font-palette: unset; font-synthesis: unset; position-area: unset; text-orientation: unset; text-rendering: unset; text-spacing-trim: unset; -webkit-font-smoothing: unset; -webkit-locale: unset; -webkit-text-orientation: unset; -webkit-writing-mode: unset; writing-mode: unset; zoom: unset; accent-color: unset; place-content: unset; align-items: center; place-self: unset; alignment-baseline: unset; anchor-name: unset; anchor-scope: unset; animation-composition: unset; animation: unset; app-region: unset; aspect-ratio: unset; backdrop-filter: unset; backface-visibility: unset; background: unset; background-blend-mode: unset; baseline-shift: unset; baseline-source: unset; block-size: unset; border-block: unset; border: unset; border-radius: unset; border-collapse: unset; border-end-end-radius: unset; border-end-start-radius: unset; border-inline: unset; border-start-end-radius: unset; border-start-start-radius: unset; inset: unset; box-decoration-break: unset; box-shadow: unset; box-sizing: unset; break-after: unset; break-before: unset; break-inside: unset; buffered-rendering: unset; caption-side: unset; caret-animation: unset; caret-color: unset; caret-shape: unset; clear: unset; clip: unset; clip-path: unset; clip-rule: unset; color-interpolation: unset; color-interpolation-filters: unset; color-rendering: unset; columns: unset; column-fill: unset; gap: 0.5rem; column-rule: unset; column-span: unset; contain: unset; contain-intrinsic-block-size: unset; contain-intrinsic-size: unset; contain-intrinsic-inline-size: unset; container: unset; content: unset; content-visibility: unset; corner-shape: unset; corner-block-end-shape: unset; corner-block-start-shape: unset; counter-increment: unset; counter-reset: unset; counter-set: unset; cursor: pointer; cx: unset; cy: unset; d: unset; display: inline-flex; dominant-baseline: unset; dynamic-range-limit: unset; empty-cells: unset; field-sizing: unset; fill: unset; fill-opacity: unset; fill-rule: unset; filter: unset; flex: unset; flex-flow: unset; float: unset; flood-color: unset; flood-opacity: unset; grid: unset; grid-area: unset; height: unset; hyphenate-character: unset; hyphenate-limit-chars: unset; hyphens: unset; image-orientation: unset; image-rendering: unset; initial-letter: unset; inline-size: unset; inset-block: unset; inset-inline: unset; interactivity: unset; interest-delay: unset; interpolate-size: unset; isolation: unset; justify-items: unset; letter-spacing: unset; lighting-color: unset; line-break: unset; list-style: unset; margin-block: unset; margin: unset; margin-inline: unset; marker: unset; mask-type: unset; math-shift: unset; math-style: unset; max-block-size: unset; max-height: unset; max-inline-size: unset; max-width: unset; min-block-size: unset; min-height: unset; min-inline-size: unset; min-width: unset; mix-blend-mode: unset; object-fit: unset; object-position: unset; object-view-box: unset; offset: unset; opacity: unset; order: unset; orphans: unset; outline: unset; outline-offset: unset; overflow-anchor: unset; overflow-block: unset; overflow-clip-margin: unset; overflow-inline: unset; overflow-wrap: unset; overflow: unset; overlay: unset; overscroll-behavior-block: unset; overscroll-behavior-inline: unset; overscroll-behavior: unset; padding-block: unset; padding-bottom: unset; padding-inline: unset; padding-left: calc(var(--ds-size-3) * 0); padding-right: unset; padding-top: unset; page: unset; page-orientation: unset; paint-order: unset; perspective: unset; perspective-origin: unset; pointer-events: unset; position-try: unset; position-visibility: unset; print-color-adjust: unset; quotes: unset; r: unset; reading-flow: unset; reading-order: unset; resize: unset; rotate: unset; ruby-align: unset; ruby-position: unset; rx: unset; ry: unset; scale: unset; scroll-behavior: unset; scroll-initial-target: unset; scroll-margin-block: unset; scroll-margin: unset; scroll-margin-inline: unset; scroll-marker-group: unset; scroll-padding-block: unset; scroll-padding: unset; scroll-padding-inline: unset; scroll-snap-align: unset; scroll-snap-stop: unset; scroll-snap-type: unset; scroll-target-group: unset; scroll-timeline: unset; scrollbar-color: unset; scrollbar-gutter: unset; scrollbar-width: unset; shape-image-threshold: unset; shape-margin: unset; shape-outside: unset; shape-rendering: unset; size: unset; speak: unset; stop-color: unset; stop-opacity: unset; stroke: unset; stroke-dasharray: unset; stroke-dashoffset: unset; stroke-linecap: unset; stroke-linejoin: unset; stroke-miterlimit: unset; stroke-opacity: unset; stroke-width: unset; tab-size: unset; table-layout: unset; text-align: unset; text-align-last: unset; text-anchor: unset; text-autospace: unset; text-box: unset; text-combine-upright: unset; text-decoration: unset; text-decoration-skip-ink: unset; text-emphasis: unset; text-emphasis-position: unset; text-indent: unset; text-justify: unset; text-overflow: unset; text-shadow: unset; text-transform: unset; text-underline-offset: unset; text-underline-position: unset; text-wrap: unset; timeline-scope: unset; touch-action: unset; transform: unset; transform-box: unset; transform-origin: unset; transform-style: unset; transition: unset; translate: <removed>; user-select: unset; vector-effect: unset; vertical-align: unset; view-timeline: unset; view-transition-class: unset; view-transition-group: unset; view-transition-name: unset; visibility: unset; border-spacing: unset; -webkit-box-align: unset; -webkit-box-decoration-break: unset; -webkit-box-direction: unset; -webkit-box-flex: unset; -webkit-box-ordinal-group: unset; -webkit-box-orient: unset; -webkit-box-pack: unset; -webkit-box-reflect: unset; -webkit-line-break: unset; -webkit-line-clamp: unset; -webkit-mask-box-image: unset; -webkit-rtl-ordering: unset; -webkit-ruby-position: unset; -webkit-tap-highlight-color: unset; -webkit-text-combine: unset; -webkit-text-decorations-in-effect: unset; -webkit-text-fill-color: unset; -webkit-text-security: unset; -webkit-text-stroke: unset; -webkit-user-drag: unset; white-space-collapse: unset; widows: unset; width: unset; will-change: unset; word-break: unset; word-spacing: unset; x: unset; y: unset; z-index: unset;"
+          aria-expanded="true"
+          aria-label="Skjul undernivå for 8. trinn"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          8. trinn
+          <span style="--tree-depth: 0;">
+            <span aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+            </span>
+            <span>
+              8. trinn
+            </span>
+          </span>
         </button>
       </th>
-      <td style="text-align: right;">
+      <td>
         88,5%
       </td>
-      <td style="text-align: right;">
+      <td>
         86,3%
       </td>
-      <td style="text-align: right;">
+      <td>
         85,3%
       </td>
     </tr>
     <tr>
-      <th
-        scope="row"
-        style="text-align: left;"
-      >
-        <span style="padding-left: calc(var(--ds-size-7) * 0);">
-          9. trinn
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="true"
+          aria-label="Skjul undernivå for Fra Oslo"
+        >
+          <span style="--tree-depth: 1;">
+            <span aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+            </span>
+            <span>
+              Fra Oslo
+            </span>
+          </span>
+        </button>
+      </th>
+      <td>
+        30,5%
+      </td>
+      <td>
+        1,3%
+      </td>
+      <td>
+        23,3%
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">
+        <span style="--tree-depth: 2;">
+          <span aria-hidden="true">
+          </span>
+          <span>
+            Sentrum
+          </span>
         </span>
       </th>
-      <td style="text-align: right;">
+      <td>
+        15,1%
+      </td>
+      <td>
+        0,7%
+      </td>
+      <td>
+        11,0%
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">
+        <span style="--tree-depth: 2;">
+          <span aria-hidden="true">
+          </span>
+          <span>
+            Øst
+          </span>
+        </span>
+      </th>
+      <td>
+        15,4%
+      </td>
+      <td>
+        0,6%
+      </td>
+      <td>
+        12,3%
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">
+        <span style="--tree-depth: 1;">
+          <span aria-hidden="true">
+          </span>
+          <span>
+            Fra Drøbak
+          </span>
+        </span>
+      </th>
+      <td>
+        28,5%
+      </td>
+      <td>
+        0,9%
+      </td>
+      <td>
+        20,3%
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-label="Vis undernivå for 9. trinn"
+        >
+          <span style="--tree-depth: 0;">
+            <span aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+            </span>
+            <span>
+              9. trinn
+            </span>
+          </span>
+        </button>
+      </th>
+      <td>
         88,7%
       </td>
-      <td style="text-align: right;">
+      <td>
         86,3%
       </td>
-      <td style="text-align: right;">
+      <td>
         84,9%
+      </td>
+    </tr>
+    <tr>
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-label="Vis undernivå for 10. trinn"
+        >
+          <span style="--tree-depth: 0;">
+            <span aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+            </span>
+            <span>
+              10. trinn
+            </span>
+          </span>
+        </button>
+      </th>
+      <td>
+        89,7%
+      </td>
+      <td>
+        87,3%
+      </td>
+      <td>
+        85,7%
       </td>
     </tr>
   </tbody>

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -866,6 +866,97 @@ exports[`Sticky Header 1`] = `
 </div>
 `;
 
+exports[`Tree Structured Table 1`] = `
+<table
+  data-zebra="true"
+  data-color="support1"
+  data-tinted-column-header="true"
+  data-tinted-row-header="true"
+>
+  <caption style="font-size: var(--ds-font-size-3); caption-side: bottom; text-align: center; font-weight: normal; margin-top: var(--ds-size-2);">
+    Svarprosent for elevundersøkelsen nasjonalt
+  </caption>
+  <thead>
+    <tr>
+      <td>
+      </td>
+      <th scope="col">
+        2022–23
+      </th>
+      <th scope="col">
+        2023–24
+      </th>
+      <th scope="col">
+        2024–25
+      </th>
+    </tr>
+  </thead>
+  <tbody style="text-align: right;">
+    <tr>
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-controls="rowgroup-8trinn"
+          style="color-scheme: unset; forced-color-adjust: unset; mask: unset; math-depth: unset; position: unset; position-anchor: unset; text-size-adjust: unset; appearance: unset; color: unset; font: unset; font-palette: unset; font-synthesis: unset; position-area: unset; text-orientation: unset; text-rendering: unset; text-spacing-trim: unset; -webkit-font-smoothing: unset; -webkit-locale: unset; -webkit-text-orientation: unset; -webkit-writing-mode: unset; writing-mode: unset; zoom: unset; accent-color: unset; place-content: unset; align-items: center; place-self: unset; alignment-baseline: unset; anchor-name: unset; anchor-scope: unset; animation-composition: unset; animation: unset; app-region: unset; aspect-ratio: unset; backdrop-filter: unset; backface-visibility: unset; background: unset; background-blend-mode: unset; baseline-shift: unset; baseline-source: unset; block-size: unset; border-block: unset; border: unset; border-radius: unset; border-collapse: unset; border-end-end-radius: unset; border-end-start-radius: unset; border-inline: unset; border-start-end-radius: unset; border-start-start-radius: unset; inset: unset; box-decoration-break: unset; box-shadow: unset; box-sizing: unset; break-after: unset; break-before: unset; break-inside: unset; buffered-rendering: unset; caption-side: unset; caret-animation: unset; caret-color: unset; caret-shape: unset; clear: unset; clip: unset; clip-path: unset; clip-rule: unset; color-interpolation: unset; color-interpolation-filters: unset; color-rendering: unset; columns: unset; column-fill: unset; gap: 0.5rem; column-rule: unset; column-span: unset; contain: unset; contain-intrinsic-block-size: unset; contain-intrinsic-size: unset; contain-intrinsic-inline-size: unset; container: unset; content: unset; content-visibility: unset; corner-shape: unset; corner-block-end-shape: unset; corner-block-start-shape: unset; counter-increment: unset; counter-reset: unset; counter-set: unset; cursor: pointer; cx: unset; cy: unset; d: unset; display: inline-flex; dominant-baseline: unset; dynamic-range-limit: unset; empty-cells: unset; field-sizing: unset; fill: unset; fill-opacity: unset; fill-rule: unset; filter: unset; flex: unset; flex-flow: unset; float: unset; flood-color: unset; flood-opacity: unset; grid: unset; grid-area: unset; height: unset; hyphenate-character: unset; hyphenate-limit-chars: unset; hyphens: unset; image-orientation: unset; image-rendering: unset; initial-letter: unset; inline-size: unset; inset-block: unset; inset-inline: unset; interactivity: unset; interest-delay: unset; interpolate-size: unset; isolation: unset; justify-items: unset; letter-spacing: unset; lighting-color: unset; line-break: unset; list-style: unset; margin-block: unset; margin: unset; margin-inline: unset; marker: unset; mask-type: unset; math-shift: unset; math-style: unset; max-block-size: unset; max-height: unset; max-inline-size: unset; max-width: unset; min-block-size: unset; min-height: unset; min-inline-size: unset; min-width: unset; mix-blend-mode: unset; object-fit: unset; object-position: unset; object-view-box: unset; offset: unset; opacity: unset; order: unset; orphans: unset; outline: unset; outline-offset: unset; overflow-anchor: unset; overflow-block: unset; overflow-clip-margin: unset; overflow-inline: unset; overflow-wrap: unset; overflow: unset; overlay: unset; overscroll-behavior-block: unset; overscroll-behavior-inline: unset; overscroll-behavior: unset; padding-block: unset; padding-bottom: unset; padding-inline: unset; padding-left: calc(var(--ds-size-3) * 0); padding-right: unset; padding-top: unset; page: unset; page-orientation: unset; paint-order: unset; perspective: unset; perspective-origin: unset; pointer-events: unset; position-try: unset; position-visibility: unset; print-color-adjust: unset; quotes: unset; r: unset; reading-flow: unset; reading-order: unset; resize: unset; rotate: unset; ruby-align: unset; ruby-position: unset; rx: unset; ry: unset; scale: unset; scroll-behavior: unset; scroll-initial-target: unset; scroll-margin-block: unset; scroll-margin: unset; scroll-margin-inline: unset; scroll-marker-group: unset; scroll-padding-block: unset; scroll-padding: unset; scroll-padding-inline: unset; scroll-snap-align: unset; scroll-snap-stop: unset; scroll-snap-type: unset; scroll-target-group: unset; scroll-timeline: unset; scrollbar-color: unset; scrollbar-gutter: unset; scrollbar-width: unset; shape-image-threshold: unset; shape-margin: unset; shape-outside: unset; shape-rendering: unset; size: unset; speak: unset; stop-color: unset; stop-opacity: unset; stroke: unset; stroke-dasharray: unset; stroke-dashoffset: unset; stroke-linecap: unset; stroke-linejoin: unset; stroke-miterlimit: unset; stroke-opacity: unset; stroke-width: unset; tab-size: unset; table-layout: unset; text-align: unset; text-align-last: unset; text-anchor: unset; text-autospace: unset; text-box: unset; text-combine-upright: unset; text-decoration: unset; text-decoration-skip-ink: unset; text-emphasis: unset; text-emphasis-position: unset; text-indent: unset; text-justify: unset; text-overflow: unset; text-shadow: unset; text-transform: unset; text-underline-offset: unset; text-underline-position: unset; text-wrap: unset; timeline-scope: unset; touch-action: unset; transform: unset; transform-box: unset; transform-origin: unset; transform-style: unset; transition: unset; translate: <removed>; user-select: unset; vector-effect: unset; vertical-align: unset; view-timeline: unset; view-transition-class: unset; view-transition-group: unset; view-transition-name: unset; visibility: unset; border-spacing: unset; -webkit-box-align: unset; -webkit-box-decoration-break: unset; -webkit-box-direction: unset; -webkit-box-flex: unset; -webkit-box-ordinal-group: unset; -webkit-box-orient: unset; -webkit-box-pack: unset; -webkit-box-reflect: unset; -webkit-line-break: unset; -webkit-line-clamp: unset; -webkit-mask-box-image: unset; -webkit-rtl-ordering: unset; -webkit-ruby-position: unset; -webkit-tap-highlight-color: unset; -webkit-text-combine: unset; -webkit-text-decorations-in-effect: unset; -webkit-text-fill-color: unset; -webkit-text-security: unset; -webkit-text-stroke: unset; -webkit-user-drag: unset; white-space-collapse: unset; widows: unset; width: unset; will-change: unset; word-break: unset; word-spacing: unset; x: unset; y: unset; z-index: unset;"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+          8. trinn
+        </button>
+      </th>
+      <td style="text-align: right;">
+        88,5%
+      </td>
+      <td style="text-align: right;">
+        86,3%
+      </td>
+      <td style="text-align: right;">
+        85,3%
+      </td>
+    </tr>
+    <tr>
+      <th
+        scope="row"
+        style="text-align: left;"
+      >
+        <span style="padding-left: calc(var(--ds-size-7) * 0);">
+          9. trinn
+        </span>
+      </th>
+      <td style="text-align: right;">
+        88,7%
+      </td>
+      <td style="text-align: right;">
+        86,3%
+      </td>
+      <td style="text-align: right;">
+        84,9%
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`With Border 1`] = `
 <div style="<removed>">
   <table

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -132,6 +132,89 @@ exports[`Column And Row Headers 1`] = `
 </table>
 `;
 
+exports[`Expandable Rows 1`] = `
+<table style="<removed>">
+  <thead>
+    <tr>
+      <th>
+        Navn
+      </th>
+      <th>
+        Rolle
+      </th>
+      <th>
+        Epost
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          type="button"
+          aria-expanded="true"
+        >
+          Rita Nordmann
+        </button>
+      </td>
+      <td>
+        Rektor
+      </td>
+      <td>
+        rita@nordmann.no
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        Rita har vært rektor i 12 år og har ansvar for 45 ansatte. Hun leder skolens pedagogiske utviklingsarbeid.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Kari Nordmann
+        </button>
+      </td>
+      <td>
+        Lektor
+      </td>
+      <td>
+        kari@nordmann.no
+      </td>
+    </tr>
+    <tr hidden>
+      <td colspan="3">
+        Kari underviser i norsk og samfunnsfag for 8.–10. trinn. Hun er også kontaktlærer for 9A.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Ola Nordmann
+        </button>
+      </td>
+      <td>
+        Lektor
+      </td>
+      <td>
+        ola@nordmann.no
+      </td>
+    </tr>
+    <tr hidden>
+      <td colspan="3">
+        Ola underviser i matematikk og naturfag. Han er ansvarlig for skolens realfagssatsing.
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`Fixed Table 1`] = `
 <div>
   <table
@@ -867,301 +950,282 @@ exports[`Sticky Header 1`] = `
 `;
 
 exports[`Tree Structured Table 1`] = `
-<style>
-  /* Styles defined in application-specific css */
-            .treeStructuredTable-caption {
-              font-size: var(--ds-font-size-3);
-              caption-side: bottom;
-              text-align: center;
-              font-weight: normal;
-              margin-top: var(--ds-size-2);
-            }
-
-            .treeStructuredTable-valueCell {
-              text-align: right;
-            }
-
-            .treeStructuredTable-button {
-              background: none;
-              border: 0;
-              margin: 0;
-              padding: 0;
-              font: inherit;
-              color: inherit;
-              cursor: pointer;
-            }
-
-            .treeStructuredTable-label {
-              display: grid;
-              grid-template-columns: var(--ds-size-5) auto;
-              align-items: center;
-              column-gap: 0.5rem;
-              padding-inline-start: calc(var(--ds-size-3) * var(--tree-depth));
-            }
-
-            .treeStructuredTable-icon {
-              display: inline-flex;
-              align-items: center;
-              justify-content: center;
-              width: var(--ds-size-5);
-            }
-</style>
 <table
   data-zebra="true"
   data-color="support1"
   data-tinted-column-header="true"
   data-tinted-row-header="true"
+  style="<removed>"
 >
-  <caption>
-    Svarprosent for elevundersøkelsen nasjonalt
+  <caption style="<removed>">
+    Nasjonale prøver 5. trinn – skoleåret 2024–25, snitt skalapoeng
   </caption>
   <thead>
     <tr>
       <th scope="col">
-        Elevgruppe
+        Område
       </th>
-      <th scope="col">
-        2022–23
+      <th
+        scope="col"
+        style="<removed>"
+      >
+        Lesing
       </th>
-      <th scope="col">
-        2023–24
+      <th
+        scope="col"
+        style="<removed>"
+      >
+        Regning
       </th>
-      <th scope="col">
-        2024–25
+      <th
+        scope="col"
+        style="<removed>"
+      >
+        Engelsk
       </th>
     </tr>
   </thead>
   <tbody>
-    <tr>
+    <tr aria-level="1">
       <th scope="row">
         <button
           type="button"
           aria-expanded="true"
-          aria-label="Skjul undernivå for 8. trinn"
         >
-          <span style="--tree-depth: 0;">
-            <span aria-hidden="true">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="1em"
-                height="1em"
-                fill="none"
-                viewbox="0 0 24 24"
-                focusable="false"
-                role="img"
-              >
-                <path
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                  clip-rule="evenodd"
-                >
-                </path>
-              </svg>
-            </span>
-            <span>
-              8. trinn
-            </span>
-          </span>
+          Nasjonalt
         </button>
       </th>
-      <td>
-        88,5%
+      <td style="<removed>">
+        50
       </td>
-      <td>
-        86,3%
+      <td style="<removed>">
+        50
       </td>
-      <td>
-        85,3%
+      <td style="<removed>">
+        50
       </td>
     </tr>
-    <tr>
+    <tr aria-level="2">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Akershus
+        </button>
+      </th>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        53
+      </td>
+    </tr>
+    <tr aria-level="2">
       <th scope="row">
         <button
           type="button"
           aria-expanded="true"
-          aria-label="Skjul undernivå for Fra Oslo"
         >
-          <span style="--tree-depth: 1;">
-            <span aria-hidden="true">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="1em"
-                height="1em"
-                fill="none"
-                viewbox="0 0 24 24"
-                focusable="false"
-                role="img"
-              >
-                <path
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                  d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                  clip-rule="evenodd"
-                >
-                </path>
-              </svg>
-            </span>
-            <span>
-              Fra Oslo
-            </span>
-          </span>
+          Oslo
         </button>
       </th>
-      <td>
-        30,5%
+      <td style="<removed>">
+        53
       </td>
-      <td>
-        1,3%
+      <td style="<removed>">
+        52
       </td>
-      <td>
-        23,3%
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <span style="--tree-depth: 2;">
-          <span aria-hidden="true">
-          </span>
-          <span>
-            Sentrum
-          </span>
-        </span>
-      </th>
-      <td>
-        15,1%
-      </td>
-      <td>
-        0,7%
-      </td>
-      <td>
-        11,0%
+      <td style="<removed>">
+        54
       </td>
     </tr>
-    <tr>
-      <th scope="row">
-        <span style="--tree-depth: 2;">
-          <span aria-hidden="true">
-          </span>
-          <span>
-            Øst
-          </span>
-        </span>
-      </th>
-      <td>
-        15,4%
-      </td>
-      <td>
-        0,6%
-      </td>
-      <td>
-        12,3%
-      </td>
-    </tr>
-    <tr>
-      <th scope="row">
-        <span style="--tree-depth: 1;">
-          <span aria-hidden="true">
-          </span>
-          <span>
-            Fra Drøbak
-          </span>
-        </span>
-      </th>
-      <td>
-        28,5%
-      </td>
-      <td>
-        0,9%
-      </td>
-      <td>
-        20,3%
-      </td>
-    </tr>
-    <tr>
+    <tr aria-level="3">
       <th scope="row">
         <button
           type="button"
           aria-expanded="false"
-          aria-label="Vis undernivå for 9. trinn"
         >
-          <span style="--tree-depth: 0;">
-            <span aria-hidden="true">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="1em"
-                height="1em"
-                fill="none"
-                viewbox="0 0 24 24"
-                focusable="false"
-                role="img"
-              >
-                <path
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                  d="M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06"
-                  clip-rule="evenodd"
-                >
-                </path>
-              </svg>
-            </span>
-            <span>
-              9. trinn
-            </span>
-          </span>
+          Frogner
         </button>
       </th>
-      <td>
-        88,7%
+      <td style="<removed>">
+        55
       </td>
-      <td>
-        86,3%
+      <td style="<removed>">
+        53
       </td>
-      <td>
-        84,9%
+      <td style="<removed>">
+        56
       </td>
     </tr>
-    <tr>
+    <tr aria-level="3">
       <th scope="row">
         <button
           type="button"
           aria-expanded="false"
-          aria-label="Vis undernivå for 10. trinn"
         >
-          <span style="--tree-depth: 0;">
-            <span aria-hidden="true">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="1em"
-                height="1em"
-                fill="none"
-                viewbox="0 0 24 24"
-                focusable="false"
-                role="img"
-              >
-                <path
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                  d="M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06"
-                  clip-rule="evenodd"
-                >
-                </path>
-              </svg>
-            </span>
-            <span>
-              10. trinn
-            </span>
-          </span>
+          Gamle Oslo
         </button>
       </th>
-      <td>
-        89,7%
+      <td style="<removed>">
+        52
       </td>
-      <td>
-        87,3%
+      <td style="<removed>">
+        50
       </td>
-      <td>
-        85,7%
+      <td style="<removed>">
+        52
+      </td>
+    </tr>
+    <tr aria-level="3">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Grünerløkka
+        </button>
+      </th>
+      <td style="<removed>">
+        54
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        55
+      </td>
+    </tr>
+    <tr aria-level="3">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Nordre Aker
+        </button>
+      </th>
+      <td style="<removed>">
+        53
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        54
+      </td>
+    </tr>
+    <tr aria-level="3">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          St. Hanshaugen
+        </button>
+      </th>
+      <td style="<removed>">
+        54
+      </td>
+      <td style="<removed>">
+        53
+      </td>
+      <td style="<removed>">
+        55
+      </td>
+    </tr>
+    <tr aria-level="3">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Søndre Nordstrand
+        </button>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        48
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr aria-level="2">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Rogaland
+        </button>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+    </tr>
+    <tr aria-level="2">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Trøndelag
+        </button>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr aria-level="2">
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Vestland
+        </button>
+      </th>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr aria-level="2">
+      <th scope="row">
+        …
+      </th>
+      <td style="<removed>">
+        …
+      </td>
+      <td style="<removed>">
+        …
+      </td>
+      <td style="<removed>">
+        …
       </td>
     </tr>
   </tbody>

--- a/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
+++ b/@udir-design/react/src/components/table/__snapshots__/Table.stories.tsx.snap
@@ -132,6 +132,89 @@ exports[`Column And Row Headers 1`] = `
 </table>
 `;
 
+exports[`Expandable Rows 1`] = `
+<table style="<removed>">
+  <thead>
+    <tr>
+      <th>
+        Navn
+      </th>
+      <th>
+        Rolle
+      </th>
+      <th>
+        Epost
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          type="button"
+          aria-expanded="true"
+        >
+          Rita Nordmann
+        </button>
+      </td>
+      <td>
+        Rektor
+      </td>
+      <td>
+        rita@nordmann.no
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        Rita har vært rektor i 12 år og har ansvar for 45 ansatte. Hun leder skolens pedagogiske utviklingsarbeid.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Kari Nordmann
+        </button>
+      </td>
+      <td>
+        Lektor
+      </td>
+      <td>
+        kari@nordmann.no
+      </td>
+    </tr>
+    <tr hidden>
+      <td colspan="3">
+        Kari underviser i norsk og samfunnsfag for 8.–10. trinn. Hun er også kontaktlærer for 9A.
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          type="button"
+          aria-expanded="false"
+        >
+          Ola Nordmann
+        </button>
+      </td>
+      <td>
+        Lektor
+      </td>
+      <td>
+        ola@nordmann.no
+      </td>
+    </tr>
+    <tr hidden>
+      <td colspan="3">
+        Ola underviser i matematikk og naturfag. Han er ansvarlig for skolens realfagssatsing.
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`Fixed Table 1`] = `
 <div>
   <table

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -80,7 +80,7 @@
   }
 
   /* Expandable rows (simple expand/collapse, not drilldown) */
-  & > tbody > tr:not([aria-level]):has(> :is(td, th) > button[aria-expanded]) {
+  & > tbody > tr:not([data-level]):has(> :is(td, th) > button[aria-expanded]) {
     & > :is(td, th):has(> button[aria-expanded]) {
       padding: 0;
     }
@@ -101,19 +101,19 @@
 
   /* Drilldown / tree-structured rows */
 
-  & > tbody > tr[aria-level] {
+  & > tbody > tr[data-level] {
     --dsc-table-drilldown-depth: 0;
 
-    &[aria-level='2'] {
+    &[data-level='2'] {
       --dsc-table-drilldown-depth: 1;
     }
-    &[aria-level='3'] {
+    &[data-level='3'] {
       --dsc-table-drilldown-depth: 2;
     }
-    &[aria-level='4'] {
+    &[data-level='4'] {
       --dsc-table-drilldown-depth: 3;
     }
-    &[aria-level='5'] {
+    &[data-level='5'] {
       --dsc-table-drilldown-depth: 4;
     }
 

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -48,4 +48,91 @@
       margin-bottom: var(--ds-size-3);
     }
   }
+
+  /* Shared expand/collapse button styles */
+  & > tbody > tr > :is(td, th) > button[aria-expanded] {
+    all: unset;
+    box-sizing: border-box;
+    cursor: pointer;
+    border-radius: var(--ds-border-radius-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+
+    @composes ds-focus from '@digdir/designsystemet-css/base.css';
+
+    &::before {
+      all: unset;
+      display: inline-block;
+      content: '';
+      background: currentcolor;
+      flex-shrink: 0;
+      height: var(--ds-size-5);
+      width: var(--ds-size-5);
+      mask: center / contain no-repeat var(--uds-icon-chevronDown);
+      rotate: -90deg;
+    }
+
+    &[aria-expanded='true']::before {
+      rotate: 0deg;
+    }
+  }
+
+  /* Expandable rows (simple expand/collapse, not drilldown) */
+  & > tbody > tr:not([aria-level]):has(> :is(td, th) > button[aria-expanded]) {
+    & > :is(td, th):has(> button[aria-expanded]) {
+      padding: 0;
+    }
+
+    & > :is(td, th) > button[aria-expanded] {
+      padding: var(--dsc-table-padding);
+    }
+
+    /* Remove border between expanded row and its content */
+    &:has(button[aria-expanded='true']) > :is(td, th) {
+      border-bottom: 0;
+    }
+
+    &:has(button[aria-expanded='false']) + tr > td[colspan]:only-child {
+      display: none;
+    }
+  }
+
+  /* Drilldown / tree-structured rows */
+
+  & > tbody > tr[aria-level] {
+    --dsc-table-drilldown-depth: 0;
+
+    &[aria-level='2'] {
+      --dsc-table-drilldown-depth: 1;
+    }
+    &[aria-level='3'] {
+      --dsc-table-drilldown-depth: 2;
+    }
+    &[aria-level='4'] {
+      --dsc-table-drilldown-depth: 3;
+    }
+    &[aria-level='5'] {
+      --dsc-table-drilldown-depth: 4;
+    }
+
+    & > :is(th, td):first-child {
+      padding-inline-start: calc(
+        var(--ds-size-3) + var(--ds-size-6) * var(--dsc-table-drilldown-depth) +
+          var(--ds-size-5) + 0.5rem
+      );
+
+      &:has(> button[aria-expanded]) {
+        padding: 0;
+      }
+    }
+
+    & > :is(th, td):first-child > button[aria-expanded] {
+      padding: var(--dsc-table-padding);
+      padding-inline-start: calc(
+        var(--ds-size-3) + var(--ds-size-6) * var(--dsc-table-drilldown-depth)
+      );
+    }
+  }
 }

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -1,3 +1,15 @@
+/* Drilldown: language-aware level label injected by useDrilldownTable.
+ * These are read by the hook via getComputedStyle, not used in CSS content. */
+:root,
+[lang='nb'],
+[lang='nn'] {
+  --udsc-table-level-prefix: Nivå;
+}
+
+[lang='en'] {
+  --udsc-table-level-prefix: Level;
+}
+
 .ds-table {
   --dsc-table-background--zebra: var(--ds-color-neutral-background-tinted);
   --dsc-table-header-background--sorted: var(--ds-color-surface-active);
@@ -46,6 +58,93 @@
   &[data-tinted-column-header] {
     > caption {
       margin-bottom: var(--ds-size-3);
+    }
+  }
+
+  /* Shared expand/collapse button styles */
+  & > tbody > tr > :is(td, th) > button[aria-expanded] {
+    all: unset;
+    box-sizing: border-box;
+    cursor: pointer;
+    border-radius: var(--ds-border-radius-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+
+    @composes ds-focus from '@digdir/designsystemet-css/base.css';
+
+    &::before {
+      all: unset;
+      display: inline-block;
+      content: '';
+      background: currentcolor;
+      flex-shrink: 0;
+      height: var(--ds-size-5);
+      width: var(--ds-size-5);
+      mask: center / contain no-repeat var(--uds-icon-chevronDown);
+      rotate: -90deg;
+    }
+
+    &[aria-expanded='true']::before {
+      rotate: 0deg;
+    }
+  }
+
+  /* Expandable rows (simple expand/collapse, not drilldown) */
+  & > tbody > tr:not([data-level]):has(> :is(td, th) > button[aria-expanded]) {
+    & > :is(td, th):has(> button[aria-expanded]) {
+      padding: 0;
+    }
+
+    & > :is(td, th) > button[aria-expanded] {
+      padding: var(--dsc-table-padding);
+    }
+
+    /* Remove border between expanded row and its content */
+    &:has(button[aria-expanded='true']) > :is(td, th) {
+      border-bottom: 0;
+    }
+
+    &:has(button[aria-expanded='false']) + tr > td[colspan]:only-child {
+      display: none;
+    }
+  }
+
+  /* Drilldown / tree-structured rows */
+
+  & > tbody > tr[data-level] {
+    --dsc-table-drilldown-depth: 0;
+
+    &[data-level='2'] {
+      --dsc-table-drilldown-depth: 1;
+    }
+    &[data-level='3'] {
+      --dsc-table-drilldown-depth: 2;
+    }
+    &[data-level='4'] {
+      --dsc-table-drilldown-depth: 3;
+    }
+    &[data-level='5'] {
+      --dsc-table-drilldown-depth: 4;
+    }
+
+    & > :is(th, td):first-child {
+      padding-inline-start: calc(
+        var(--ds-size-3) + var(--ds-size-6) * var(--dsc-table-drilldown-depth) +
+          var(--ds-size-5) + 0.5rem
+      );
+
+      &:has(> button[aria-expanded]) {
+        padding: 0;
+      }
+    }
+
+    & > :is(th, td):first-child > button[aria-expanded] {
+      padding: var(--dsc-table-padding);
+      padding-inline-start: calc(
+        var(--ds-size-3) + var(--ds-size-6) * var(--dsc-table-drilldown-depth)
+      );
     }
   }
 }

--- a/@udir-design/react/src/utilities/hooks/alpha.ts
+++ b/@udir-design/react/src/utilities/hooks/alpha.ts
@@ -5,6 +5,7 @@
  * @module
  */
 
+export { useDrilldownTable } from './useDrilldownTable/useDrilldownTable';
 export {
   type FormNavigationState,
   type GetFormNavigationStepProps,

--- a/@udir-design/react/src/utilities/hooks/useDrilldownTable/__snapshots__/useDrilldownTable.stories.tsx.snap
+++ b/@udir-design/react/src/utilities/hooks/useDrilldownTable/__snapshots__/useDrilldownTable.stories.tsx.snap
@@ -1,0 +1,416 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Preview 1`] = `
+<table
+  data-zebra="true"
+  data-color="support1"
+  data-tinted-column-header="true"
+  data-tinted-row-header="true"
+  style="<removed>"
+>
+  <caption style="<removed>">
+    Nasjonale prøver 5. trinn – skoleåret 2024–25, snitt skalapoeng
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">
+        Område
+      </th>
+      <th
+        scope="col"
+        style="<removed>"
+      >
+        Lesing
+      </th>
+      <th
+        scope="col"
+        style="<removed>"
+      >
+        Regning
+      </th>
+      <th
+        scope="col"
+        style="<removed>"
+      >
+        Engelsk
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr
+      id="<removed>"
+      data-level="1"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="true"
+          aria-describedby="<removed>"
+        >
+          Nasjonalt
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 1
+        </span>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="2"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Akershus
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 2
+        </span>
+      </th>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        53
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="2"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="true"
+          aria-describedby="<removed>"
+        >
+          Oslo
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 2
+        </span>
+      </th>
+      <td style="<removed>">
+        53
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        54
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="3"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Frogner
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 3
+        </span>
+      </th>
+      <td style="<removed>">
+        55
+      </td>
+      <td style="<removed>">
+        53
+      </td>
+      <td style="<removed>">
+        56
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="3"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Gamle Oslo
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 3
+        </span>
+      </th>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="3"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Grünerløkka
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 3
+        </span>
+      </th>
+      <td style="<removed>">
+        54
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        55
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="3"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Nordre Aker
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 3
+        </span>
+      </th>
+      <td style="<removed>">
+        53
+      </td>
+      <td style="<removed>">
+        52
+      </td>
+      <td style="<removed>">
+        54
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="3"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          St. Hanshaugen
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 3
+        </span>
+      </th>
+      <td style="<removed>">
+        54
+      </td>
+      <td style="<removed>">
+        53
+      </td>
+      <td style="<removed>">
+        55
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="3"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Søndre Nordstrand
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 3
+        </span>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        48
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="2"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Rogaland
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 2
+        </span>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="2"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Trøndelag
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 2
+        </span>
+      </th>
+      <td style="<removed>">
+        50
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="2"
+    >
+      <th scope="row">
+        <button
+          type="button"
+          aria-expanded="false"
+          aria-describedby="<removed>"
+        >
+          Vestland
+        </button>
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 2
+        </span>
+      </th>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        51
+      </td>
+      <td style="<removed>">
+        50
+      </td>
+    </tr>
+    <tr
+      id="<removed>"
+      data-level="2"
+    >
+      <th
+        scope="row"
+        aria-describedby="<removed>"
+      >
+        …
+        <span
+          aria-hidden="true"
+          id="<removed>"
+        >
+          Nivå 2
+        </span>
+      </th>
+      <td style="<removed>">
+        …
+      </td>
+      <td style="<removed>">
+        …
+      </td>
+      <td style="<removed>">
+        …
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;

--- a/@udir-design/react/src/utilities/hooks/useDrilldownTable/useDrilldownTable.mdx
+++ b/@udir-design/react/src/utilities/hooks/useDrilldownTable/useDrilldownTable.mdx
@@ -1,0 +1,56 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './useDrilldownTable.stories';
+import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
+
+<Meta of={Stories} />
+
+# useDrilldownTable
+
+En React-hook for å håndtere skjermleserstøtte i drilldown-tabeller (tabeller med hierarkiske tabellrader).
+
+For hver `<Table.Row>` med `data-level` i den tilknyttede `<Table.Body>` legger hooken automatisk inn en visuelt skjult nivåbeskrivelse og setter `aria-describedby` på riktig element, slik at skjermlesere annonserer hvilket nivå raden befinner seg på.
+
+Se [`Table` – Hierarkiske data](/docs/components-table--docs#hierarkiske-data-drilldown) for veiledning om struktur og begrensninger med denne fremgangsmåten.
+
+<Canvas of={Stories.Preview} />
+
+## Bruk
+
+Opprett en ref og send den som parameter til hooken, og send den deretter på `<Table.Body>`.
+Sett `data-level` på hver `<Table.Row>`: 1 for toppnivå, 2 for første undernivå osv.
+
+```tsx
+import { useRef } from 'react';
+import { Table } from '@udir-design/react';
+import { useDrilldownTable } from '@udir-design/react/alpha';
+
+const tbodyRef = useRef<HTMLTableSectionElement>(null);
+useDrilldownTable(tbodyRef);
+
+<Table.Body ref={tbodyRef}>
+  <Table.Row id="rad-1" data-level={1}>
+    <Table.HeaderCell scope="row">
+      <button type="button" aria-expanded={isOpen} onClick={toggle}>
+        Rad med undernivåer
+      </button>
+    </Table.HeaderCell>
+    <Table.Cell>Verdi</Table.Cell>
+  </Table.Row>
+  <Table.Row id="rad-1-1" data-level={2}>
+    <Table.HeaderCell scope="row">Underrad</Table.HeaderCell>
+    <Table.Cell>Verdi</Table.Cell>
+  </Table.Row>
+</Table.Body>;
+```
+
+### Rad-ID
+
+Hooken bruker `id`-attributtet på `<Table.Row>` som grunnlag for `aria-describedby`. Sett `id` eksplisitt for å kontrollere hvilken id som brukes. Uten `id` genereres en stabil id automatisk.
+
+## Språkstøtte
+
+Nivåteksten ("Nivå 1", "Level 1" osv.) styres av CSS-variabelen `--udsc-table-level-prefix` og arver `lang`-attributtet fra nærmeste foreldreelement. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+
+Følgende tekstvariabler er tilgjengelige for overstyring:
+
+<CssLanguageVariables variables={['--udsc-table-level-prefix']} />

--- a/@udir-design/react/src/utilities/hooks/useDrilldownTable/useDrilldownTable.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useDrilldownTable/useDrilldownTable.stories.tsx
@@ -1,0 +1,225 @@
+import type React from 'react';
+import { useMemo, useRef, useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+import preview from '.storybook/preview';
+import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
+import { Table } from 'src/components/table';
+import { useDrilldownTable } from './useDrilldownTable';
+
+const meta = preview.meta({
+  title: 'Utilities/useDrilldownTable',
+  tags: ['alpha', 'udir'],
+  parameters: {
+    componentOrigin: { originator: 'self' },
+    customStyles: { width: 'fit-content', margin: '0 auto' },
+  },
+});
+
+type TreeNode = {
+  id: string;
+  label: string;
+  values: React.ReactNode[];
+  children?: TreeNode[];
+};
+
+type NpNode = [label: string, values: string[], children?: NpNode[]];
+
+const toTree = (nodes: NpNode[], prefix = 'np'): TreeNode[] =>
+  nodes.map(([label, values, children]) => {
+    const id = `${prefix}-${label.toLowerCase().replace(/[^a-zæøå0-9]/g, '')}`;
+    return {
+      id,
+      label,
+      values,
+      ...(children && { children: toTree(children, id) }),
+    };
+  });
+
+const nasjonalePrøverData = toTree([
+  [
+    'Nasjonalt',
+    ['50', '50', '50'],
+    [
+      ['Akershus', ['52', '52', '53'], [['…', ['…', '…', '…']]]],
+      [
+        'Oslo',
+        ['53', '52', '54'],
+        [
+          ['Frogner', ['55', '53', '56'], [['…', ['…', '…', '…']]]],
+          [
+            'Gamle Oslo',
+            ['52', '50', '52'],
+            [
+              ['Gamlebyen skole', ['51', '49', '51']],
+              ['Kampen skole', ['54', '52', '55']],
+              ['Tøyen skole', ['53', '51', '53']],
+              ['Vahl skole', ['52', '50', '52']],
+            ],
+          ],
+          ['Grünerløkka', ['54', '52', '55'], [['…', ['…', '…', '…']]]],
+          ['Nordre Aker', ['53', '52', '54'], [['…', ['…', '…', '…']]]],
+          ['St. Hanshaugen', ['54', '53', '55'], [['…', ['…', '…', '…']]]],
+          ['Søndre Nordstrand', ['50', '48', '50'], [['…', ['…', '…', '…']]]],
+        ],
+      ],
+      ['Rogaland', ['50', '51', '51'], [['…', ['…', '…', '…']]]],
+      ['Trøndelag', ['50', '51', '50'], [['…', ['…', '…', '…']]]],
+      ['Vestland', ['51', '51', '50'], [['…', ['…', '…', '…']]]],
+      ['…', ['…', '…', '…']],
+    ],
+  ],
+]);
+
+export const Preview = meta.story({
+  parameters: { docs: advancedCodeDocs },
+  render: () => {
+    const tbodyRef = useRef<HTMLTableSectionElement>(null);
+    useDrilldownTable(tbodyRef);
+
+    const [open, setOpen] = useState<Set<string>>(
+      new Set([
+        'np-nasjonalt',
+        'np-nasjonalt-oslo',
+        'np-nasjonalt-oslo-gamleoslo',
+      ]),
+    );
+
+    const toggle = (id: string) => {
+      setOpen((prev) => {
+        const next = new Set(prev);
+        next.has(id) ? next.delete(id) : next.add(id);
+        return next;
+      });
+    };
+
+    const rows = useMemo(() => {
+      const renderRows = (node: TreeNode, depth = 0): React.ReactNode[] => {
+        const isOpen = open.has(node.id);
+        const children = node.children ?? [];
+        const hasChildren = children.length > 0;
+
+        const currentRow = (
+          <Table.Row
+            key={node.id}
+            id={node.id}
+            data-testid={`row-${node.id}`}
+            data-level={depth + 1}
+          >
+            <Table.HeaderCell scope="row">
+              {hasChildren ? (
+                <button
+                  type="button"
+                  onClick={() => toggle(node.id)}
+                  aria-expanded={isOpen}
+                  data-testid={`toggle-${node.id}`}
+                >
+                  {node.label}
+                </button>
+              ) : (
+                node.label
+              )}
+            </Table.HeaderCell>
+
+            {node.values.map((value, index) => (
+              <Table.Cell
+                key={`${node.id}-c${index}`}
+                style={{ textAlign: 'right' }}
+              >
+                {value}
+              </Table.Cell>
+            ))}
+          </Table.Row>
+        );
+
+        if (!hasChildren || !isOpen) {
+          return [currentRow];
+        }
+
+        return [
+          currentRow,
+          ...children.flatMap((child) => renderRows(child, depth + 1)),
+        ];
+      };
+
+      return nasjonalePrøverData.flatMap((node) => renderRows(node));
+    }, [open]);
+
+    return (
+      <Table
+        zebra
+        tintedColumnHeader
+        tintedRowHeader
+        data-color="support1"
+        style={{
+          tableLayout: 'fixed',
+          width: '550px',
+        }}
+      >
+        <caption
+          style={{
+            fontSize: 'var(--ds-font-size-3)',
+            captionSide: 'bottom',
+            textAlign: 'center',
+            fontWeight: 'normal',
+            marginTop: 'var(--ds-size-2)',
+          }}
+        >
+          Nasjonale prøver 5. trinn – skoleåret 2024–25, snitt skalapoeng
+        </caption>
+
+        <Table.Head>
+          <Table.Row>
+            <Table.HeaderCell scope="col">Område</Table.HeaderCell>
+            <Table.HeaderCell scope="col" style={{ width: '4rem' }}>
+              Lesing
+            </Table.HeaderCell>
+            <Table.HeaderCell scope="col" style={{ width: '4rem' }}>
+              Regning
+            </Table.HeaderCell>
+            <Table.HeaderCell scope="col" style={{ width: '4rem' }}>
+              Engelsk
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Head>
+
+        <Table.Body ref={tbodyRef}>{rows}</Table.Body>
+      </Table>
+    );
+  },
+  async play({ canvasElement, step }) {
+    const canvas = within(canvasElement);
+
+    await step('Nasjonalt, Oslo and Gamle Oslo are expanded by default', () => {
+      expect(canvas.getByTestId('toggle-np-nasjonalt')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      );
+      expect(canvas.getByTestId('toggle-np-nasjonalt-oslo')).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      );
+      expect(
+        canvas.getByTestId('toggle-np-nasjonalt-oslo-gamleoslo'),
+      ).toHaveAttribute('aria-expanded', 'true');
+      expect(
+        canvas.getByTestId('row-np-nasjonalt-oslo-gamleoslo-tøyenskole'),
+      ).toBeInTheDocument();
+      expect(
+        canvas.getByTestId('row-np-nasjonalt-oslo-gamleoslo-kampenskole'),
+      ).toBeInTheDocument();
+    });
+
+    await step('Collapsing Gamle Oslo hides schools', async () => {
+      await userEvent.click(
+        canvas.getByTestId('toggle-np-nasjonalt-oslo-gamleoslo'),
+      );
+
+      expect(
+        canvas.getByTestId('toggle-np-nasjonalt-oslo-gamleoslo'),
+      ).toHaveAttribute('aria-expanded', 'false');
+      expect(
+        canvas.queryByTestId('row-np-nasjonalt-oslo-gamleoslo-tøyenskole'),
+      ).not.toBeInTheDocument();
+    });
+  },
+});

--- a/@udir-design/react/src/utilities/hooks/useDrilldownTable/useDrilldownTable.ts
+++ b/@udir-design/react/src/utilities/hooks/useDrilldownTable/useDrilldownTable.ts
@@ -1,0 +1,175 @@
+import { useEffect, useId } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Automatically manages accessible level descriptions for drilldown /
+ * tree-structured table rows.
+ *
+ * For each `<tr>` with a `data-level` attribute inside the referenced `<tbody>`,
+ * this hook:
+ * - Injects a visually hidden `<span>` with the level description into the
+ *   first `<th>`.
+ * - Sets `aria-describedby` on the `<button>` inside the `<th>` (expandable
+ *   rows) or on the `<th>` itself (leaf rows).
+ *
+ * The level text ("Nivå 1", "Level 1", etc.) is CSS-driven and respects the
+ * `lang` attribute on ancestor elements.
+ *
+ * Row IDs are taken from the row's own `id` attribute when present; otherwise
+ * a stable generated ID is used.
+ *
+ * @example
+ * const tbodyRef = useRef<HTMLTableSectionElement>(null);
+ * useDrilldownTable(tbodyRef);
+ *
+ * <Table.Body ref={tbodyRef}>
+ *   <Table.Row id="row-1" data-level={1}>
+ *     <Table.HeaderCell scope="row">
+ *       <button aria-expanded={isOpen} onClick={toggle}>Label</button>
+ *     </Table.HeaderCell>
+ *   </Table.Row>
+ * </Table.Body>
+ */
+export function useDrilldownTable(
+  ref: RefObject<HTMLTableSectionElement | null>,
+): void {
+  const idPrefix = useId();
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const tbody: HTMLTableSectionElement = el;
+
+    const generatedIds = new WeakMap<Element, string>();
+    const injectedDescriptions = new WeakMap<
+      HTMLTableRowElement,
+      HTMLSpanElement
+    >();
+    let counter = 0;
+
+    const getLevelPrefix = (): string =>
+      getComputedStyle(tbody)
+        .getPropertyValue('--udsc-table-level-prefix')
+        .trim() || 'Nivå';
+
+    let levelPrefix = getLevelPrefix();
+
+    function getRowId(row: HTMLTableRowElement): string {
+      if (row.id) return row.id;
+      let id = generatedIds.get(row);
+      if (!id) {
+        id = `${idPrefix}-row-${counter++}`;
+        generatedIds.set(row, id);
+      }
+      return id;
+    }
+
+    function processRow(row: HTMLTableRowElement): void {
+      const level = row.getAttribute('data-level');
+      const th = row.querySelector<HTMLElement>('th');
+      if (!th) return;
+
+      let levelDescription = injectedDescriptions.get(row);
+
+      if (!level) {
+        // data-level removed: clean up injected elements
+        levelDescription?.remove();
+        th.removeAttribute('aria-describedby');
+        th.querySelector('button')?.removeAttribute('aria-describedby');
+        return;
+      }
+
+      const descriptionId = `${getRowId(row)}-level`;
+
+      if (!levelDescription) {
+        levelDescription = document.createElement('span');
+        levelDescription.className = 'ds-sr-only';
+        // aria-hidden keeps the span out of the normal reading flow.
+        // It is still included when resolved via aria-describedby.
+        levelDescription.setAttribute('aria-hidden', 'true');
+        th.appendChild(levelDescription);
+        injectedDescriptions.set(row, levelDescription);
+      }
+
+      levelDescription.id = descriptionId;
+      levelDescription.textContent = `${levelPrefix} ${level}`;
+
+      const button = th.querySelector<HTMLButtonElement>('button');
+      if (button) {
+        // Expandable rows: aria-describedby goes on the button, not the th,
+        // otherwise it wouldn't be read when the button receives focus.
+        button.setAttribute('aria-describedby', descriptionId);
+        th.removeAttribute('aria-describedby');
+      } else {
+        // Leaf rows: aria-describedby goes on the th, not a child span,
+        // since VoiceOver doesn't read it when set on a child element.
+        th.setAttribute('aria-describedby', descriptionId);
+      }
+    }
+
+    const processAllRows = (): void =>
+      tbody
+        .querySelectorAll<HTMLTableRowElement>('tr[data-level]')
+        .forEach(processRow);
+
+    // Initial pass over all pre-existing rows
+    processAllRows();
+
+    // Watches for rows being added to or removed from the tbody,
+    // and for data-level attribute changes on existing rows.
+    const observer = new MutationObserver((mutations) => {
+      const rowsToProcess = new Set<HTMLTableRowElement>();
+
+      for (const mutation of mutations) {
+        if (mutation.type === 'childList' && mutation.target === tbody) {
+          // A row was added to or removed from the tbody.
+          // Mutations from injected description elements are excluded
+          // because their MutationRecord.target is the th, not the tbody.
+
+          mutation.addedNodes.forEach((node) => {
+            if (
+              node instanceof HTMLTableRowElement &&
+              node.hasAttribute('data-level')
+            ) {
+              rowsToProcess.add(node);
+            }
+          });
+        } else if (
+          mutation.type === 'attributes' &&
+          mutation.target instanceof HTMLTableRowElement &&
+          mutation.attributeName === 'data-level'
+        ) {
+          // The data-level attribute changed on a row, so re-process it.
+          rowsToProcess.add(mutation.target);
+        }
+      }
+
+      rowsToProcess.forEach(processRow);
+    });
+
+    observer.observe(tbody, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-level'],
+    });
+
+    // Re-runs when the lang attribute changes on any ancestor element,
+    // so level labels stay in sync with the page language.
+    const langObserver = new MutationObserver(() => {
+      levelPrefix = getLevelPrefix();
+      processAllRows();
+    });
+
+    langObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['lang'],
+      subtree: true,
+    });
+
+    return () => {
+      observer.disconnect();
+      langObserver.disconnect();
+    };
+  }, [idPrefix, ref]);
+}


### PR DESCRIPTION
## Hva er gjort

Lagt på støtte for både ekspanderbare rader og drilldown i Table, med felles CSS for toggle-knapp, ikon og innrykk.

- **Ekspanderbare rader:** rad med knapp (`aria-expanded`) + detaljrad som vises/skjules med `hidden`.
- **Drilldown:** hierarkiske rader rendres betinget, og innrykk styres via `data-level`. Har bare lagt til fem rader med drilldown, kan legge til flere, men tenker at det er fint med et maks antall. Mulig det kan løses på andre måter eventuelt.

### Vurdering av `aria-level`

Vurderte `aria-level`, men det er ikke gyldig på vanlige tabellrader (kun i `treegrid`).  
For å unngå regelbrudd og a11y-feil gikk jeg for `data-level` som ren visuell styring av nivå/innrykk. Irriterende at aria-level ikke er lov... Men det sies at det kan skape varierende resultater hos skjermlesere.