### PR TITLE
fix(Details): focus was being clipped when nested inside Card

### DIFF
--- a/@udir-design/react/src/components/card/Card.tsx
+++ b/@udir-design/react/src/components/card/Card.tsx
@@ -1,3 +1,4 @@
+import './card.css';
 import {
   Card,
   CardBlock,

--- a/@udir-design/react/src/components/card/card.css
+++ b/@udir-design/react/src/components/card/card.css
@@ -1,0 +1,14 @@
+/*
+Fix focus style on details nested in card.
+Can be removed after the next version of @digdir/designsystemet-css is released and we have upgraded.
+*/
+.ds-card {
+  & > .ds-details:first-child > :is(summary, u-summary) {
+    border-top-left-radius: var(--dsc-card-border-radius);
+    border-top-right-radius: var(--dsc-card-border-radius);
+  }
+  & > .ds-details:last-child:not([open]) > :is(summary, u-summary) {
+    border-bottom-left-radius: var(--dsc-card-border-radius);
+    border-bottom-right-radius: var(--dsc-card-border-radius);
+  }
+}


### PR DESCRIPTION
## Hva er gjort?

Backporter [denne fiksen i `@digdir/designsystemet-css`](https://github.com/digdir/designsystemet/pull/4379) så vi slepp å vente på ny versjon
## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog
