### PR TITLE
build: ensure Chromatic can detect css-only changes to components

### DIFF
--- a/@udir-design/react/.storybook/main.ts
+++ b/@udir-design/react/.storybook/main.ts
@@ -32,6 +32,7 @@ const config: StorybookConfig = {
 
   async viteFinal(cfg, opts) {
     const { mergeConfig } = await import('vite');
+    process.env['IS_STORYBOOK'] = 'true';
     return mergeConfig(cfg, {
       optimizeDeps: {
         /*

--- a/@udir-design/react/.storybook/style.css
+++ b/@udir-design/react/.storybook/style.css
@@ -1,4 +1,12 @@
-@import '../public/style.css';
+/*
+  We import only the external css, without the component css (../../css/src/index.css)
+  Instead, we let the component css be imported from the component tsx file.
+  This is to ensure that Chromatic can re-snapshot only changed components, by
+  analyzing the imports. E.g:
+    - Table.tsx imports './table.css'
+    - If table.css changes, Table stories must be re-snapshotted
+*/
+@import '../../css/src/external.css';
 
 body {
   font-family: 'Inter', sans-serif;

--- a/@udir-design/react/project.json
+++ b/@udir-design/react/project.json
@@ -8,7 +8,11 @@
   "targets": {
     "dev": {
       "continuous": true,
-      "dependsOn": ["build", "^watch", "lint:cycles"]
+      "dependsOn": [
+        "build",
+        { "projects": "!css", "target": "^watch" },
+        "lint:cycles"
+      ]
     },
     "build:storybook": {
       "inputs": ["default", "^default", "{workspaceRoot}/README.md"],

--- a/@udir-design/react/src/components/alert/Alert.tsx
+++ b/@udir-design/react/src/components/alert/Alert.tsx
@@ -1,2 +1,3 @@
 import { Alert, type AlertProps } from '@digdir/designsystemet-react';
+import './alert.css';
 export { Alert, AlertProps };

--- a/@udir-design/react/src/components/button/Button.tsx
+++ b/@udir-design/react/src/components/button/Button.tsx
@@ -3,6 +3,7 @@ import {
   type ButtonProps as DigdirButtonProps,
 } from '@digdir/designsystemet-react';
 import { ComponentRef, ForwardRefExoticComponent, RefAttributes } from 'react';
+import './button.css';
 
 type ButtonProps = Omit<DigdirButtonProps, 'data-color'> & {
   /**

--- a/@udir-design/react/src/components/dropdown/Dropdown.tsx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.tsx
@@ -14,6 +14,7 @@ import {
   type DropdownButtonProps,
 } from '@digdir/designsystemet-react';
 import { ComponentRef, ForwardRefExoticComponent, RefAttributes } from 'react';
+import './dropdown.css';
 
 type DropdownProps = Omit<DigdirDropdownProps, 'data-color'>;
 

--- a/@udir-design/react/src/components/footer/Footer.tsx
+++ b/@udir-design/react/src/components/footer/Footer.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, forwardRef, HTMLAttributes } from 'react';
 import logo from '../../../assets/img/udir-main-logo.svg';
 import cl from 'clsx/lite';
+import './footer.css';
 
 export type FooterProps = HTMLAttributes<HTMLDivElement> & {
   /**

--- a/@udir-design/react/src/components/header/Header.tsx
+++ b/@udir-design/react/src/components/header/Header.tsx
@@ -5,6 +5,7 @@ import circleLogo from '../../../assets/img/udir-circle-logo.svg';
 import { useScrollDirection } from '../../utilities/useScrollDirection';
 import { Heading } from '../typography';
 import { CSSProperties } from 'react';
+import './header.css';
 
 export type HeaderProps = HTMLAttributes<HTMLElement> & {
   /**

--- a/@udir-design/react/src/components/link/Link.tsx
+++ b/@udir-design/react/src/components/link/Link.tsx
@@ -3,6 +3,7 @@ import {
   type LinkProps as DigdirLinkProps,
 } from '@digdir/designsystemet-react';
 import { ComponentRef, ForwardRefExoticComponent, RefAttributes } from 'react';
+import './link.css';
 
 type LinkProps = Omit<DigdirLinkProps, 'data-color'>;
 

--- a/@udir-design/react/src/components/table/Table.tsx
+++ b/@udir-design/react/src/components/table/Table.tsx
@@ -3,6 +3,7 @@ import {
   type TableProps as DigdirTableProps,
 } from '@digdir/designsystemet-react';
 import { forwardRef, ForwardRefExoticComponent } from 'react';
+import './table.css';
 
 export type TableProps = DigdirTableProps & {
   /**

--- a/@udir-design/react/src/components/tabs/Tabs.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.tsx
@@ -8,6 +8,7 @@ import {
   TabsList,
   type TabsListProps,
 } from '@digdir/designsystemet-react';
+import './tabs.css';
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Tabs.displayName = 'Tabs';

--- a/@udir-design/react/vite.config.ts
+++ b/@udir-design/react/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types='vitest' />
-import { defineConfig } from 'vite';
+import { createFilter, defineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import dts from 'vite-plugin-dts';
 import tsConfigPaths from 'vite-tsconfig-paths';
@@ -40,6 +40,7 @@ export default defineConfig({
   },
 
   plugins: [
+    processComponentCss(),
     react(),
     tsConfigPaths(),
     dts({
@@ -89,3 +90,27 @@ export default defineConfig({
     },
   },
 });
+
+function processComponentCss(): Plugin {
+  const componentBase = '**/@udir-design/react/src/components';
+  const include = `${componentBase}/**/*.css`;
+  const exclude = `${componentBase}/**/*.module.css`;
+  const filter = createFilter(include, exclude);
+
+  return {
+    name: 'udir-process-component-css',
+    transform(code, id) {
+      if (!filter(id)) return;
+
+      const isStorybook = process.env.IS_STORYBOOK === 'true';
+      if (isStorybook) {
+        // Ensure the loaded css is wrapped in a layer, as @udir-design/css/src/index.css does
+        return `@layer udir.components {\n${code}\n}`;
+      } else {
+        // Remove the css from the @udir-design/react bundle by returning an empty string.
+        // Consumers will load it from @udir-design/css instead.
+        return '';
+      }
+    },
+  };
+}


### PR DESCRIPTION
Before this, changing only a component's `.css` file would not trigger a new snapshot for that component's stories in Chromatic. This was because the component css was never imported by the `@udir-design/react` project itself.

We could have added `"../css/dist/**"` to `"externals"` in `chromatic.config.json`, but this would cause **all** components to be re-snapshotted even if we only changed a single component's css.

The new solution ensures that component css is imported from the component file, since storybook now doesn't actually load the bundled `@udir-design/css` styling. Instead, a Vite plugin transforms the `.css` source files so that, when Vite is run by Storybook, the imported styling is included and wrapped in the correct css layer. However, when Vite is **not** run by Storybook, the component `.css` files are stripped from the bundle. They are still included by `@udir-design/css/src/index.css`, as before.

As a bonus, we now don't have to run the css build in watch mode concurrently with Storybook, so the Storybook CLI console gets some more terminal real estate when run through Nx.