### PR TITLE
docs: remove extra bottom margin

### DIFF
--- a/@udir-design/react/.storybook/componentOverrides.module.scss
+++ b/@udir-design/react/.storybook/componentOverrides.module.scss
@@ -40,6 +40,20 @@
   }
 }
 
+.list {
+  max-width: 70ch;
+  margin-bottom: var(--ds-size-6);
+
+  & li {
+    margin-top: var(--ds-size-1);
+  }
+}
+
+.paragraph:last-child,
+.list:last-child {
+  margin-bottom: 0;
+}
+
 .code {
   background-color: var(--ds-color-background-tinted);
   font-size: var(--ds-font-size-minus-1);

--- a/@udir-design/react/.storybook/docs-components/SimpleAlert/SimpleAlert.tsx
+++ b/@udir-design/react/.storybook/docs-components/SimpleAlert/SimpleAlert.tsx
@@ -1,5 +1,5 @@
 import { SeverityColors } from '@digdir/designsystemet-react/colors';
-import { Alert, Heading } from '../../../src/alpha';
+import { Alert } from '../../../src/alpha';
 import styles from './SimpleAlert.module.scss';
 
 export const SimpleAlert: React.FC<
@@ -10,15 +10,9 @@ export const SimpleAlert: React.FC<
 > = ({ type, heading, children }) => (
   <Alert data-color={type} className={`sb-unstyled ${styles.simpleAlert}`}>
     {heading && (
-      <Heading
-        asChild
-        data-size="xs"
-        style={{
-          marginBottom: 'var(--ds-size-2)',
-        }}
-      >
+      <Alert.Heading asChild>
         <p>{heading}</p>
-      </Heading>
+      </Alert.Heading>
     )}
     {children}
   </Alert>

--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -92,24 +92,16 @@ export const componentOverrides: MdxComponentOverrides = {
   ol: (props) => (
     <List.Ordered
       {...props}
-      style={{ maxWidth: '70ch', marginBottom: 'var(--ds-size-6)' }}
-      className="sb-unstyled"
+      className={`sb-unstyled ${componentStyles.list}`}
     />
   ),
   ul: (props) => (
     <List.Unordered
       {...props}
-      style={{ maxWidth: '70ch', marginBottom: 'var(--ds-size-6)' }}
-      className="sb-unstyled"
+      className={`sb-unstyled ${componentStyles.list}`}
     />
   ),
-  li: (props) => (
-    <List.Item
-      {...props}
-      className="sb-unstyled"
-      style={{ maxWidth: '70ch', marginTop: 'var(--ds-size-1)' }}
-    />
-  ),
+  li: (props) => <List.Item {...props} className="sb-unstyled" />,
   a: ({ children = '', ...props }) => {
     // if link starts with /, add current path to link
     const href = getPath(props.href);


### PR DESCRIPTION
Noen småjusteringer jeg ikke plukka opp på da det ble lagt til bottom-margins i storybook-tekst:))

<img width="1001" height="481" alt="image" src="https://github.com/user-attachments/assets/5040580c-d5b4-425c-9e1a-9a99c16e752f" />

<img width="995" height="429" alt="image" src="https://github.com/user-attachments/assets/19209cfa-4ed9-4db8-a2dd-da3616cf4905" />
