### PR TITLE
build: remove devEngines.packageManager

### DIFF
--- a/@internal/build-tools/package.json
+++ b/@internal/build-tools/package.json
@@ -9,11 +9,5 @@
     "micromatch": "catalog:",
     "tsx": "catalog:",
     "yargs": "catalog:"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/@udir-design/css/package.json
+++ b/@udir-design/css/package.json
@@ -34,11 +34,5 @@
   "scripts": {
     "build": "postcss src/*.css --dir dist/",
     "watch": "pnpm build --watch"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -35,11 +35,5 @@
   "devDependencies": {
     "svgo": "catalog:",
     "tsup": "catalog:"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -117,11 +117,5 @@
     "@types/react": {
       "optional": true
     }
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/@udir-design/symbols/package.json
+++ b/@udir-design/symbols/package.json
@@ -84,11 +84,5 @@
     "svgo": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/@udir-design/theme/package.json
+++ b/@udir-design/theme/package.json
@@ -33,11 +33,5 @@
     "postprocess-css": "../../@internal/build-tools/bin/postprocess-css-colors.ts ./dist/index.css",
     "clean": "rimraf ./dist && mkdir ./dist",
     "build": "pnpm clean && pnpm copy-css && pnpm postprocess-css"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -420,16 +420,11 @@ pnpm update -r --latest "@digdir/*"
 
 `nx` har sin egen oppdateringskommando, som også klargjør migreringer i de tilfellene det er relevant.
 
-Før den kan kjøres må vi **midlertidig** skru av sjekken for at pnpm er i bruk ved å redigere
-`package.json` i rot av repoet, og endre `devEngines.packageManager.onFail` fra `"error"` til `"warn"`. **Denne endringen skal ikke sjekkes inn!**
-
 ```sh
 pnpm nx migrate latest
 pnpm install --no-frozen-lockfile
 pnpm nx --run-migrations # kun dersom migrations.json ble opprettet
 ```
-
-Husk å sette `devEngines.packageManager.onFail` tilbake til `"error"` før du committer endringene!
 
 ### `prettier`
 

--- a/design-tokens/package.json
+++ b/design-tokens/package.json
@@ -15,11 +15,5 @@
   "devDependencies": {
     "@digdir/designsystemet": "catalog:",
     "rimraf": "catalog:"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,11 +67,5 @@
       "tmp@<=0.2.3": ">=0.2.4",
       "glob@>=10.2.0 <10.5.0": "^10.5.0"
     }
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/test-apps/nextjs/package.json
+++ b/test-apps/nextjs/package.json
@@ -26,11 +26,5 @@
     "@udir-design/react": {
       "injected": true
     }
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/test-apps/parcel-vanilla/package.json
+++ b/test-apps/parcel-vanilla/package.json
@@ -19,11 +19,5 @@
   },
   "devDependencies": {
     "parcel": "catalog:"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }

--- a/test-apps/vite/package.json
+++ b/test-apps/vite/package.json
@@ -30,11 +30,5 @@
     "@udir-design/react": {
       "injected": true
     }
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
   }
 }


### PR DESCRIPTION
Enforcing pnpm using devEngines.packageManager has too many unfortunate side effects:
  - storybook migrate doesn't work
  - nx only works when run from root of repo
  - nx built-in target `nx-release-publish` runs `npm view` and thus fails the entire publish process

Note: `npm install` is still impossible to run since it doesn't support `catalog:` version specifiers, so `devEngines.packageManager` was mostly there to provider a better error message if you tried to use the wrong package manager