### PR TITLE
fix: header feedback

### DIFF
--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -47,10 +47,10 @@ Subkomponenter:
 
 ### Brukerprofil
 
-Subkomponenten `Header.UserButton` viser brukerinformasjon og kan knyttes til en meny med brukerrelaterte handlinger. Den har props for brukernavn, rolle og avatar og finnes i fargene `neutral` og `accent`. I eksempelet brukes [`Dropdown`](/docs/components-dropdown--docs) som brukermeny.
+Subkomponenten `Header.UserButton` viser brukerinformasjon og kan knyttes til en meny med brukerrelaterte handlinger. Den har props for navn, beskrivelse og avatar og finnes i fargene `neutral` og `accent`. I eksempelet brukes [`Dropdown`](/docs/components-dropdown--docs) som brukermeny.
 På mindre skjermer flytter du enten `Header.UserButton` inn i `Header.Menu`, eller bytter ut `Header.UserButton` med en [`Avatar`](/docs/components-avatar--docs) som knapp. Du kan også benytte `Avatar` som en knapp på større skjermer dersom det blir trangt med andre elementer i Header.
 
-`Header.UserButton` har en maksbredde på `16rem`. Hvis brukernavnet er lengre enn dette, vil det bli avkortet med ellipse (`...`). Vi anbefaler å korte ned lange brukernavn for å unngå dette, for eksempel ved å ekskludere mellomnavn.
+`Header.UserButton` har en maksbredde på `16rem`. Hvis navnet er lengre enn knappen, vil det bli avkortet med ellipse (`...`). Vi anbefaler å korte ned lange navn for å unngå dette, for eksempel ved å ekskludere mellomnavn.
 
 <Canvas
   story={{ inline: false, height: '350px' }}

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -42,7 +42,7 @@ Subkomponenter:
 - `Header.Search`
 - `Header.Navigation` med `Header.Navigation.Item`
 - `Header.MenuButton`
-- `Header.Menu`
+- `Header.Menu` med `Header.Menu.Link`
 - `Header.ThemeMenuButton`
 
 ### Brukerprofil
@@ -87,7 +87,7 @@ Unngå å bruke for mange lenker, og vurder om noen av lenkene heller kan plasse
 
 `Header.MenuButton` og `Header.Menu` brukes sammen for å lage en meny. Menyen inneholder som regel navigasjon, men kan også inneholde andre handlinger. På mindre skjermer flytter du for eksempel navigasjonslenker og brukerprofil inn i menyen.
 
-`Header.MenuButton` er en [`Button`](/docs/components-button--docs) med åpne/lukke-ikon. Teksten kan tilpasses ved bruk av `children`. `Header.Menu` er en stor nedtrekksmeny som er basert på [`Popover`](/docs/components-popover--docs).
+`Header.MenuButton` er en [`Button`](/docs/components-button--docs) med åpne/lukke-ikon. Teksten kan tilpasses ved bruk av `children`. `Header.Menu` er en stor nedtrekksmeny som er basert på [`Popover`](/docs/components-popover--docs). Bruk `Header.Menu.Link` for lenker i menyen. Merk at lenkene legges i en [`List`](/docs/components-list--docs), men skal ikke pakkes inn i en `List.Item`.
 
 Eksempelet under viser hvordan du kan sette opp en meny med navigasjon. Her ser du også at overskrifter kan fungere som lenker.
 
