### PR TITLE
feat: new component ReadMore

### DIFF
--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -52,7 +52,8 @@
     "@digdir/designsystemet-types": "catalog:",
     "@udir-design/css": "workspace:*",
     "@udir-design/icons": "workspace:*",
-    "tslib": "catalog:"
+    "tslib": "catalog:",
+    "@u-elements/u-details": "catalog:"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "catalog:",

--- a/@udir-design/react/src/components/readMore/ReadMore.mdx
+++ b/@udir-design/react/src/components/readMore/ReadMore.mdx
@@ -1,0 +1,41 @@
+import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as ReadMoreStories from './ReadMore.stories';
+
+<Meta of={ReadMoreStories} />
+
+# ReadMore
+
+`ReadMore` består av en knapp som åpner/lukker et tekstpanel. Komponenten brukes i skjemaer for å forklare vanskelige begreper eller ord, eller for å gi mer utdypende informasjon om hvorfor et spørsmål stilles.
+
+**Passer til å**
+
+- begrunne spørsmål
+- forklare vanskelige begreper eller ord
+
+**Passer ikke til å**
+
+- vise nødvendig informasjon
+- vise mye eller rikt innhold
+
+## Slik bruker du ReadMore
+
+<Primary />
+<Controls />
+
+## Eksempel
+
+<Canvas of={ReadMoreStories.Example} />
+
+## Retningslinjer
+
+### Tekst på knappen
+
+Teksten på knappen skal skrives slik at bruker forstår hva som vises i panelet som åpnes. Ofte refererer dette til beskrivelsen av input-feltet.
+
+- Teksten på knappen bør ikke skrives som et spørsmål.
+- Hold teksten på knappen kort, unngå at den går over to linjer.
+
+### Plassering i skjema
+
+`ReadMore` plasseres under skjemaelementet.

