### PR TITLE
docs: add beta-version patterns

### DIFF
--- a/@udir-design/react/.storybook/docs/components/Origin.tsx
+++ b/@udir-design/react/.storybook/docs/components/Origin.tsx
@@ -7,16 +7,8 @@ export interface OriginProps extends ComponentOrigin {
   component: string;
 }
 
-export function OriginText({
-  component,
-  originator,
-  details,
-  demo,
-}: OriginProps) {
-  const digdirText = demo
-    ? ' er basert på et eksempel fra Digdir.'
-    : ' bygger på en komponent fra Digdirs designsystem.';
-  const selfText = ' er egenutviklet.';
+export function OriginText({ component, originator, details }: OriginProps) {
+  const digdirText = ' bygger på arbeid gjort i Digdirs designsystem.';
   const navText = (
     <div style={{ display: 'inline' }}>
       {' bygger på '}
@@ -26,6 +18,7 @@ export function OriginText({
       .
     </div>
   );
+  const selfText = ' er utarbeidet av Udir.';
   const baseText =
     originator === 'digdir'
       ? digdirText

--- a/@udir-design/react/.storybook/manager.tsx
+++ b/@udir-design/react/.storybook/manager.tsx
@@ -8,6 +8,7 @@ import {
 import {
   ComponentIcon,
   ImageIcon,
+  LayersIcon,
   RectangleSectionsIcon,
   WrenchIcon,
 } from '@udir-design/icons';
@@ -59,6 +60,14 @@ addons.setConfig({
             <>
               <RectangleSectionsIcon aria-hidden fontSize={18} />
               Demosider
+            </>
+          );
+        }
+        if (item.id === 'bruksmønstre') {
+          return (
+            <>
+              <LayersIcon aria-hidden fontSize={18} />
+              Bruksmønstre
             </>
           );
         }

--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -34,6 +34,8 @@ const preview: Preview = {
           'iconsandsymbols',
           ['Retningslinjer', 'Ikoner'],
           'demo',
+          'bruksmønstre',
+          ['Introduksjon', '*'],
           'components',
         ],
       },

--- a/@udir-design/react/.storybook/types/parameters.ts
+++ b/@udir-design/react/.storybook/types/parameters.ts
@@ -56,7 +56,6 @@ type DocsSourceParams = Partial<Omit<SourceBlockParameters, 'transform'>> & {
 export type ComponentOrigin = {
   originator: 'self' | 'digdir' | 'nav';
   details?: string;
-  demo?: boolean;
 };
 export type ComponentOriginParameters = {
   componentOrigin: ComponentOrigin;

--- a/@udir-design/react/src/demo/dashboard-demo/DashboardDemo.stories.tsx
+++ b/@udir-design/react/src/demo/dashboard-demo/DashboardDemo.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof DashboardDemo> = {
     ...demoParameters,
     componentOrigin: {
       originator: 'self',
-      demo: true,
     },
   },
 };

--- a/@udir-design/react/src/demo/form-demo/FormDemo.stories.tsx
+++ b/@udir-design/react/src/demo/form-demo/FormDemo.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof FormDemo> = {
     ...demoParameters,
     componentOrigin: {
       originator: 'self',
-      demo: true,
     },
     a11y: {
       config: {

--- a/@udir-design/react/src/demo/page-demo/DemoPage.stories.tsx
+++ b/@udir-design/react/src/demo/page-demo/DemoPage.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof DemoPage> = {
     ...demoParameters,
     componentOrigin: {
       originator: 'digdir',
-      demo: true,
     },
   },
 };

--- a/@udir-design/react/src/demo/table-demo/TableDemo.stories.tsx
+++ b/@udir-design/react/src/demo/table-demo/TableDemo.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof TableDemo> = {
     ...demoParameters,
     componentOrigin: {
       originator: 'self',
-      demo: true,
     },
   },
 };

--- a/@udir-design/react/src/patterns/Feilmeldinger.mdx
+++ b/@udir-design/react/src/patterns/Feilmeldinger.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="bruksmønstre/Feilmeldinger" tags={['beta']} />
+
+# Brukerutløste feilmeldinger
+
+Dette bruksmønsteret handler om brukerutløste feilmeldinger i selvbetjeningsløsninger og skjema. Hvordan kan vi unngå å gi feilmeldinger, og hvordan kan vi hjelpe brukerne å komme seg videre når det likevel har oppstått en feil?
+
+Udir følger [Digdirs mønster for brukerutløste feilmeldinger](https://designsystemet.no/no/patterns/errors).

--- a/@udir-design/react/src/patterns/Introduksjon.mdx
+++ b/@udir-design/react/src/patterns/Introduksjon.mdx
@@ -1,0 +1,15 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="bruksmønstre/Introduksjon" />
+
+# Bruksmønstre
+
+Et bruksmønster handler om hvordan flere komponenter settes sammen for å støtte en bestemt brukerflyt. Et bruksmønster tar utgangspunkt i hvordan brukeren opplever det å fullføre en oppgave. Det kan omfatte visuelt uttrykk, tekstinnhold, interaksjon og universell utforming.
+
+Om man klarer å etablere felles mønstre blir det lettere for en bruker å kjenne igjen og forstå hvordan det funker et annet sted. Derfor følger Udir Digdirs bruksmønstre, og supplerer med egne. Disse er resultat av et tverretatlig samarbeid og bidrar til å inkludere flere digitalt.
+
+Felles mønstre kan blant annet bidra til at
+
+- interaksjon og oppførsel på elementer blir gjenkjennelig på tvers
+- plassering av sentrale elementer stemmer med brukerens forventninger
+- gjentagende brukeroppgaver oppleves gjenkjennelig

--- a/@udir-design/react/src/patterns/MerkingAvLenker.mdx
+++ b/@udir-design/react/src/patterns/MerkingAvLenker.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="bruksmønstre/Merking av lenker" tags={['beta']} />
+
+# Merking av lenker
+
+Lenker er en viktig del av navigasjonen på nett, og måten vi merker dem på påvirker brukeropplevelsen. Bruksmønsteret tar for seg hvordan vi bør merke lenker og hvilke språk- og designprinsipper vi bør følge.
+
+Udir følger [Digdirs bruksmønster for merking av lenker](https://designsystemet.no/no/patterns/external-links).

--- a/@udir-design/react/src/patterns/systemvarsler.mdx
+++ b/@udir-design/react/src/patterns/systemvarsler.mdx
@@ -1,0 +1,9 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="bruksmønstre/Systemvarsler" tags={['beta']} />
+
+# Systemvarsler
+
+Systemvarsler informerer brukerne om feil i systemet, eller viktige hendelser de bør være oppmerksomme på.
+
+Udir følger [Digdirs bruksmønster for systemvarsler](https://designsystemet.no/no/patterns/systemnotifications).


### PR DESCRIPTION
- Lagt til egen kategori for bruksmønstre med introduksjonsside 
- Lagt til side for systemvarsler, merking av lenker og feilmeldinger som lenker til digdir
- Gjort om på OriginText til å være mer generell siden vi hele tiden legger til nye ting og tenker dette er mindre vedlikehold 
  - Fremfor f.eks. `demo: boolean` for hver ny type dokumentasjon vi legger til:) 

## Spørsmål
- Vil vi har `Origin` for bruksmønstersidene? Tenker at det er ryddig for å være konsistent, men at det ser litt overflødig ut når man enn så lenge bare har typ to setninger på siden uansett som sier at det er et mønster fra Digdir, så klarer ikke bestemme meg 🤷🏻‍♀️ 