### PR TITLE
docs: fix displayname for component origin in storybook docs

### DIFF
--- a/@udir-design/react/.storybook/docs/components/Origin.tsx
+++ b/@udir-design/react/.storybook/docs/components/Origin.tsx
@@ -7,7 +7,12 @@ export interface OriginProps extends ComponentOrigin {
   component: string;
 }
 
-export function OriginText({ component, originator, details }: OriginProps) {
+export function OriginText({
+  component,
+  name,
+  originator,
+  details,
+}: OriginProps) {
   const digdirText = ' bygger på arbeid gjort i Digdirs designsystem.';
   const navText = (
     <div style={{ display: 'inline' }}>
@@ -48,7 +53,7 @@ export function OriginText({ component, originator, details }: OriginProps) {
         Kilde
       </Heading>
       <Paragraph className="sb-unstyled">
-        <code className="css-b5rkn5">{component}</code>
+        <code className="css-b5rkn5">{name ?? component}</code>
         {fullText}
       </Paragraph>
     </>

--- a/@udir-design/react/.storybook/types/custom.ts
+++ b/@udir-design/react/.storybook/types/custom.ts
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react';
 
 export type ComponentOrigin = {
+  name?: string;
   originator: 'self' | 'digdir' | 'nav';
   details?: string;
 };

--- a/@udir-design/react/src/components/chip/Chip.stories.tsx
+++ b/@udir-design/react/src/components/chip/Chip.stories.tsx
@@ -10,6 +10,7 @@ const meta = preview.meta({
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
+      name: 'Chip',
       originator: 'digdir',
     },
     customStyles: {

--- a/@udir-design/react/src/components/list/List.stories.tsx
+++ b/@udir-design/react/src/components/list/List.stories.tsx
@@ -8,6 +8,7 @@ const meta = preview.meta({
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
+      name: 'List',
       originator: 'digdir',
       details: 'Vi har fjernet mulighet for fargevalg.',
     },


### PR DESCRIPTION
## Hva er gjort?

Lagt til optional parameter `name` som overskriver `component` om den er definert. 

Oppdatert og gjort riktig for: 
- List 
- Chip

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
