### PR TITLE
docs: color documentation

### DIFF
--- a/@udir-design/react/src/design-tokens/Colors.mdx
+++ b/@udir-design/react/src/design-tokens/Colors.mdx
@@ -1,0 +1,41 @@
+import { Meta, Unstyled } from '@storybook/addon-docs/blocks';
+import {
+  ColorDisplay,
+  SeverityColors,
+  BrandColors,
+} from './docs/color/color-display';
+
+<Meta title="design-tokens/Farger" />
+<Unstyled>
+
+# Farger
+
+Vi deler fargene i designsystemet inn i tre grupper: Farger for brukergrensesnitt, datavisualisering, og for andre flater.
+
+## Farger for brukergrensesnitt
+
+Fargene for brukergrensesnitt er delt opp i underkategorier for identitetsfarger og varselfarger. Disse fargene er testet for kontrast og tilgjengelighet, og de gir forutsigbarhet og konsistens på tvers av komponenter og plattformer. Når du bruker fargene skal du alltid referere til design tokens, ikke hardkodede verdier.
+
+Farger i denne gruppen brukes for eksempel på komponenter som knapper, bakgrunner, lenker, ikoner og lignende. Designteamet har definert hvordan og hvor disse fargene kan brukes:
+
+- Mange komponenter er kun tilgjengelig i et relevant utvalg av fargene. Dette gjelder for eksempel [`Alert`](/docs/components-alert--docs), som skal bruke varselfargene for å indikere status på varselet.
+
+- Andre komponenter og egendefinerte flater har mer fleksibilitet, og designeren må ta valg ut ifra hensikt og visuell helhet. Dette gjelder for eksempel card.
+
+### Identitetsfarger
+
+Identitetsfargene tar utgangspunkt i Udirs visuelle identitet, men nyansene er tilpasset interaktive flater. På den måten opprettholder vi både tydelig identitet og god brukeropplevelse i digitale tjenester.
+
+<BrandColors />
+
+### Varselfarger
+
+Varselfargene brukes til å formidle varsler av typen info, suksess, advarsel eller fare. Disse fargene er tilgjengelig for komponenter der det er relevant, for eksempel [`Alert`](/docs/components-alert--docs) og [`Tag`](/docs/components-tag--docs). Varselfarger skal ikke brukes som dekor eller fordi de ser fine ut. De skal kun benyttes i kontekst der innholdet har tilsvarende funksjon.
+
+<SeverityColors />
+
+## Farger for andre flater
+
+Dersom du skal lage illustrasjoner, trykksaker eller lignende, kan du lese mer om [fargepaletter for øvrige bruksområder](https://www.udir.no/om-udir/designprofil/farger/) på Udir.no.
+
+</Unstyled>

--- a/@udir-design/react/src/design-tokens/docs/color/color-display.tsx
+++ b/@udir-design/react/src/design-tokens/docs/color/color-display.tsx
@@ -1,0 +1,57 @@
+import { Heading } from '../../../components/typography/heading/Heading';
+import { Paragraph } from '../../../components/typography/paragraph/Paragraph';
+import styles from './color.module.css';
+import type { ColorInfo } from './colors';
+import { brandColors, severityColors } from './colors';
+
+interface ColorDisplayProps {
+  colorPalette: ColorInfo[];
+}
+
+export const ColorDisplay = ({ colorPalette }: ColorDisplayProps) => {
+  return (
+    <div className={styles.root}>
+      {colorPalette.map((color) => (
+        <div key={color.name}>
+          <Heading level={4} data-size="xs">
+            {color.name}
+          </Heading>
+          {color.description && (
+            <Paragraph className={styles.description}>
+              {color.description}
+            </Paragraph>
+          )}
+          <div className={styles.semanticGrid}>
+            {color.semantics.map((category) => (
+              <div className={styles.valueGrid}>
+                <Paragraph className={styles.category}>
+                  {category.name}
+                </Paragraph>
+                <div className={styles.shadesContainer}>
+                  {category.shades.map((shade) => (
+                    <div key={shade.value} className={styles.colorContainer}>
+                      <div
+                        key={shade.value}
+                        style={{ backgroundColor: shade.value }}
+                        className={styles.colorSquare}
+                      />
+                      <Paragraph>{shade.name}</Paragraph>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const BrandColors = () => {
+  return <ColorDisplay colorPalette={brandColors} />;
+};
+
+export const SeverityColors = () => {
+  return <ColorDisplay colorPalette={severityColors} />;
+};

--- a/@udir-design/react/src/design-tokens/docs/color/color.module.css
+++ b/@udir-design/react/src/design-tokens/docs/color/color.module.css
@@ -20,3 +20,85 @@
 .input {
   max-width: 200px;
 }
+
+/** 
+* CSS for color documentation page
+*/
+
+.root {
+  display: flex;
+  gap: var(--ds-size-8);
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  width: 100%;
+
+  & > * > h4 {
+    flex: 2;
+    margin-block: 0;
+    margin-block-end: var(--ds-size-2);
+  }
+}
+
+.description {
+  margin-block-end: var(--ds-size-5);
+}
+
+.colorSquare {
+  height: var(--ds-size-15);
+  width: var(--ds-size-15);
+  border-radius: var(--ds-border-radius-md);
+  display: inline-block;
+  border: 1px solid var(--ds-color-neutral-border-default);
+}
+
+.colorContainer {
+  display: flex;
+  flex-direction: column;
+  max-width: 75px;
+  text-align: center;
+  align-items: center;
+}
+
+.semanticGrid {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: var(--ds-size-5);
+  row-gap: var(--ds-size-6);
+  justify-content: flex-start;
+
+  & > * > p {
+    margin-block: var(--ds-size-1);
+    word-break: break-word;
+  }
+}
+
+.category {
+  background: white;
+  padding-inline: var(--ds-size-1);
+  z-index: 10;
+}
+
+.valueGrid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  gap: var(--ds-size-2);
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 1rem;
+    left: auto;
+    width: 90%;
+    height: 0.7rem;
+    border-width: 2px 2px 0px 2px;
+    border-style: solid;
+    border-color: var(--ds-color-neutral-border-default);
+  }
+}
+
+.shadesContainer {
+  display: flex;
+  gap: var(--ds-size-2);
+}

--- a/@udir-design/react/src/design-tokens/docs/color/colors.ts
+++ b/@udir-design/react/src/design-tokens/docs/color/colors.ts
@@ -1,0 +1,116 @@
+import type { Color, SeverityColors } from '@digdir/designsystemet-types';
+
+export type ColorInfo = {
+  name: string;
+  description?: string;
+  semantics: {
+    name: string;
+    shades: {
+      name: string;
+      value: string;
+    }[];
+  }[];
+};
+
+export type ColorValue = {
+  main?: boolean;
+  name: string;
+  value: string;
+};
+
+function makeColorScale(color: Color | SeverityColors) {
+  return [
+    {
+      name: 'Background',
+      shades: [
+        {
+          name: 'Default',
+          value: `var(--ds-color-${color}-background-default)`,
+        },
+        { name: 'Tinted', value: `var(--ds-color-${color}-background-tinted)` },
+      ],
+    },
+    {
+      name: 'Surface',
+      shades: [
+        { name: 'Default', value: `var(--ds-color-${color}-surface-default)` },
+        { name: 'Tinted', value: `var(--ds-color-${color}-surface-tinted)` },
+        { name: 'Hover', value: `var(--ds-color-${color}-surface-hover)` },
+        { name: 'Active', value: `var(--ds-color-${color}-surface-active)` },
+      ],
+    },
+    {
+      name: 'Border',
+      shades: [
+        { name: 'Subtle', value: `var(--ds-color-${color}-border-subtle)` },
+        { name: 'Default', value: `var(--ds-color-${color}-border-default)` },
+        { name: 'Strong', value: `var(--ds-color-${color}-border-strong)` },
+      ],
+    },
+    {
+      name: 'Text',
+      shades: [
+        { name: 'Subtle', value: `var(--ds-color-${color}-text-subtle)` },
+        { name: 'Default', value: `var(--ds-color-${color}-text-default)` },
+      ],
+    },
+    {
+      name: 'Base',
+      shades: [
+        { name: 'Default', value: `var(--ds-color-${color}-base-default)` },
+        { name: 'Hover', value: `var(--ds-color-${color}-base-hover)` },
+        { name: 'Active', value: `var(--ds-color-${color}-base-active)` },
+        {
+          name: 'Contrast subtle',
+          value: `var(--ds-color-${color}-base-contrast-subtle)`,
+        },
+        {
+          name: 'Contrast default',
+          value: `var(--ds-color-${color}-base-contrast-default)`,
+        },
+      ],
+    },
+  ];
+}
+
+export const brandColors: ColorInfo[] = [
+  {
+    name: 'Accent',
+    description: 'Accent er basert på Udir grønn.',
+    semantics: makeColorScale('accent'),
+  },
+  {
+    name: 'Neutral',
+    description: 'Neutral er basert på Udir sort.',
+    semantics: makeColorScale('neutral'),
+  },
+  {
+    name: 'Support1',
+    description: 'Support1 er basert på Udir blå.',
+    semantics: makeColorScale('support1'),
+  },
+  {
+    name: 'Support2',
+    description: 'Support2 er basert på Udir brun.',
+    semantics: makeColorScale('support2'),
+  },
+];
+
+export const severityColors: ColorInfo[] = [
+  {
+    name: 'Info',
+    semantics: makeColorScale('info'),
+  },
+  {
+    name: 'Success',
+    semantics: makeColorScale('success'),
+  },
+  {
+    name: 'Warning',
+    semantics: makeColorScale('warning'),
+  },
+  {
+    name: 'Danger',
+    semantics: makeColorScale('danger'),
+  },
+];


### PR DESCRIPTION
## Hva er gjort?

Lagt til en dokumentasjonsside i seksjonen _Design Tokens_, som forklarer de tre fargegrupperingene for brukergrensesnitt, datavisualisering og andre flater. 
Visning av nyanser for de ulike fargetokensene. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
