### PR TITLE
build: use devEngines.packageManager field to prevent use of npm

### DIFF
--- a/@internal/build-tools/package.json
+++ b/@internal/build-tools/package.json
@@ -9,5 +9,11 @@
     "micromatch": "catalog:",
     "tsx": "catalog:",
     "yargs": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/@udir-design/css/package.json
+++ b/@udir-design/css/package.json
@@ -34,5 +34,11 @@
   "scripts": {
     "build": "postcss src/*.css --dir dist/",
     "watch": "pnpm build --watch"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -35,5 +35,11 @@
   "devDependencies": {
     "svgo": "catalog:",
     "tsup": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -115,5 +115,11 @@
     "@types/react": {
       "optional": true
     }
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/@udir-design/symbols/package.json
+++ b/@udir-design/symbols/package.json
@@ -84,5 +84,11 @@
     "svgo": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/@udir-design/theme/package.json
+++ b/@udir-design/theme/package.json
@@ -33,5 +33,11 @@
     "postprocess-css": "../../@internal/build-tools/bin/postprocess-css-colors.ts ./dist/index.css",
     "clean": "rimraf ./dist && mkdir ./dist",
     "build": "pnpm clean && pnpm copy-css && pnpm postprocess-css"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/design-tokens/package.json
+++ b/design-tokens/package.json
@@ -15,5 +15,11 @@
   "devDependencies": {
     "@digdir/designsystemet": "catalog:",
     "rimraf": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-plugin-react-hooks": "catalog:",
     "husky": "catalog:",
     "jsdom": "catalog:",
-    "just-pnpm": "catalog:",
     "madge": "catalog:",
     "nx": "catalog:",
     "playwright": "catalog:",
@@ -61,13 +60,16 @@
       "style-dictionary",
       "unrs-resolver"
     ],
-    "onlyBuiltDependencies": [
-      "just-pnpm"
-    ],
     "overrides": {
       "@eslint/plugin-kit@<0.3.4": ">=0.3.4",
       "tmp@<=0.2.3": ">=0.2.4",
       "glob@>=10.2.0 <10.5.0": "^10.5.0"
+    }
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,9 +204,6 @@ catalogs:
     jsdom:
       specifier: ^27.2.0
       version: 27.2.0
-    just-pnpm:
-      specifier: 1.0.2
-      version: 1.0.2
     lodash-es:
       specifier: ^4.17.21
       version: 4.17.21
@@ -445,9 +442,6 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 27.2.0
-      just-pnpm:
-        specifier: 'catalog:'
-        version: 1.0.2
       madge:
         specifier: 'catalog:'
         version: 8.0.0(typescript@5.9.3)
@@ -6184,10 +6178,6 @@ packages:
   junit-report-builder@5.1.1:
     resolution: {integrity: sha512-ZNOIIGMzqCGcHQEA2Q4rIQQ3Df6gSIfne+X9Rly9Bc2y55KxAZu8iGv+n2pP0bLf0XAOctJZgeloC54hWzCahQ==}
     engines: {node: '>=16'}
-
-  just-pnpm@1.0.2:
-    resolution: {integrity: sha512-a/LtVYjTy1Z1yBl3kFEsic313J8MZ29ZEAFrw1snFOY7/x6Afy1VO2zAgtAlUjIgexOt8TRCRCXo1J+PABIo/Q==}
-    hasBin: true
 
   jwa@1.4.2:
     resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
@@ -14658,8 +14648,6 @@ snapshots:
       lodash: 4.17.21
       make-dir: 3.1.0
       xmlbuilder: 15.1.1
-
-  just-pnpm@1.0.2: {}
 
   jwa@1.4.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,6 @@ catalog:
   husky: ^9.1.7
   js-yaml: ^4.1.1
   jsdom: ^27.2.0
-  just-pnpm: 1.0.2
   lodash-es: ^4.17.21
   madge: ^8.0.0
   markdown-to-jsx: ^7.7.17

--- a/test-apps/nextjs/package.json
+++ b/test-apps/nextjs/package.json
@@ -26,5 +26,11 @@
     "@udir-design/react": {
       "injected": true
     }
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/test-apps/parcel-vanilla/package.json
+++ b/test-apps/parcel-vanilla/package.json
@@ -19,5 +19,11 @@
   },
   "devDependencies": {
     "parcel": "catalog:"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }

--- a/test-apps/vite/package.json
+++ b/test-apps/vite/package.json
@@ -30,5 +30,11 @@
     "@udir-design/react": {
       "injected": true
     }
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This works better than the `just-pnpm` package because it can be enabled for all our package.json files, not just the root file (using `just-pnpm` in published packages would require the package consumers to also use pnpm, which we can't do).

Running any npm subcommand in any of our projects now results in this error message:

```
The developer of this package has specified the following through devEngines
Invalid engine "packageManager"
Invalid name "pnpm" does not match "npm" for "packageManager"
{
  current: { name: 'npm', version: '11.6.0' },
  required: { name: 'pnpm', onFail: 'error' }
}
```

Without `just-pnpm` we now have no allowed pre/post/install scripts from dependencies, closing one potential supply chain attack vector which already was very small since we only allowed it for this one package.

If `npm install` etc is run with an earlier npm version which doesn't support devEngines it will still fail (like we want it to) because we use the `catalog:` protocol, and thus no scripts will be run in that case either. The error message will be less helpful, e.g.

```
Unsupported URL Type "catalog:": catalog:
```