### PR TITLE
build: update pnpm to v10.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "pnpm nx format:check && pnpm nx affected -t typecheck lint test build build:storybook"
   },
   "private": true,
-  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706",
+  "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef",
   "engines": {
     "node": ">= 22.14.0 < 25"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,4 @@ packageExtensions:
         optional: true
 minimumReleaseAge: 1440 # packages must be at least 1 day old, to allow time for supply-chain attacks to be detected
 minimumReleaseAgeExclude:
-  - '@digdir/designsystemet'
-  - '@digdir/designsystemet-css'
-  - '@digdir/designsystemet-react'
+  - '@digdir/*'


### PR DESCRIPTION
pnpm 10.17:
> The `minimumReleaseAgeExclude` setting now supports patterns.