### PR TITLE
docs: typo in tags

### DIFF
--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -4,7 +4,7 @@ import { Breadcrumbs } from './Breadcrumbs';
 
 const meta = preview.meta({
   component: Breadcrumbs,
-  tags: ['beta', 'udir'],
+  tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/fieldset/Fieldset.stories.tsx
+++ b/@udir-design/react/src/components/fieldset/Fieldset.stories.tsx
@@ -7,7 +7,7 @@ import { Fieldset } from './Fieldset';
 
 const meta = preview.meta({
   component: Fieldset,
-  tags: ['beta', 'didir'],
+  tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',


### PR DESCRIPTION
## Hva er gjort?

Fikset typo _didir_ -> _digdir_ for `Fieldset` og brukt riktig tag _digdir_ for `Breadcrumbs`

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
