### PR TITLE
docs: remove tags from stories

### DIFF
--- a/@udir-design/react/.storybook/manager.tsx
+++ b/@udir-design/react/.storybook/manager.tsx
@@ -120,7 +120,7 @@ addons.setConfig({
 
       // Add Tag component to tags that need it
       const badge = getBadgeFromTags(item.tags);
-      if (badge) {
+      if (badge && item.type !== 'story') {
         return (
           <>
             <span>{item.name}</span>

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
@@ -21,6 +21,7 @@ const meta = preview.meta<
   Partial<UseCheckboxGroupProps>
 >({
   title: 'Utilities/useCheckboxGroup',
+  tags: ['beta'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
     chromatic: { disableSnapshot: true },

--- a/@udir-design/react/src/utilities/hooks/usePagination/usePagination.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/usePagination/usePagination.stories.tsx
@@ -10,6 +10,7 @@ const meta = preview.meta<
   Partial<UsePaginationProps>
 >({
   title: 'Utilities/usePagination',
+  tags: ['beta'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
     chromatic: { disableSnapshot: true },

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
@@ -17,6 +17,7 @@ const meta = preview.meta<
   Partial<UseRadioGroupProps>
 >({
   title: 'Utilities/useRadioGroup',
+  tags: ['beta'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
     chromatic: { disableSnapshot: true },

--- a/@udir-design/react/src/utilities/hooks/useTableOfContents/useTableOfContents.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useTableOfContents/useTableOfContents.stories.tsx
@@ -18,6 +18,7 @@ const meta = preview.meta<
   useTableOfContentsProps
 >({
   title: 'Utilities/useTableOfContents',
+  tags: ['alpha'],
   parameters: {
     chromatic: { disableSnapshot: true },
     tags: ['alpha', 'udir'],


### PR DESCRIPTION
## Hva er gjort?
Oppdatert `manager.tsx` slik at tags ikke vises for stories og lagt til tags for hooks

| Før    | Etter |
| -------- | ------- |
| <img width="298" height="454" alt="image" src="https://github.com/user-attachments/assets/db0f2c6a-f582-4521-bfa0-b0b8b2dc7ce9" />  | <img width="292" height="514" alt="image" src="https://github.com/user-attachments/assets/8858c4ab-39a5-420c-83e7-df785d4d7e4c" />  |

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog