### PR TITLE
fix: style disabled state in FormNavigation.Step

### DIFF
--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -69,6 +69,8 @@ Farger og ikoner baserer seg på tilstanden til hvert steg eller gruppe (`state 
 
 Bruk react-hooken [`useFormNavigation`](/docs/utilities-useformnavigation--docs) for å håndtere tilstanden til navigasjonen. Hooken gir deg funksjonalitet for å håndtere aktiv side, fullførte sider, feilmarkering og navigasjonskontroller. Validering av skjema håndteres utenfor hooken, slik at du kan tilpasse valideringslogikken etter behov. Se [dokumentasjon om `useFormNavigation`](/docs/utilities-useformnavigation--docs) for mer detaljert informasjon.
 
+Kvitteringssiden burde være disabled inntil skjemaet er sendt inn.
+
 <Canvas of={FormNavigationStories.Full} />
 
 ### Mobilvisning

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -40,7 +40,7 @@ Subkomponenter:
 
 ### Enkeltsteg
 
-`FormNavigation.Step` er et steg som representerer en side i skjemaet. En side i skjemaet inneholder informasjon eller spørsmål relatert til ett tema. Et steg kan også brukes som informasjonsside, oppsummeringsside, innsendingside og bekreftelsesside.
+`FormNavigation.Step` er et steg som representerer en side i skjemaet. En side i skjemaet inneholder informasjon eller spørsmål relatert til ett tema. Et steg kan også brukes som informasjonsside, oppsummeringsside, innsendingside og kvitteringsside.
 
 Tittel legges inn som `children`. Bruk `variant`-propen for å automatisk få riktige ikoner som passer til typen steg (`variant='info' | 'summary' | 'submission' | 'confirmation' | 'default'`).
 

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
@@ -124,11 +124,11 @@ export const States = meta.story({
         <FormNavigation.Step state="completed">Andre steg</FormNavigation.Step>
         <FormNavigation.Step state="active">Tredje steg</FormNavigation.Step>
       </FormNavigation.Group>
+      <FormNavigation.Step variant="summary">Oppsummering</FormNavigation.Step>
       <FormNavigation.Step variant="submission">Innsending</FormNavigation.Step>
       <FormNavigation.Step variant="confirmation">
-        Bekreftelse
+        Kvittering
       </FormNavigation.Step>
-      <FormNavigation.Step variant="summary">Oppsummering</FormNavigation.Step>
     </FormNavigation>
   ),
 });
@@ -171,10 +171,10 @@ export const AllStates = meta.story({
 
         <FormNavigation {...args}>
           <FormNavigation.Step variant="confirmation">
-            Bekreftelse
+            Kvittering
           </FormNavigation.Step>
           <FormNavigation.Step state="active" variant="confirmation">
-            Bekreftelse
+            Kvittering
           </FormNavigation.Step>
         </FormNavigation>
       </div>

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
@@ -622,9 +622,10 @@ export const Full = meta.story({
         </FormNavigation.Step>
         <FormNavigation.Step
           variant="confirmation"
+          disabled={!isSubmitSuccessful}
           {...getStepProps('confirmation')}
         >
-          Bekreftelse
+          Kvittering
         </FormNavigation.Step>
       </FormNavigation>
     );
@@ -669,12 +670,14 @@ export const Full = meta.story({
                     label="Første spørsmål"
                     {...register('q1')}
                     error={formErrors.q1?.message}
+                    readOnly={isSubmitSuccessful}
                   />
                   <Textfield
                     id="q2"
                     label="Andre spørsmål"
                     {...register('q2')}
                     error={formErrors.q2?.message}
+                    readOnly={isSubmitSuccessful}
                   />
                 </>
               )}
@@ -684,6 +687,7 @@ export const Full = meta.story({
                   label="Tredje spørsmål"
                   {...register('q3')}
                   error={formErrors.q3?.message}
+                  readOnly={isSubmitSuccessful}
                   autoFocus
                 />
               )}
@@ -694,6 +698,7 @@ export const Full = meta.story({
                     label="Fjerde spørsmål"
                     {...register('q4')}
                     error={formErrors.q4?.message}
+                    readOnly={isSubmitSuccessful}
                     autoFocus
                   />
                   <Textfield
@@ -701,6 +706,7 @@ export const Full = meta.story({
                     label="Femte spørsmål"
                     {...register('q5')}
                     error={formErrors.q5?.message}
+                    readOnly={isSubmitSuccessful}
                   />
                 </>
               )}
@@ -710,6 +716,7 @@ export const Full = meta.story({
                   label="Sjette spørsmål"
                   {...register('q6')}
                   error={formErrors.q6?.message}
+                  readOnly={isSubmitSuccessful}
                   autoFocus
                 />
               )}
@@ -719,6 +726,7 @@ export const Full = meta.story({
                   label="Syvende spørsmål"
                   {...register('q7')}
                   error={formErrors.q7?.message}
+                  readOnly={isSubmitSuccessful}
                   autoFocus
                 />
               )}
@@ -747,7 +755,7 @@ export const Full = meta.story({
                     Forrige
                   </Button>
                 )}
-                {hasNext() && (
+                {hasNext() && (isSubmitSuccessful || id !== 'submission') && (
                   <Button variant="secondary" onClick={next}>
                     Neste
                   </Button>

--- a/@udir-design/react/src/components/formNavigation/FormNavigationStep.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigationStep.tsx
@@ -1,9 +1,9 @@
-import type { HTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 import type { FormNavigationState } from './FormNavigation';
 
 export type FormNavigationStepProps = Omit<
-  HTMLAttributes<HTMLButtonElement>,
+  ButtonHTMLAttributes<HTMLButtonElement>,
   'children'
 > & {
   /**

--- a/@udir-design/react/src/components/formNavigation/__snapshots__/FormNavigation.stories.tsx.snap
+++ b/@udir-design/react/src/components/formNavigation/__snapshots__/FormNavigation.stories.tsx.snap
@@ -104,7 +104,7 @@ exports[`All States 1`] = `
         >
           <div>
           </div>
-          Bekreftelse
+          Kvittering
         </button>
         <button
           data-state="active"
@@ -113,7 +113,7 @@ exports[`All States 1`] = `
         >
           <div>
           </div>
-          Bekreftelse
+          Kvittering
         </button>
       </div>
     </div>
@@ -782,10 +782,11 @@ exports[`Full 1`] = `
         <button
           data-state="idle"
           data-variant="confirmation"
+          disabled
         >
           <div>
           </div>
-          Bekreftelse
+          Kvittering
         </button>
       </div>
     </div>
@@ -921,10 +922,11 @@ exports[`Full 1`] = `
             <button
               data-state="idle"
               data-variant="confirmation"
+              disabled
             >
               <div>
               </div>
-              Bekreftelse
+              Kvittering
             </button>
           </div>
         </dialog>
@@ -1317,6 +1319,14 @@ exports[`States 1`] = `
     </u-details>
     <button
       data-state="idle"
+      data-variant="summary"
+    >
+      <div>
+      </div>
+      Oppsummering
+    </button>
+    <button
+      data-state="idle"
       data-variant="submission"
     >
       <div>
@@ -1329,15 +1339,7 @@ exports[`States 1`] = `
     >
       <div>
       </div>
-      Bekreftelse
-    </button>
-    <button
-      data-state="idle"
-      data-variant="summary"
-    >
-      <div>
-      </div>
-      Oppsummering
+      Kvittering
     </button>
   </div>
 </div>

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -165,6 +165,21 @@
       }
     }
 
+    /* DISABLED */
+    &:disabled {
+      cursor: not-allowed;
+      opacity: var(--ds-opacity-disabled);
+
+      /* Avoid hover effect on icon when disabled */
+      &[data-variant='confirmation'] {
+        &:hover {
+          --uds-form-navigation__step-icon-url: var(
+            --uds-form-navigation__step-confirmation-icon-url
+          );
+        }
+      }
+    }
+
     @composes ds-focus from '@digdir/designsystemet-css/base.css';
   }
 


### PR DESCRIPTION
## Hva er gjort?

- Tatt en avgjørelse på at`hasNext` og `hasPrev` blir stående as is og at konsument selv må håndtere edge cases der man ikke vil vise neste / tilbake knapp. 
- Styler `disabled` steg i `FormNavigation.Step` og endret typen for å unngå typefeil ved bruk av disabled, slik at man ikke kan trykke på kvitteringssteget før man har sendt inn. 
- Oppdatert eksempel i storybook, bruker nå konsekvent ordet **kvittering** fremfor bekreftelse. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
