### PR TITLE
fix(breadcrumbs): align Breadcrumbs breakpoint with Header

### DIFF
--- a/@udir-design/react/src/components/breadcrumbs/breadcrumbs.css
+++ b/@udir-design/react/src/components/breadcrumbs/breadcrumbs.css
@@ -4,4 +4,23 @@
       color: var(--dsc-link-color);
     }
   }
+
+  /* Override display to match header "sm" breakpoint */
+  & > :is(ol, ul):not(:only-child),
+  & > :is(:not(ol, ul)):not(:only-child) {
+    display: revert;
+  }
+  & > :is(ol, ul):not([hidden]) {
+    display: flex;
+  }
+  @media (width > 40rem) {
+    & > :is(:not(ol, ul)):not(:only-child) {
+      display: none;
+    }
+  }
+  @media (max-width: 40rem) {
+    & > :is(ol, ul):not(:only-child) {
+      display: none;
+    }
+  }
 }


### PR DESCRIPTION
## Hva er gjort?

Re-map 650px breakpoint to 40rem via CSS override. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
