### PR TITLE
build: fix nx crash during --preview-changelog

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,8 @@
       }
     },
     "version": {
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "fallbackCurrentVersionResolver": "disk"
     }
   },
   "targetDefaults": {


### PR DESCRIPTION
Weirdly, Nx has started crashing during `releaseVersion()` with this message

> Error: No git tags matching pattern "v{version}" for project "@udir-design/symbols" were found. You will need to create an initial matching tag to use as a base for determining the next version. Alternatively, you can use the --first-release option or set "release.version.fallbackCurrentVersionResolver" to "disk" in order to fallback to the version on disk when no matching git tags are found.

But this happens **after** it has successfully changed the version in the package.json files on disk. Because of this, we can fallback to the version on disk to resolve the error.