--- a/@udir-design/react/src/components/readMore/ReadMore.stories.tsx
+++ b/@udir-design/react/src/components/readMore/ReadMore.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Fieldset } from '../fieldset/Fieldset';
+import { Radio } from '../radio/Radio';
+import { ReadMore } from './ReadMore';
+
+const meta: Meta<typeof ReadMore> = {
+  component: ReadMore,
+  tags: ['alpha', 'udir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'self',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReadMore>;
+
+export const Preview: Story = {
+  args: {
+    summary: 'Dette er en ReadMore',
+  },
+  render: (args) => (
+    <ReadMore {...args}>Dette er innhold i en ReadMore</ReadMore>
+  ),
+};
+
+export const Example: Story = {
+  args: {
+    summary: 'Dette er individuelt tilrettelagt opplæring',
+  },
+  render: (args) => (
+    <Fieldset>
+      <Fieldset.Legend>
+        Trenger eleven individuelt tilrettelagt opplæring?
+      </Fieldset.Legend>
+      <Radio
+        id="components-radio--group-ja"
+        label="Ja"
+        name="my-group"
+        value="ja"
+      />
+      <Radio
+        id="components-radio--group-nei"
+        label="Nei"
+        name="my-group"
+        value="nei"
+      />
+      <ReadMore {...args}>
+        Elever som ikke har eller kan få tilfredsstillende utbytte av det
+        ordinære opplæringstilbudet har rett til individuell tilrettelegging.
+        Før det fattes vedtak om individuell tilrettelagt opplæring skal det
+        foreligge en sakkyndig vurdering utarbeidet av Pedagogisk-psykologisk
+        tjeneste.
+      </ReadMore>
+    </Fieldset>
+  ),
+};

--- a/@udir-design/react/src/components/readMore/ReadMore.tsx
+++ b/@udir-design/react/src/components/readMore/ReadMore.tsx
@@ -1,0 +1,46 @@
+import type { Size } from '@digdir/designsystemet-react';
+import cl from 'clsx/lite';
+import '@u-elements/u-details';
+import type { HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import './readMore.css';
+
+export type ReadMoreProps = HTMLAttributes<HTMLDetailsElement> & {
+  /**
+   * Text to be displayed in the ReadMore summary
+   */
+  summary: string;
+  /**
+   * Changes size for descendant Designsystemet components. Select from predefined sizes.
+   */
+  'data-size'?: Size;
+  /**
+   * Controls open-state.
+   *
+   * @default undefined
+   */
+  open?: boolean;
+  /**
+   * Content for the collapsible section
+   */
+  children?: ReactNode;
+};
+
+/**
+ * ReadMore component
+ *
+ * @example
+ * <ReadMore summary="summary">
+ *  Content
+ * </ReadMore>
+ */
+export const ReadMore = forwardRef<HTMLDetailsElement, ReadMoreProps>(
+  function ReadMore({ className, summary, children, ...rest }, ref) {
+    return (
+      <u-details className={cl('uds-readmore', className)} ref={ref} {...rest}>
+        <u-summary>{summary}</u-summary>
+        <div>{children}</div>
+      </u-details>
+    );
+  },
+);

--- a/@udir-design/react/src/components/readMore/__snapshots__/ReadMore.stories.tsx.snap
+++ b/@udir-design/react/src/components/readMore/__snapshots__/ReadMore.stories.tsx.snap
@@ -1,0 +1,66 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Example 1`] = `
+<fieldset>
+  <legend data-weight="medium">
+    Trenger eleven individuelt tilrettelagt opplæring?
+  </legend>
+  <div>
+    <input
+      id="components-radio--group-ja"
+      type="radio"
+      value="ja"
+      name="my-group"
+    >
+    <label
+      data-weight="regular"
+      for="components-radio--group-ja"
+    >
+      Ja
+    </label>
+  </div>
+  <div>
+    <input
+      id="components-radio--group-nei"
+      type="radio"
+      value="nei"
+      name="my-group"
+    >
+    <label
+      data-weight="regular"
+      for="components-radio--group-nei"
+    >
+      Nei
+    </label>
+  </div>
+  <u-details role="group">
+    <u-summary
+      aria-expanded="false"
+      role="button"
+      slot="summary"
+      tabindex="0"
+    >
+      Dette er individuelt tilrettelagt opplæring
+    </u-summary>
+    <div>
+      Elever som ikke har eller kan få tilfredsstillende utbytte av det ordinære opplæringstilbudet har rett til individuell tilrettelegging. Før det fattes vedtak om individuell tilrettelagt opplæring skal det foreligge en sakkyndig vurdering utarbeidet av Pedagogisk-psykologisk tjeneste.
+    </div>
+  </u-details>
+</fieldset>
+`;
+
+exports[`Preview 1`] = `
+<u-details role="group">
+  <u-summary
+    aria-expanded="false"
+    role="button"
+    slot="summary"
+    tabindex="0"
+  >
+    Dette er en ReadMore
+  </u-summary>
+  <div>
+    Dette er innhold i en ReadMore
+  </div>
+</u-details>
+`;

--- a/@udir-design/react/src/components/readMore/readMore.css
+++ b/@udir-design/react/src/components/readMore/readMore.css
@@ -1,0 +1,66 @@
+.uds-readmore {
+  --uds-readmore-icon-gap: var(--ds-size-2);
+  --uds-readmore-icon-size: var(--ds-size-6);
+  --uds-readmore-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
+  --uds-readmore-padding: var(--ds-size-2);
+  --uds-readmore-size: var(--ds-size-10);
+  --uds-readmore-summary-color: var(--ds-color-info-text-subtle);
+  --uds-readmore-summary-background--hover: var(--ds-color-info-surface-tinted);
+
+  margin-inline-start: calc(var(--uds-readmore-padding) * -1);
+
+  & > :is(summary, u-summary) {
+    color: var(--uds-readmore-summary-color);
+    align-items: center;
+    box-sizing: border-box;
+    cursor: pointer;
+    list-style: none;
+    min-height: var(--uds-readmore-size);
+    gap: var(--uds-readmore-icon-gap);
+    outline: none;
+    padding: var(--uds-readmore-padding);
+    position: relative;
+    width: fit-content;
+
+    @composes ds-focus from '@digdir/designsystemet-css/base.css';
+
+    &:not([hidden]) {
+      display: flex;
+    }
+
+    &:hover {
+      background: var(--uds-readmore-summary-background--hover);
+    }
+
+    &::before {
+      all: unset;
+      display: inline-block;
+      content: '';
+      background: currentcolor;
+      flex-shrink: 0;
+      height: var(--uds-readmore-icon-size);
+      width: var(--uds-readmore-icon-size);
+      mask: 50% / contain no-repeat var(--uds-readmore-icon-url);
+    }
+  }
+
+  & > div {
+    position: relative;
+    padding-inline-start: var(--ds-size-10);
+
+    &::before {
+      content: '';
+      position: absolute;
+      inset: 0 var(--ds-size-5);
+      transform: translateX(-50%);
+      width: var(--ds-border-width-default);
+      background-color: var(--ds-color-border-subtle);
+    }
+  }
+
+  &[open] > :is(summary, u-summary) {
+    &::before {
+      rotate: 180deg;
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     '@typescript-eslint/parser':
       specifier: ^8.48.0
       version: 8.48.0
+    '@u-elements/u-details':
+      specifier: ^0.1.5
+      version: 0.1.5
     '@vitejs/plugin-react-swc':
       specifier: ^4.2.2
       version: 4.2.2
@@ -543,6 +546,9 @@ importers:
       '@digdir/designsystemet-types':
         specifier: 'catalog:'
         version: 1.8.0
+      '@u-elements/u-details':
+        specifier: 'catalog:'
+        version: 0.1.5
       '@udir-design/css':
         specifier: workspace:*
         version: link:../css
@@ -12133,6 +12139,7 @@ snapshots:
     dependencies:
       '@digdir/designsystemet-react': 1.8.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@digdir/designsystemet-types': 1.8.0
+      '@u-elements/u-details': 0.1.5
       '@udir-design/css': link:@udir-design/css
       '@udir-design/icons': link:@udir-design/icons
       react: 18.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,6 +43,7 @@ catalog:
   '@types/yargs': ^17.0.35
   '@typescript-eslint/eslint-plugin': ^8.48.0
   '@typescript-eslint/parser': ^8.48.0
+  '@u-elements/u-details': ^0.1.5
   '@vitejs/plugin-react-swc': ^4.2.2
   '@vitest/browser': ^3.2.4
   '@vitest/coverage-v8': ^3.2.4


### PR DESCRIPTION
Ny komponent `Readmore` er en slim `details`-variant ment for bruk i skjemaer der man må forklare et ord eller hvorfor man stiller et spørsmål
- Bygd den på `u-elements` sånn som Digdir sin `Details`, men enklere, uten f.eks. `defaultOpen` siden den har begrenset bruksområde og tenker det er nice å ha den så slim som mulig  