### PR TITLE
feat: update `@digdir/*` to 1.6.0

### DIFF
--- a/@udir-design/css/package.json
+++ b/@udir-design/css/package.json
@@ -20,7 +20,7 @@
     "./dist"
   ],
   "dependencies": {
-    "@digdir/designsystemet-css": "1.5.0",
+    "@digdir/designsystemet-css": "1.6.0",
     "@udir-design/theme": "workspace:*"
   },
   "devDependencies": {

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -46,7 +46,7 @@
     "test:storybook": "pnpm exec playwright install --with-deps chromium && pnpm vitest --project storybook"
   },
   "dependencies": {
-    "@digdir/designsystemet-react": "1.5.0",
+    "@digdir/designsystemet-react": "1.6.0",
     "@navikt/aksel-icons": "^7.31.0",
     "@udir-design/css": "workspace:*",
     "tslib": "^2.8.1"

--- a/@udir-design/react/src/components/avatar/Avatar.tsx
+++ b/@udir-design/react/src/components/avatar/Avatar.tsx
@@ -4,16 +4,7 @@ import {
 } from '@digdir/designsystemet-react';
 import { ComponentRef, ForwardRefExoticComponent, RefAttributes } from 'react';
 
-type AriaLabel = {
-  /**
-   * The name of the person the avatar represents.
-   */
-  'aria-label': string;
-};
-type AriaHidden = Partial<AriaLabel> & { 'aria-hidden': true | 'true' };
-
-type AvatarProps = (AriaLabel | AriaHidden) &
-  Omit<DigdirAvatarProps, 'variant' | 'aria-label'>;
+type AvatarProps = Omit<DigdirAvatarProps, 'variant'>;
 const Avatar = DigdirAvatar as ForwardRefExoticComponent<
   AvatarProps & RefAttributes<ComponentRef<typeof DigdirAvatar>>
 >;

--- a/@udir-design/react/src/components/link/link.css
+++ b/@udir-design/react/src/components/link/link.css
@@ -1,6 +1,12 @@
-/* Use Digdir's "special case" for neutral link color as default, since neutral is our default */
 .ds-link {
+  /* Use Digdir's "special case" for neutral link color as default, since neutral is our default */
   --dsc-link-color--active: var(--ds-color-text-subtle);
   --dsc-link-color--hover: var(--ds-color-text-subtle);
   --dsc-link-color: var(--ds-color-text-default);
+
+  /* Focus style: use sharp corners on the outline, and remove text underline */
+  --dsc-link-border-radius: 0;
+  &:focus-visible {
+    text-decoration: none;
+  }
 }

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
@@ -5,7 +5,7 @@ import * as ToggleGroupStories from './ToggleGroup.stories';
 
 # ToggleGroup
 
-Med `ToggleGroup` kan brukerne velge alternativer som påvirker innholdet på en side. Komponenten består av en gruppe knapper som henger sammen, der kun én knapp er mulig å velge om gangen.
+Med `ToggleGroup` kan brukerne velge alternativer som påvirker innholdet på en side. Komponenten består av en gruppe knapper som henger sammen, der kun én knapp er mulig å velge om gangen. `ToggleGroup` har variantene `primary` og `secondary`.
 
 **Passer til å**
 
@@ -34,6 +34,22 @@ import { ToggleGroup } from '@udir-design/react';
   <ToggleGroup.Item value="value3">Option 3</ToggleGroup.Item>
 </ToggleGroup>;
 ```
+
+## Varianter av ToggleGroup
+
+`ToggleGroup` har to varianter, `primary` og `secondary`. Hvilken man bruker avhenger av hvor framtredende valgene skal være.
+
+### Primary ToggleGroup
+
+Dette er den mest framtredende varianten.
+
+<Canvas of={ToggleGroupStories.Primary} />
+
+### Secondary ToggleGroup
+
+Denne varianten kan brukes for å tone ned viktigheten av valgene i forhold til andre valg eller handlinger på siden.
+
+<Canvas of={ToggleGroupStories.Secondary} />
 
 ## Eksempler
 

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -105,6 +105,16 @@ export const Preview: Story = {
   },
 };
 
+export const Primary: Story = {
+  args: { defaultValue: 'innboks', variant: 'primary' },
+  render: Preview.render,
+};
+
+export const Secondary: Story = {
+  args: { defaultValue: 'innboks', variant: 'secondary' },
+  render: Preview.render,
+};
+
 export const OnlyText: Story = {
   args: {},
   parameters: {

--- a/@udir-design/react/src/components/toggleGroup/__snapshots__/ToggleGroup.stories.tsx.snap
+++ b/@udir-design/react/src/components/toggleGroup/__snapshots__/ToggleGroup.stories.tsx.snap
@@ -6,17 +6,18 @@ exports[`Controlled 1`] = `
 </h1>
 <div
   role="radiogroup"
+  data-variant="primary"
   tabindex="0"
 >
   <button
     data-variant="tertiary"
     type="button"
     value="answers"
-    id="togglegroup-item-«r19»"
+    id="togglegroup-item-«r1r»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«r17»"
+    name="togglegroup-name-«r1p»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -44,11 +45,11 @@ exports[`Controlled 1`] = `
     data-variant="tertiary"
     type="button"
     value="drafts"
-    id="togglegroup-item-«r1c»"
+    id="togglegroup-item-«r1u»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«r17»"
+    name="togglegroup-name-«r1p»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -76,11 +77,11 @@ exports[`Controlled 1`] = `
     data-variant="primary"
     type="button"
     value="correctedAnswers"
-    id="togglegroup-item-«r1f»"
+    id="togglegroup-item-«r21»"
     aria-checked="true"
     aria-current="true"
     role="radio"
-    name="togglegroup-name-«r17»"
+    name="togglegroup-name-«r1p»"
     data-roving-tabindex-item="true"
     tabindex="0"
   >
@@ -139,7 +140,7 @@ exports[`Controlled 1`] = `
           data-variant="tertiary"
           type="button"
           aria-label="Se retting"
-          popovertarget="«r1h»"
+          popovertarget="«r23»"
           popovertargetaction="show"
         >
           <svg
@@ -161,7 +162,7 @@ exports[`Controlled 1`] = `
         </button>
         <span
           role="tooltip"
-          id="«r1h»"
+          id="«r23»"
           popover="manual"
           style="opacity: 0;"
         >
@@ -185,7 +186,7 @@ exports[`Controlled 1`] = `
           data-variant="tertiary"
           type="button"
           aria-label="Se retting"
-          popovertarget="«r1j»"
+          popovertarget="«r25»"
           popovertargetaction="show"
         >
           <svg
@@ -207,7 +208,7 @@ exports[`Controlled 1`] = `
         </button>
         <span
           role="tooltip"
-          id="«r1j»"
+          id="«r25»"
           popover="manual"
           style="opacity: 0;"
         >
@@ -231,7 +232,7 @@ exports[`Controlled 1`] = `
           data-variant="tertiary"
           type="button"
           aria-label="Se retting"
-          popovertarget="«r1l»"
+          popovertarget="«r27»"
           popovertargetaction="show"
         >
           <svg
@@ -253,7 +254,7 @@ exports[`Controlled 1`] = `
         </button>
         <span
           role="tooltip"
-          id="«r1l»"
+          id="«r27»"
           popover="manual"
           style="opacity: 0;"
         >
@@ -275,6 +276,7 @@ exports[`Controlled 1`] = `
 exports[`Only Icons 1`] = `
 <div
   role="radiogroup"
+  data-variant="primary"
   tabindex="0"
 >
   <button
@@ -283,13 +285,13 @@ exports[`Only Icons 1`] = `
     type="button"
     value="venstrestilt"
     aria-label="Venstrestilt"
-    popovertarget="«rr»"
+    popovertarget="«r1d»"
     popovertargetaction="show"
-    id="togglegroup-item-«rt»"
+    id="togglegroup-item-«r1f»"
     aria-checked="true"
     aria-current="true"
     role="radio"
-    name="togglegroup-name-«rq»"
+    name="togglegroup-name-«r1c»"
     data-roving-tabindex-item="true"
     tabindex="0"
   >
@@ -314,7 +316,7 @@ exports[`Only Icons 1`] = `
   </button>
   <span
     role="tooltip"
-    id="«rr»"
+    id="«r1d»"
     popover="manual"
     style="opacity: 0;"
   >
@@ -326,13 +328,13 @@ exports[`Only Icons 1`] = `
     type="button"
     value="midtstilt"
     aria-label="Midtstilt"
-    popovertarget="«rv»"
+    popovertarget="«r1h»"
     popovertargetaction="show"
-    id="togglegroup-item-«r11»"
+    id="togglegroup-item-«r1j»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«rq»"
+    name="togglegroup-name-«r1c»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -357,7 +359,7 @@ exports[`Only Icons 1`] = `
   </button>
   <span
     role="tooltip"
-    id="«rv»"
+    id="«r1h»"
     popover="manual"
     style="opacity: 0;"
   >
@@ -369,13 +371,13 @@ exports[`Only Icons 1`] = `
     type="button"
     value="høyrestilt"
     aria-label="Høyrestilt"
-    popovertarget="«r13»"
+    popovertarget="«r1l»"
     popovertargetaction="show"
-    id="togglegroup-item-«r15»"
+    id="togglegroup-item-«r1n»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«rq»"
+    name="togglegroup-name-«r1c»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -400,7 +402,7 @@ exports[`Only Icons 1`] = `
   </button>
   <span
     role="tooltip"
-    id="«r13»"
+    id="«r1l»"
     popover="manual"
     style="opacity: 0;"
   >
@@ -415,17 +417,18 @@ exports[`Only Text 1`] = `
 </label>
 <div
   role="radiogroup"
+  data-variant="primary"
   tabindex="0"
 >
   <button
     data-variant="primary"
     type="button"
     value="personlig"
-    id="togglegroup-item-«rb»"
+    id="togglegroup-item-«rt»"
     aria-checked="true"
     aria-current="true"
     role="radio"
-    name="togglegroup-name-«r9»"
+    name="togglegroup-name-«rr»"
     data-roving-tabindex-item="true"
     tabindex="0"
   >
@@ -435,11 +438,11 @@ exports[`Only Text 1`] = `
     data-variant="tertiary"
     type="button"
     value="generelt"
-    id="togglegroup-item-«rd»"
+    id="togglegroup-item-«rv»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«r9»"
+    name="togglegroup-name-«rr»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -449,11 +452,11 @@ exports[`Only Text 1`] = `
     data-variant="tertiary"
     type="button"
     value="tilleggsinformasjon"
-    id="togglegroup-item-«rf»"
+    id="togglegroup-item-«r11»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«r9»"
+    name="togglegroup-name-«rr»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -465,6 +468,7 @@ exports[`Only Text 1`] = `
 exports[`Preview 1`] = `
 <div
   role="radiogroup"
+  data-variant="primary"
   tabindex="0"
 >
   <button
@@ -526,20 +530,151 @@ exports[`Preview 1`] = `
 </div>
 `;
 
+exports[`Primary 1`] = `
+<div
+  role="radiogroup"
+  data-variant="primary"
+  tabindex="0"
+>
+  <button
+    data-variant="primary"
+    type="button"
+    value="innboks"
+    id="togglegroup-item-«rb»"
+    aria-checked="true"
+    aria-current="true"
+    role="radio"
+    name="togglegroup-name-«r9»"
+    data-roving-tabindex-item="true"
+    tabindex="0"
+  >
+    Innboks
+  </button>
+  <button
+    data-variant="tertiary"
+    type="button"
+    value="utkast"
+    id="togglegroup-item-«rd»"
+    aria-checked="false"
+    aria-current="false"
+    role="radio"
+    name="togglegroup-name-«r9»"
+    data-roving-tabindex-item="true"
+    tabindex="-1"
+  >
+    Utkast
+  </button>
+  <button
+    data-variant="tertiary"
+    type="button"
+    value="arkiv"
+    id="togglegroup-item-«rf»"
+    aria-checked="false"
+    aria-current="false"
+    role="radio"
+    name="togglegroup-name-«r9»"
+    data-roving-tabindex-item="true"
+    tabindex="-1"
+  >
+    Arkiv
+  </button>
+  <button
+    data-variant="tertiary"
+    type="button"
+    value="sendt"
+    id="togglegroup-item-«rh»"
+    aria-checked="false"
+    aria-current="false"
+    role="radio"
+    name="togglegroup-name-«r9»"
+    data-roving-tabindex-item="true"
+    tabindex="-1"
+  >
+    Sendt
+  </button>
+</div>
+`;
+
+exports[`Secondary 1`] = `
+<div
+  role="radiogroup"
+  data-variant="secondary"
+  tabindex="0"
+>
+  <button
+    data-variant="secondary"
+    type="button"
+    value="innboks"
+    id="togglegroup-item-«rk»"
+    aria-checked="true"
+    aria-current="true"
+    role="radio"
+    name="togglegroup-name-«ri»"
+    data-roving-tabindex-item="true"
+    tabindex="0"
+  >
+    Innboks
+  </button>
+  <button
+    data-variant="tertiary"
+    type="button"
+    value="utkast"
+    id="togglegroup-item-«rm»"
+    aria-checked="false"
+    aria-current="false"
+    role="radio"
+    name="togglegroup-name-«ri»"
+    data-roving-tabindex-item="true"
+    tabindex="-1"
+  >
+    Utkast
+  </button>
+  <button
+    data-variant="tertiary"
+    type="button"
+    value="arkiv"
+    id="togglegroup-item-«ro»"
+    aria-checked="false"
+    aria-current="false"
+    role="radio"
+    name="togglegroup-name-«ri»"
+    data-roving-tabindex-item="true"
+    tabindex="-1"
+  >
+    Arkiv
+  </button>
+  <button
+    data-variant="tertiary"
+    type="button"
+    value="sendt"
+    id="togglegroup-item-«rq»"
+    aria-checked="false"
+    aria-current="false"
+    role="radio"
+    name="togglegroup-name-«ri»"
+    data-roving-tabindex-item="true"
+    tabindex="-1"
+  >
+    Sendt
+  </button>
+</div>
+`;
+
 exports[`Text And Icons 1`] = `
 <div
   role="radiogroup"
+  data-variant="primary"
   tabindex="0"
 >
   <button
     data-variant="primary"
     type="button"
     value="aktiv"
-    id="togglegroup-item-«ri»"
+    id="togglegroup-item-«r14»"
     aria-checked="true"
     aria-current="true"
     role="radio"
-    name="togglegroup-name-«rg»"
+    name="togglegroup-name-«r12»"
     data-roving-tabindex-item="true"
     tabindex="0"
   >
@@ -567,11 +702,11 @@ exports[`Text And Icons 1`] = `
     data-variant="tertiary"
     type="button"
     value="advarsel"
-    id="togglegroup-item-«rl»"
+    id="togglegroup-item-«r17»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«rg»"
+    name="togglegroup-name-«r12»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -599,11 +734,11 @@ exports[`Text And Icons 1`] = `
     data-variant="tertiary"
     type="button"
     value="kritisk"
-    id="togglegroup-item-«ro»"
+    id="togglegroup-item-«r1a»"
     aria-checked="false"
     aria-current="false"
     role="radio"
-    name="togglegroup-name-«rg»"
+    name="togglegroup-name-«r12»"
     data-roving-tabindex-item="true"
     tabindex="-1"
   >
@@ -637,17 +772,18 @@ exports[`Toggle Group In Color Context 1`] = `
 >
   <div
     role="radiogroup"
+    data-variant="primary"
     tabindex="0"
   >
     <button
       data-variant="primary"
       type="button"
       value="innboks"
-      id="togglegroup-item-«r1p»"
+      id="togglegroup-item-«r2b»"
       aria-checked="true"
       aria-current="true"
       role="radio"
-      name="togglegroup-name-«r1n»"
+      name="togglegroup-name-«r29»"
       data-roving-tabindex-item="true"
       tabindex="0"
     >
@@ -657,11 +793,11 @@ exports[`Toggle Group In Color Context 1`] = `
       data-variant="tertiary"
       type="button"
       value="utkast"
-      id="togglegroup-item-«r1r»"
+      id="togglegroup-item-«r2d»"
       aria-checked="false"
       aria-current="false"
       role="radio"
-      name="togglegroup-name-«r1n»"
+      name="togglegroup-name-«r29»"
       data-roving-tabindex-item="true"
       tabindex="-1"
     >
@@ -671,11 +807,11 @@ exports[`Toggle Group In Color Context 1`] = `
       data-variant="tertiary"
       type="button"
       value="arkiv"
-      id="togglegroup-item-«r1t»"
+      id="togglegroup-item-«r2f»"
       aria-checked="false"
       aria-current="false"
       role="radio"
-      name="togglegroup-name-«r1n»"
+      name="togglegroup-name-«r29»"
       data-roving-tabindex-item="true"
       tabindex="-1"
     >
@@ -685,11 +821,11 @@ exports[`Toggle Group In Color Context 1`] = `
       data-variant="tertiary"
       type="button"
       value="sendt"
-      id="togglegroup-item-«r1v»"
+      id="togglegroup-item-«r2h»"
       aria-checked="false"
       aria-current="false"
       role="radio"
-      name="togglegroup-name-«r1n»"
+      name="togglegroup-name-«r29»"
       data-roving-tabindex-item="true"
       tabindex="-1"
     >

--- a/@udir-design/react/src/demo/dashboard-demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/dashboard-demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -186,6 +186,7 @@ exports[`Dashboard Page 2 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -281,6 +282,7 @@ exports[`Dashboard Page 2 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -756,6 +758,7 @@ exports[`Dashboard Page 3 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -849,6 +852,7 @@ exports[`Dashboard Page 3 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -1324,6 +1328,7 @@ exports[`Dashboard Page 4 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -1419,6 +1424,7 @@ exports[`Dashboard Page 4 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -1895,6 +1901,7 @@ exports[`Dashboard Story 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button
@@ -1990,6 +1997,7 @@ exports[`Dashboard Story 1`] = `
           <div>
             <div
               role="radiogroup"
+              data-variant="primary"
               tabindex="0"
             >
               <button

--- a/@udir-design/theme/dist/types.d.ts
+++ b/@udir-design/theme/dist/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.5.0 */
+/* build: v1.6.0 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/@udir-design/theme/dist/udir.css
+++ b/@udir-design/theme/dist/udir.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 /*
-build: v1.5.0
+build: v1.6.0
 design-tokens: v1.5.0
 */
 
@@ -74,6 +74,19 @@ design-tokens: v1.5.0
   --ds-body-long-md-font-size: var(--ds-font-size-4);
   --ds-body-long-sm-font-size: var(--ds-font-size-3);
   --ds-body-long-xs-font-size: var(--ds-font-size-2);
+
+  @supports (width: round(down, .1em, 1px)) {
+    --ds-font-size-1: round(calc(0.75rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-2: round(calc(0.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-3: round(calc(1rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-4: round(calc(1.125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-5: round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-6: round(calc(1.5rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-7: round(calc(1.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-8: round(calc(2.25rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-9: round(calc(3rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-10: round(calc(3.75rem * var(--_ds-font-size-factor)), 1px);
+  }
 }
 }
 @layer ds.theme.color-scheme.light {

--- a/@udir-design/theme/package.json
+++ b/@udir-design/theme/package.json
@@ -21,7 +21,7 @@
     "./dist"
   ],
   "dependencies": {
-    "@digdir/designsystemet": "1.5.0"
+    "@digdir/designsystemet": "1.6.0"
   },
   "devDependencies": {
     "@internal/build-tools": "workspace:*",

--- a/design-tokens/package.json
+++ b/design-tokens/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf dist"
   },
   "devDependencies": {
-    "@digdir/designsystemet": "1.5.0",
+    "@digdir/designsystemet": "1.6.0",
     "rimraf": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
   '@udir-design/css':
     dependencies:
       '@digdir/designsystemet-css':
-        specifier: 1.5.0
-        version: 1.5.0
+        specifier: 1.6.0
+        version: 1.6.0
       '@udir-design/theme':
         specifier: workspace:*
         version: link:../theme
@@ -172,8 +172,8 @@ importers:
   '@udir-design/react':
     dependencies:
       '@digdir/designsystemet-react':
-        specifier: 1.5.0
-        version: 1.5.0(@types/react@19.1.14)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 1.6.0
+        version: 1.6.0(@types/react@19.1.14)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@navikt/aksel-icons':
         specifier: ^7.31.0
         version: 7.31.0(react@19.1.1)
@@ -332,8 +332,8 @@ importers:
   '@udir-design/theme':
     dependencies:
       '@digdir/designsystemet':
-        specifier: 1.5.0
-        version: 1.5.0
+        specifier: 1.6.0
+        version: 1.6.0
     devDependencies:
       '@internal/build-tools':
         specifier: workspace:*
@@ -348,8 +348,8 @@ importers:
   design-tokens:
     devDependencies:
       '@digdir/designsystemet':
-        specifier: 1.5.0
-        version: 1.5.0
+        specifier: 1.6.0
+        version: 1.6.0
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1203,18 +1203,18 @@ packages:
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
     engines: {node: '>=18'}
 
-  '@digdir/designsystemet-css@1.5.0':
-    resolution: {integrity: sha512-cfDfgTXBru+N9gi8T9PGXEonrbK7sCqKxT21Pv6YijekzDI5bQVjBb2oFFvqzgMbCbsiS+lFqYhOJ8XwvP5Vyw==}
+  '@digdir/designsystemet-css@1.6.0':
+    resolution: {integrity: sha512-I6bT2S4uKxTFEgi+y8/kGIloxMlW/4dKUhBDHi+nqmQFaBW7SK85/+y7xboQdjgmhFdLq9Uu2bfn6K1O/1fatQ==}
 
-  '@digdir/designsystemet-react@1.5.0':
-    resolution: {integrity: sha512-Tsbn9mpFe1t0Su+oOfF0Z18U1xaiYffxp/RcTIWFCr83Ab6wfK/g3egEWRXOCZJTDbqdXvnwzZ07qrz5cFR/XQ==}
+  '@digdir/designsystemet-react@1.6.0':
+    resolution: {integrity: sha512-zaggFLCc64+zrVMcruj7ck5yPvpYx6LT7P7rUfzvSyMHu1vIw0W01YBp6omAv7vJi6qZ7gu1QAFQiADGmditlg==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
 
-  '@digdir/designsystemet@1.5.0':
-    resolution: {integrity: sha512-TsYyqIuyl7fRyfRH1bKKxirrGeriL1uCnCCoY/ZUHY6dq9FsK7DthiB2GAnRv4IiyKSgYwU/LW9yJO+8CR+4Yw==}
-    engines: {node: '>=22.19.0'}
+  '@digdir/designsystemet@1.6.0':
+    resolution: {integrity: sha512-czTQnEndW71HX60uXyRQpMzVv172mLimh8uU9vkilYArhh3O31ea1Pymwn2NIBeqat2/0A1DF/P+SIEcmewNaQ==}
+    engines: {node: '>=20 <25'}
     hasBin: true
 
   '@emnapi/core@1.5.0':
@@ -8064,9 +8064,9 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
 
-  '@digdir/designsystemet-css@1.5.0': {}
+  '@digdir/designsystemet-css@1.6.0': {}
 
-  '@digdir/designsystemet-react@1.5.0(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@digdir/designsystemet-react@1.6.0(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/react': 0.26.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8082,7 +8082,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@digdir/designsystemet-react@1.5.0(@types/react@19.1.14)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@digdir/designsystemet-react@1.6.0(@types/react@19.1.14)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/react': 0.26.23(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -8098,7 +8098,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@digdir/designsystemet@1.5.0':
+  '@digdir/designsystemet@1.6.0':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.1)
       '@tokens-studio/sd-transforms': 1.3.0(style-dictionary@5.0.4)
@@ -9569,7 +9569,7 @@ snapshots:
 
   '@udir-design/react@file:@udir-design/react(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@digdir/designsystemet-react': 1.5.0(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@digdir/designsystemet-react': 1.6.0(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@navikt/aksel-icons': 7.31.0(react@18.3.1)
       '@udir-design/css': link:@udir-design/css
       react: 18.3.1


### PR DESCRIPTION
Notable minor changes:

- **ToggleGroup**: add `variant="secondary"` with a more subdued look

Notable patch changes:

- **Link**: change `:focus-visible` styling to use border, not background
- Font size variables are now rounded to the nearest pixel
- **Spinner**: allow using `aria-hidden` when `aria-label` is set, which can be useful to hide or show the element from the accessibility tree based on some UI state like whether a visual label is also rendered
 - **Field.Counter**: update count when React controls the input
- **Popover**: only call `onClose` when `Popover` is open

See the changelogs:
- [v1.5.1](https://github.com/digdir/designsystemet/releases/tag/v1.5.1)
- [v1.6.0](https://github.com/digdir/designsystemet/releases/tag/v1.6.0)