### PR TITLE
fix: export prose from alpha

### DIFF
--- a/@udir-design/react/src/components/alpha.ts
+++ b/@udir-design/react/src/components/alpha.ts
@@ -4,6 +4,7 @@
 
 export * from './footer';
 export * from './header';
+export * from './typography/prose/Prose';
 export * from './suggestion/Suggestion';
 export * from './switch/Switch';
 export * from './tableOfContents/TableOfContents';


### PR DESCRIPTION
Prose ble ikke med da `export * from ./typography` ble dratt ut til enkeltkomponenter en stund tilbake, legger den i alpha siden den er merka som det 