@@ -263,7 +263,7 @@ Bruk [`<nav>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Eleme
   <h2 id="header-menu-navigation" className="ds-sr-only">
     Menynavigasjon
   </h2>
-  <ListUnordered>{/* liste med lenker */}</ListUnordered>
+  <List.Unordered>{/* liste med lenker */}</List.Unordered>
 </nav>
 ```
 

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -50,6 +50,8 @@ Subkomponenter:
 Subkomponenten `Header.UserButton` viser brukerinformasjon og kan knyttes til en meny med brukerrelaterte handlinger. Den har props for brukernavn, rolle og avatar og finnes i fargene `neutral` og `accent`. I eksempelet brukes [`Dropdown`](/docs/components-dropdown--docs) som brukermeny.
 På mindre skjermer flytter du enten `Header.UserButton` inn i `Header.Menu`, eller bytter ut `Header.UserButton` med en [`Avatar`](/docs/components-avatar--docs) som knapp. Du kan også benytte `Avatar` som en knapp på større skjermer dersom det blir trangt med andre elementer i Header.
 
+`Header.UserButton` har en maksbredde på `16rem`. Hvis brukernavnet er lengre enn dette, vil det bli avkortet med ellipse (`...`). Vi anbefaler å korte ned lange brukernavn for å unngå dette, for eksempel ved å ekskludere mellomnavn.
+
 <Canvas
   story={{ inline: false, height: '350px' }}
   of={HeaderStories.WithUserButton}

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -89,7 +89,7 @@ Unngå å bruke for mange lenker, og vurder om noen av lenkene heller kan plasse
 
 `Header.MenuButton` og `Header.Menu` brukes sammen for å lage en meny. Menyen inneholder som regel navigasjon, men kan også inneholde andre handlinger. På mindre skjermer flytter du for eksempel navigasjonslenker og brukerprofil inn i menyen.
 
-`Header.MenuButton` er en [`Button`](/docs/components-button--docs) med åpne/lukke-ikon. Teksten kan tilpasses ved bruk av `children`. `Header.Menu` er en stor nedtrekksmeny som er basert på [`Popover`](/docs/components-popover--docs). Bruk `Header.Menu.Link` for lenker i menyen. Merk at lenkene legges i en [`List`](/docs/components-list--docs), men skal ikke pakkes inn i en `List.Item`.
+`Header.MenuButton` er en [`Button`](/docs/components-button--docs) med åpne/lukke-ikon. Teksten kan tilpasses ved bruk av `children`. `Header.Menu` er en stor nedtrekksmeny som er basert på [`Popover`](/docs/components-popover--docs). Bruk `Header.Menu.Link` for lenker i menyen. Merk at lenkene legges i en [`List`](/docs/components-list--docs), men hver enkelt lenke skal ikke pakkes inn i en `List.Item`.
 
 Eksempelet under viser hvordan du kan sette opp en meny med navigasjon. Her ser du også at overskrifter kan fungere som lenker.
 

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -50,8 +50,8 @@ export const WithUserButton: Story = {
   render: (args) => (
     <Header {...args}>
       <Header.UserButton
-        username="Stian Hansen"
-        userRole="Admin"
+        name="Stian Hansen"
+        description="Admin"
         popovertarget="usermenu"
         avatar={
           <Avatar aria-hidden>
@@ -561,8 +561,8 @@ export const Responsive: Story = {
           <Header.Navigation.Item href="#">Navlink 3</Header.Navigation.Item>
         </Header.Navigation>
         <Header.UserButton
-          username="Stian Hansen"
-          userRole="Admin"
+          name="Stian Hansen"
+          description="Admin"
           popovertarget="usermenu2"
           data-show="md"
           avatar={<Avatar aria-hidden>SH</Avatar>}
@@ -592,8 +592,8 @@ export const Responsive: Story = {
         <Header.MenuButton />
         <Header.Menu>
           <Header.UserButton
-            username="Stian Hansen"
-            userRole="Admin"
+            name="Stian Hansen"
+            description="Admin"
             popovertarget="usermenuInMenu"
             avatar={<Avatar aria-hidden>SH</Avatar>}
             data-hide="md"

--- a/@udir-design/react/src/components/header/HeaderUserButton.tsx
+++ b/@udir-design/react/src/components/header/HeaderUserButton.tsx
@@ -48,7 +48,7 @@ export const HeaderUserButton = forwardRef<
       {...rest}
     >
       <div>
-        <Heading data-size="2xs" level={3}>
+        <Heading data-size="2xs" level={3} title={username}>
           {username}
         </Heading>
         {userRole && <Paragraph data-size="xs">{userRole}</Paragraph>}

--- a/@udir-design/react/src/components/header/HeaderUserButton.tsx
+++ b/@udir-design/react/src/components/header/HeaderUserButton.tsx
@@ -7,13 +7,13 @@ import { Paragraph } from '../typography/paragraph/Paragraph';
 
 export type HeaderUserButtonProps = HTMLAttributes<HTMLButtonElement> & {
   /**
-   * The username of the logged in user.
+   * The name of the logged in user.
    */
-  username: string;
+  name: string;
   /**
-   * The role of the logged in user.
+   * Description of the logged in user, e.g. user role.
    */
-  userRole?: string;
+  description?: string;
   /**
    * The avatar of the logged in user. Use <Avatar /> component.
    */
@@ -30,8 +30,8 @@ export const HeaderUserButton = forwardRef<
   Omit<HeaderUserButtonProps, 'children'>
 >(function HeaderUserButton(
   {
-    username,
-    userRole,
+    name,
+    description,
     className,
     avatar,
     'data-color': dataColor = 'neutral',
@@ -48,10 +48,10 @@ export const HeaderUserButton = forwardRef<
       {...rest}
     >
       <div>
-        <Heading data-size="2xs" level={3} title={username}>
-          {username}
+        <Heading data-size="2xs" level={3} title={name}>
+          {name}
         </Heading>
-        {userRole && <Paragraph data-size="xs">{userRole}</Paragraph>}
+        {description && <Paragraph data-size="xs">{description}</Paragraph>}
       </div>
       {avatar && avatar}
       <ChevronDownIcon aria-hidden />

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -522,7 +522,10 @@ exports[`Responsive 1`] = `
           data-show="md"
         >
           <div>
-            <h3 data-size="2xs">
+            <h3
+              data-size="2xs"
+              title="Stian Hansen"
+            >
               Stian Hansen
             </h3>
             <p
@@ -709,7 +712,10 @@ exports[`Responsive 1`] = `
             style="width: stretch; margin: 0 var(--ds-size-5);"
           >
             <div>
-              <h3 data-size="2xs">
+              <h3
+                data-size="2xs"
+                title="Stian Hansen"
+              >
                 Stian Hansen
               </h3>
               <p
@@ -4073,7 +4079,10 @@ exports[`With User Button 1`] = `
           data-show="sm"
         >
           <div>
-            <h3 data-size="2xs">
+            <h3
+              data-size="2xs"
+              title="Stian Hansen"
+            >
               Stian Hansen
             </h3>
             <p

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -165,6 +165,7 @@
     all: unset;
     display: flex;
     width: fit-content;
+    max-width: 16rem;
     flex-shrink: 0;
     align-items: center;
     justify-content: flex-end;
@@ -191,10 +192,19 @@
       display: flex;
       flex-direction: column;
       align-items: flex-end;
+      min-width: 0;
+      .ds-heading,
+      .ds-paragraph {
+        max-width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
 
     > svg {
       margin-left: var(--ds-size-1);
+      flex-shrink: 0;
     }
 
     > svg:nth-last-child(2) {

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -256,7 +256,7 @@
     top: 0;
     transition: transform 200ms ease;
   }
-  &[data-scroll-direction='down'] {
+  &[data-scroll-direction='down']:not(:has([popover]:popover-open)) {
     transform: translateY(
       calc(-1 * var(--udsc-header-height) - (var(--udsc-header-padding) * 2))
     );

--- a/@udir-design/react/src/components/header/headerMenu/HeaderMenu.tsx
+++ b/@udir-design/react/src/components/header/headerMenu/HeaderMenu.tsx
@@ -1,5 +1,5 @@
 import cl from 'clsx/lite';
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import type { PopoverProps } from '../../popover/Popover';
 import { Popover } from '../../popover/Popover';
 
@@ -9,14 +9,61 @@ export type HeaderMenuProps = Omit<
 >;
 
 export const HeaderMenu = forwardRef<HTMLDivElement, HeaderMenuProps>(
-  function HeaderMenu({ children, className, ...rest }, ref) {
+  function HeaderMenu(
+    {
+      id = 'uds-header-menu',
+      open: openProp,
+      onOpen,
+      onClose,
+      onBlurCapture,
+      children,
+      className,
+      ...rest
+    },
+    ref,
+  ) {
+    const [internalOpen, setInternalOpen] = useState(false);
+    const isControlled = openProp !== undefined;
+    const open = isControlled ? !!openProp : internalOpen;
+
+    const toggleInternal = () => {
+      if (!isControlled) {
+        setInternalOpen((prev) => !prev);
+      }
+    };
+    const closeInternal = () => {
+      if (!isControlled) {
+        setInternalOpen(false);
+      }
+    };
+
     return (
       <Popover
-        id="uds-header-menu"
+        id={id}
         className={cl('uds-header__menu', className)}
         popover="auto"
         placement="bottom-end"
         ref={ref}
+        open={open}
+        onOpen={() => {
+          toggleInternal();
+          onOpen?.();
+        }}
+        onClose={() => {
+          closeInternal();
+          onClose?.();
+        }}
+        onBlurCapture={(e) => {
+          onBlurCapture?.(e);
+          if (e.defaultPrevented) return;
+          const pop = e.currentTarget as HTMLDivElement;
+          const next = e.relatedTarget as Element | null;
+          // Ignore blur when focus goes to the trigger button
+          if (next?.closest(`[popovertarget="${id}"]`)) return;
+          if (!next || !pop.contains(next)) {
+            closeInternal();
+          }
+        }}
         {...rest}
       >
         {children}


### PR DESCRIPTION
- Dokumentasjon om Header.Menu.Link
- Lukk Header.Menu når den mister fokus (tabber seg gjennom innholdet).
- Vis header når man åpner menyen når den vanligvis er skjult på grunn av scrolling (ha fokus på menyknappen, scroll så menyen forsvinner, trykk enter).
- Trunkere tekst på Header.Userbutton + dokumentasjon om at man burde fikse lengde på brukernavn selv.