### PR TITLE
feat: tag in header

### DIFF
--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -116,6 +116,12 @@ Navigasjonslenker og meny er de eneste navigasjonselementene som kan kombineres 
   of={HeaderStories.WithNavigationLinksAndMenu}
 />
 
+### Utviklingsmiljø
+
+Bruk `Tag` til å indikere at en tjeneste vises i et annet kjøretidsmiljø enn produksjon, f.eks. dev, test eller qa. Den skal alltid ligge som første element og vil da automatisk legges til venstre, inntil logo.
+
+<Canvas story={{ inline: false, height: '150px' }} of={HeaderStories.WithTag} />
+
 ### Responsivt innhold
 
 For å håndtere ulike skjermstørrelser og enheter er det satt opp noen predefinerte breakpoints for når innhold skal vises eller skjules. Dette brukes ved å sette `data-show=[size]` eller `data-hide=[size]` på komponentene du legger inn i `Header`. De tilgjengelige verdiene for `size` er:

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -10,6 +10,7 @@ import { Dropdown } from '../dropdown/Dropdown';
 import { Link } from '../link/Link';
 import { List } from '../list/List';
 import { Search } from '../search/Search';
+import { Tag } from '../tag/Tag';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 import styles from './header.stories.module.css';
@@ -548,6 +549,16 @@ const responsiveLinks = ['Navlinker', 'Overskrift 1', 'Overskrift 2'].map(
     ),
   }),
 );
+
+export const WithTag: Story = {
+  render(args) {
+    return (
+      <Header {...args}>
+        <Tag data-color="accent">Dev</Tag>
+      </Header>
+    );
+  },
+};
 
 export const Responsive: Story = {
   render(args) {

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -3032,6 +3032,39 @@ exports[`With Search 1`] = `
 </div>
 `;
 
+exports[`With Tag 1`] = `
+<div data-size="auto">
+  <header
+    data-scroll-direction="up"
+    style="--udsc-header-max-width: 80rem;"
+  >
+    <div>
+      <a href="/">
+        <img
+          alt
+          src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-3&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-2&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+        >
+        <img
+          alt
+          src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-2&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-3&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+        >
+        <span data-size="xs">
+          Tjenestenavn
+        </span>
+      </a>
+      <div>
+        <span
+          data-variant="default"
+          data-color="accent"
+        >
+          Dev
+        </span>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
 exports[`With Theme Menus 1`] = `
 <div data-size="auto">
   <header

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -50,6 +50,12 @@
     display: flex;
     gap: var(--ds-size-8);
     align-items: center;
+    width: 100%;
+    justify-content: flex-end;
+
+    > .ds-tag {
+      margin-right: auto;
+    }
   }
 
   .uds-header__search {


### PR DESCRIPTION
Lagt til en styling for `Tag` i `Header`, og oppdatert dokumentasjonen med informasjon om at hensikten med dette er at det kan brukes til å spesifisere kjøretidsmiljø. 