### PR TITLE
docs: import accessibility module for highcharts

### DIFF
--- a/@udir-design/react/src/demo/dashboard-demo/DashboardDemo.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/DashboardDemo.tsx
@@ -22,6 +22,7 @@ export const DashboardDemo = ({
       {...props}
       className={cl(classes.card, classes.container)}
       data-size="auto"
+      lang="nb"
     >
       <Heading level={1} data-size="md">
         Schweigaardsgate skole

--- a/@udir-design/react/src/demo/dashboard-demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/dashboard-demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -4,6 +4,7 @@ exports[`Dashboard Page 2 1`] = `
 <div
   data-color-scheme="light"
   data-size="auto"
+  lang="nb"
 >
   <h1 data-size="md">
     Schweigaardsgate skole
@@ -577,6 +578,7 @@ exports[`Dashboard Page 3 1`] = `
 <div
   data-color-scheme="light"
   data-size="auto"
+  lang="nb"
 >
   <h1 data-size="md">
     Schweigaardsgate skole
@@ -1150,6 +1152,7 @@ exports[`Dashboard Page 4 1`] = `
 <div
   data-color-scheme="light"
   data-size="auto"
+  lang="nb"
 >
   <h1 data-size="md">
     Schweigaardsgate skole
@@ -1724,6 +1727,7 @@ exports[`Dashboard Story 1`] = `
 <div
   data-color-scheme="light"
   data-size="auto"
+  lang="nb"
 >
   <h1 data-size="md">
     Schweigaardsgate skole

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/overview/Overview.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/overview/Overview.tsx
@@ -1,4 +1,5 @@
 import * as Highcharts from 'highcharts';
+import 'highcharts/modules/accessibility';
 import { HighchartsReact } from 'highcharts-react-official';
 import { useEffect, useRef, useState } from 'react';
 import { Table } from 'src/components/table';
@@ -21,7 +22,9 @@ const differenceData = testOverview.map((item) => item.sent - item.received);
 
 const options: Highcharts.Options = {
   title: {
-    text: '',
+    text: 'Prøveoversikt',
+    // hide title but keep for accessibility
+    style: { display: 'none' },
   },
   colors: [
     '#5BA27E',
@@ -43,7 +46,7 @@ const options: Highcharts.Options = {
   yAxis: {
     min: 0,
     title: {
-      text: 'Antall',
+      text: 'Antall prøver',
     },
   },
   series: [
@@ -65,6 +68,10 @@ const options: Highcharts.Options = {
   ],
   tooltip: {
     pointFormat: '{series.name}: <b>{point.y}</b>',
+  },
+  accessibility: {
+    description:
+      'Søylediagram som viser antall utsendte prøver, mottatte prøvesvar og antall som ikke har svart for årene 2022, 2023 og 2024.',
   },
 };
 

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/overview/Overview.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/overview/Overview.tsx
@@ -1,5 +1,6 @@
 import * as Highcharts from 'highcharts';
 import 'highcharts/modules/accessibility';
+import 'highcharts/i18n/nb-NO';
 import { HighchartsReact } from 'highcharts-react-official';
 import { useEffect, useRef, useState } from 'react';
 import { Table } from 'src/components/table';

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/overview/Overview.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/overview/Overview.tsx
@@ -43,6 +43,7 @@ const options: Highcharts.Options = {
   },
   xAxis: {
     categories: categories,
+    title: { text: 'Årstall' },
   },
   yAxis: {
     min: 0,
@@ -71,8 +72,9 @@ const options: Highcharts.Options = {
     pointFormat: '{series.name}: <b>{point.y}</b>',
   },
   accessibility: {
+    typeDescription: 'Stolpe- og linjediagram',
     description:
-      'Søylediagram som viser antall utsendte prøver, mottatte prøvesvar og antall som ikke har svart for årene 2022, 2023 og 2024.',
+      'Diagrammet viser antall utsendte prøver, mottatte prøvesvar og antall som ikke har svart for årene 2022, 2023 og 2024.',
   },
 };
 

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/test-answers/TestAnswers.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/test-answers/TestAnswers.tsx
@@ -16,7 +16,7 @@ const characterDistribution = [
   { name: '1', value: 90 },
 ];
 
-const options = {
+const options: Highcharts.Options = {
   title: {
     text: 'Karakterfordeling',
     // hide title but keep for accessibility
@@ -36,21 +36,19 @@ const options = {
     type: 'pie',
     style: { fontFamily: 'Inter, sans-serif' },
   },
-  plotOptions: {
-    pie: {
+  series: [
+    {
+      name: 'Antall prøvesvar',
+      type: 'pie',
       cursor: 'pointer',
       dataLabels: {
         enabled: true,
         format: 'Karakter {point.name}',
         style: {
-          fontWeight: 500,
+          fontWeight: '500',
         },
       },
-    },
-  },
-  series: [
-    {
-      name: 'Antall prøvesvar',
+
       data: characterDistribution.map((item) => ({
         name: item.name,
         y: item.value,
@@ -59,8 +57,9 @@ const options = {
     },
   ],
   accessibility: {
+    typeDescription: 'Sektordiagram',
     description:
-      'Sektordiagram som viser fordeling av prøvesvar med antall per karakter fra 1 til 6.',
+      'Diagrammet viser fordeling av prøvesvar med antall per karakter fra 1 til 6.',
   },
 };
 

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/test-answers/TestAnswers.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/test-answers/TestAnswers.tsx
@@ -50,7 +50,7 @@ const options = {
   },
   series: [
     {
-      name: 'Antall',
+      name: 'Antall prøvesvar',
       data: characterDistribution.map((item) => ({
         name: item.name,
         y: item.value,
@@ -58,6 +58,10 @@ const options = {
       })),
     },
   ],
+  accessibility: {
+    description:
+      'Sektordiagram som viser fordeling av prøvesvar med antall per karakter fra 1 til 6.',
+  },
 };
 
 export const TestAnswers = (props: HighchartsReact.Props) => {

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/tests/Tests.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/tests/Tests.tsx
@@ -70,6 +70,10 @@ const options = {
       })),
     },
   ],
+  accessibility: {
+    description:
+      'Sektordiagram som viser fordeling av prøver med antall utsendte og påbegynte prøver.',
+  },
 };
 
 export const Tests = (props: HighchartsReact.Props) => {

--- a/@udir-design/react/src/demo/dashboard-demo/tabs/tests/Tests.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/tabs/tests/Tests.tsx
@@ -12,8 +12,9 @@ const tests = [
   { name: 'Utsendte', value: 3500 },
   { name: 'Påbegynte', value: 2000 },
 ];
+const total = tests.map((x) => x.value).reduce((x, y) => x + y);
 
-const options = {
+const options: Highcharts.Options = {
   title: {
     text: 'Prøver',
     // hide title but keep for accessibility
@@ -33,18 +34,19 @@ const options = {
     type: 'pie',
     style: { fontFamily: 'Inter, sans-serif' },
   },
-  plotOptions: {
-    pie: {
+  series: [
+    {
+      name: 'Antall',
+      type: 'pie',
+      innerSize: '75%',
       cursor: 'pointer',
-    },
-    series: {
       dataLabels: [
         {
           enabled: true,
           distance: 10,
           format: '{point.name}: {point.y}',
           style: {
-            fontWeight: 500,
+            fontWeight: '500',
           },
         },
         {
@@ -57,22 +59,24 @@ const options = {
           },
         },
       ],
-    },
-  },
-  series: [
-    {
-      innerSize: '75%',
-      name: 'Antall',
-      data: tests.map((item) => ({
-        name: item.name,
-        y: item.value,
-        selected: true,
-      })),
+
+      data: tests.map(
+        (item): Highcharts.PointOptionsObject => ({
+          name: item.name,
+          y: item.value,
+          selected: true,
+          accessibility: {
+            // Adds percentage readout for screen readers, since we have it visually
+            description: `${Math.round((item.value / total) * 100)}%`,
+          },
+        }),
+      ),
     },
   ],
   accessibility: {
+    typeDescription: 'Sektordiagram',
     description:
-      'Sektordiagram som viser fordeling av prøver med antall utsendte og påbegynte prøver.',
+      'Diagrammet viser fordeling av prøver med antall utsendte og påbegynte prøver.',
   },
 };
 


### PR DESCRIPTION
~Nå er det engelsk i screenreader inne på highcharts-figurene. Det er mulig å oversette manuelt gjennom options, men vet ikke hvor mye tid vi skal bruke på det.~

Edit: fiksa med [Highcharts language-modul for bokmål](https://www.highcharts.com/docs/advanced-chart-features/internationalization#language-modules-preview) + `lang="nb"` attributt i html