### PR TITLE
fix: export alert from index to attach heading component

### DIFF
--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -2,7 +2,7 @@
  * This file exports the components that are in the beta stage of development
  */
 
-export * from './alert/Alert';
+export * from './alert';
 export * from './avatar/Avatar';
 export * from './badge/Badge';
 export * from './breadcrumbs/Breadcrumbs';


### PR DESCRIPTION
Da det ble lagt til `Alert.Heading` glemte jeg å oppdatere export i `beta.ts`, derfor ble attachment av `Heading` ikke med 