### PR TITLE
feat(Icons): allow referencing icon from another svg, useful when not using React

### DIFF
--- a/@udir-design/icons/README.md
+++ b/@udir-design/icons/README.md
@@ -12,7 +12,7 @@ Udirs ikonbibliotek er basert på [navikt/aksel](https://aksel.nav.no/komponente
 npm add @udir-design/icons@beta
 ```
 
-## Ta i bruk
+## Ta i bruk med React
 
 Nå kan du importere og bruke ikoner, for eksempel slik:
 
@@ -29,5 +29,32 @@ function MyComponent() {
   );
 }
 ```
+
+## Ta i bruk uten React
+
+SVG-filene er mulig å importere og bruke fra vanlig HTML dersom du bruker en bundler som kan resolve npm imports.
+
+### Med Parcel som bundler
+
+```css
+/* css */
+
+/* Nødvendig for riktig dimensjoner på ikon. */
+@import 'npm:@udir-design/icons/dist/style.css';
+
+/* Valgfritt: styr ikonets størrelse med font-size. Default er 1em x 1em. */
+.my-icon {
+  font-size: 2rem;
+}
+```
+
+```html
+<!-- html -->
+<svg aria-hidden class="my-icon">
+  <use href="npm:@udir-design/icons/dist/svg/Airplane.svg#root" />
+</svg>
+```
+
+## Dokumentasjon
 
 Oversikt over hvilke ikoner som finnes, og bruksdokumentasjon for disse, finner du [i vår Storybook](https://design.udir.no).

--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -2,8 +2,10 @@
   "name": "@udir-design/icons",
   "version": "0.0.0-semantically-released",
   "scripts": {
-    "copy-icons": "cp -r ./node_modules/@navikt/aksel-icons/dist/svg ./dist/",
-    "build": "tsup src/index.ts src/metadata.ts --format esm,cjs --dts && pnpm copy-icons",
+    "copy-aksel-icons": "svgo --config svgo.config.aksel.mjs -f ./node_modules/@navikt/aksel-icons/dist/svg -o ./dist/svg",
+    "copy-style": "cp src/style.css dist/",
+    "compile": "tsup src/index.ts src/metadata.ts --format esm,cjs --dts",
+    "build": "pnpm compile && pnpm copy-aksel-icons && pnpm copy-style",
     "inject": "pnpm i"
   },
   "repository": {
@@ -19,12 +21,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "default": "./dist/index.js"
-    },
-    "./metadata": {
-      "default": "./dist/metadata.js"
-    },
+    ".": "./dist/index.js",
+    "./metadata": "./dist/metadata.js",
+    "./style.css": "./dist/style.css",
     "./svg/*.svg": "./dist/svg/*.svg"
   },
   "files": [
@@ -34,6 +33,7 @@
     "@navikt/aksel-icons": "catalog:"
   },
   "devDependencies": {
+    "svgo": "catalog:",
     "tsup": "catalog:"
   }
 }

