### PR TITLE
docs: fix runtime error helper functions

### DIFF
--- a/@udir-design/react/.storybook/doc-blocks/DocsContainer.tsx
+++ b/@udir-design/react/.storybook/doc-blocks/DocsContainer.tsx
@@ -24,7 +24,14 @@ export const DocsContainer = ({
     if (!firstStory) {
       return;
     }
-    setComponentName((firstStory.component as ComponentType).displayName ?? '');
+    if (firstStory.component) {
+      setComponentName(
+        (firstStory.component as ComponentType).displayName ?? '',
+      );
+    } else {
+      const i = firstStory.title.lastIndexOf('/');
+      setComponentName(firstStory.title.substring(i + 1) ?? '');
+    }
     setComponentOrigin(
       (firstStory.parameters as ComponentOriginParameters).componentOrigin,
     );


### PR DESCRIPTION
## Hva er gjort? 
- Dokumentasjon for hjelpefunksjonene kræsjer i prod fordi de prøver å access `displayName` på `firstStory.Component` som for disse er `undefined`
  - Lagt til nullsafety siden det allere var en `?? ''` 
- Håndtere hooks i `DocsContainer` som ikke har `.component` for å unngå dette: 

<img width="497" height="105" alt="image" src="https://github.com/user-attachments/assets/7a0719e1-4b9a-4b33-b94a-ca4f5f581788" />

<img width="1874" height="1024" alt="Screenshot 2025-09-16 at 08 34 10" src="https://github.com/user-attachments/assets/5edd9109-2b8b-456d-a524-a15c34de9cb2" />