--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0-semantically-released",
   "scripts": {
     "copy-icons": "cp -r ./node_modules/@navikt/aksel-icons/dist/svg ./dist/",
-    "build": "tsup src/index.ts src/metadata.ts --format esm,cjs --dts && pnpm copy-icons"
+    "build": "tsup src/index.ts src/metadata.ts --format esm,cjs --dts && pnpm copy-icons",
+    "inject": "pnpm i"
   },
   "repository": {
     "type": "git",

--- a/@udir-design/icons/src/style.css
+++ b/@udir-design/icons/src/style.css
@@ -1,0 +1,6 @@
+@layer udir.icons {
+  svg:has(use[href$='#root']) {
+    width: 1em;
+    height: 1em;
+  }
+}

--- a/@udir-design/icons/svgo.config.aksel.mjs
+++ b/@udir-design/icons/svgo.config.aksel.mjs
@@ -1,0 +1,19 @@
+/**
+This SVGO config only adds id='root' to the <svg> element, so that it
+can be referenced with
+  <svg><use href="path/to/icon.svg#root></svg>
+
+Otherwise it does no optimizations. We assume that the .svg files from
+@navikt/aksel-icons have already been optimized.
+*/
+
+export default {
+  plugins: [
+    {
+      name: 'addAttributesToSVGElement',
+      params: {
+        attributes: [{ id: 'root' }],
+      },
+    },
+  ],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ catalogs:
     storybook-addon-tag-badges:
       specifier: ^2.0.2
       version: 2.0.2
+    svgo:
+      specifier: ^4.0.0
+      version: 4.0.0
     ts-node:
       specifier: ^10.9.2
       version: 10.9.2
@@ -497,6 +500,9 @@ importers:
         specifier: 'catalog:'
         version: 7.32.1(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
+      svgo:
+        specifier: 'catalog:'
+        version: 4.0.0
       tsup:
         specifier: 'catalog:'
         version: 8.5.0(@microsoft/api-extractor@7.53.1(@types/node@24.7.2))(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
@@ -737,6 +743,9 @@ importers:
       '@udir-design/css':
         specifier: workspace:*
         version: link:../../@udir-design/css
+      '@udir-design/icons':
+        specifier: workspace:*
+        version: link:../../@udir-design/icons
       '@udir-design/theme':
         specifier: workspace:*
         version: link:../../@udir-design/theme

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,7 +333,7 @@ overrides:
   '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
   tmp@<=0.2.3: '>=0.2.4'
 
-packageExtensionsChecksum: sha256-IQSNU9cJtri1P9xMWAvG91nRHacWCj8xtjZCK1etLxM=
+packageExtensionsChecksum: sha256-flIOz4f0q/s3iAtJtNvIIB3eviI1NJv50IqSETROLII=
 
 importers:
 
@@ -495,7 +495,7 @@ importers:
     dependencies:
       '@navikt/aksel-icons':
         specifier: 'catalog:'
-        version: 7.32.1(react@19.2.0)
+        version: 7.32.1(@types/react@19.2.2)(react@19.2.0)
     devDependencies:
       tsup:
         specifier: 'catalog:'
@@ -747,6 +747,9 @@ importers:
 
   test-apps/vite:
     dependencies:
+      '@udir-design/icons':
+        specifier: workspace:*
+        version: file:@udir-design/icons(@types/react@18.3.26)(react@18.3.1)
       '@udir-design/react':
         specifier: workspace:*
         version: file:@udir-design/react(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -760,6 +763,8 @@ importers:
         specifier: catalog:react18
         version: 18.3.1(react@18.3.1)
     dependenciesMeta:
+      '@udir-design/icons':
+        injected: true
       '@udir-design/react':
         injected: true
     devDependencies:
@@ -2061,8 +2066,11 @@ packages:
   '@navikt/aksel-icons@7.32.1':
     resolution: {integrity: sha512-CSu9KU7J8lvlDriTxQK3VXwsZV+fv6zSMi71ausWFP5xmjJKRQkTOHdZpzeOef3bj460LZ+qhsKD8+Eds+tuEQ==}
     peerDependencies:
-      react: '>=18.3.1 || ^19.0.0'
+      '@types/react': ^18.3.11 || ^19.0.0'
+      react: ^18.3.1 || ^19.0.0
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
       react:
         optional: true
 
@@ -3447,6 +3455,9 @@ packages:
 
   '@u-elements/u-details@0.1.5':
     resolution: {integrity: sha512-08sBhbc4u3VFlXIvH//m2yCDBHOJlQigs8QiKVLAVk2hMSg+fcRPggcgeBmtVPuy7iN3u/VURP6G2Ajlfbr6xg==}
+
+  '@udir-design/icons@file:@udir-design/icons':
+    resolution: {directory: '@udir-design/icons', type: directory}
 
   '@udir-design/react@file:@udir-design/react':
     resolution: {directory: '@udir-design/react', type: directory}
@@ -9076,7 +9087,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/react': 0.26.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@navikt/aksel-icons': 7.32.1(react@18.3.1)
+      '@navikt/aksel-icons': 7.32.1(@types/react@18.3.26)(react@18.3.1)
       '@radix-ui/react-slot': 1.2.3(@types/react@18.3.26)(react@18.3.1)
       '@tanstack/react-virtual': 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@u-elements/u-combobox': 1.0.2
@@ -9092,7 +9103,7 @@ snapshots:
     dependencies:
       '@floating-ui/dom': 1.7.4
       '@floating-ui/react': 0.26.23(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@navikt/aksel-icons': 7.32.1(react@19.2.0)
+      '@navikt/aksel-icons': 7.32.1(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
       '@tanstack/react-virtual': 3.13.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@u-elements/u-combobox': 1.0.2
@@ -9568,12 +9579,14 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@navikt/aksel-icons@7.32.1(react@18.3.1)':
+  '@navikt/aksel-icons@7.32.1(@types/react@18.3.26)(react@18.3.1)':
     optionalDependencies:
+      '@types/react': 18.3.26
       react: 18.3.1
 
-  '@navikt/aksel-icons@7.32.1(react@19.2.0)':
+  '@navikt/aksel-icons@7.32.1(@types/react@19.2.2)(react@19.2.0)':
     optionalDependencies:
+      '@types/react': 19.2.2
       react: 19.2.0
 
   '@next/env@14.2.33': {}
@@ -11211,6 +11224,13 @@ snapshots:
   '@u-elements/u-datalist@1.0.14': {}
 
   '@u-elements/u-details@0.1.5': {}
+
+  '@udir-design/icons@file:@udir-design/icons(@types/react@18.3.26)(react@18.3.1)':
+    dependencies:
+      '@navikt/aksel-icons': 7.32.1(@types/react@18.3.26)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
 
   '@udir-design/react@file:@udir-design/react(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -128,8 +128,11 @@ minimumReleaseAgeExclude:
 packageExtensions:
   '@navikt/aksel-icons':
     peerDependencies:
-      react: '>=18.3.1 || ^19.0.0'
+      '@types/react': ^18.3.11 || ^19.0.0'
+      react: '^18.3.1 || ^19.0.0'
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
       react:
         optional: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,6 +93,7 @@ catalog:
   storybook: ^9.1.10
   storybook-addon-pseudo-states: ^9.1.10
   storybook-addon-tag-badges: ^2.0.2
+  svgo: ^4.0.0
   ts-node: ^10.9.2
   tslib: ^2.8.1
   tsup: ^8.5.0

--- a/test-apps/parcel-vanilla/package.json
+++ b/test-apps/parcel-vanilla/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@digdir/designsystemet-css": "catalog:",
     "@udir-design/css": "workspace:*",
+    "@udir-design/icons": "workspace:*",
     "@udir-design/theme": "workspace:*"
   },
   "devDependencies": {

--- a/test-apps/parcel-vanilla/src/index.html
+++ b/test-apps/parcel-vanilla/src/index.html
@@ -16,6 +16,12 @@
     <div class="ds-card uds-prose" data-color="accent" data-variant="tinted">
       <h1 class="ds-heading" data-size="md">Parcel Vanilla App</h1>
       <p>Edit <code>src/index.html</code> to get started!</p>
+      <button type="button" class="ds-button">
+        <svg>
+          <use href="npm:@udir-design/icons/dist/svg/PencilWriting.svg#root" />
+        </svg>
+        Click me
+      </button>
     </div>
   </body>
 </html>

--- a/test-apps/parcel-vanilla/src/index.js
+++ b/test-apps/parcel-vanilla/src/index.js
@@ -1,3 +1,4 @@
 import '@udir-design/theme/dist/index.css';
 import '@digdir/designsystemet-css/dist/src/index.css';
 import '@udir-design/css/dist/components.css';
+import '@udir-design/icons/dist/style.css';

--- a/test-apps/vite/package.json
+++ b/test-apps/vite/package.json
@@ -2,10 +2,12 @@
   "name": "test-app-vite",
   "type": "module",
   "scripts": {
+    "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc --build"
   },
   "dependencies": {
+    "@udir-design/icons": "workspace:*",
     "@udir-design/react": "workspace:*",
     "@udir-design/theme": "workspace:*",
     "react": "catalog:react18",
@@ -21,6 +23,9 @@
     "vitest": "catalog:"
   },
   "dependenciesMeta": {
+    "@udir-design/icons": {
+      "injected": true
+    },
     "@udir-design/react": {
       "injected": true
     }

--- a/test-apps/vite/project.json
+++ b/test-apps/vite/project.json
@@ -5,5 +5,10 @@
   "projectType": "application",
   "tags": [],
   "// targets": "to see all targets run: nx show project test-apps/vite --web",
-  "targets": {}
+  "targets": {
+    "dev": {
+      "continuous": true,
+      "dependsOn": ["^build"]
+    }
+  }
 }

--- a/test-apps/vite/src/app/app.tsx
+++ b/test-apps/vite/src/app/app.tsx
@@ -1,3 +1,4 @@
+import { PencilWritingIcon } from '@udir-design/icons';
 import { Button } from '@udir-design/react/alpha';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import styles from './app.module.scss';
@@ -6,7 +7,10 @@ export function App() {
   return (
     <div>
       <h1>Test app for SPA setup with @udir-design/react</h1>
-      <Button>Click me</Button>
+      <Button>
+        <PencilWritingIcon aria-hidden />
+        Click me
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
E.g.
```html
<svg aria-hidden>
  <use href="path/to/svg#root" />
</svg>
```

See updated icon library README for full details