### PR TITLE
docs: links from /main should not take you to /beta where the page may not exist

### DIFF
--- a/@udir-design/react/.storybook/docs/ComponentOverrides.tsx
+++ b/@udir-design/react/.storybook/docs/ComponentOverrides.tsx
@@ -17,9 +17,10 @@ const getPath = (href: string | undefined): string => {
 
   // if link starts with /, add current path to link
   if (href.startsWith('/')) {
-    const { origin = '' } = document.location;
+    // Get location from window.parent instead of document, otherwise pathname is iframe.html
+    const { origin = '', pathname } = window.parent.location;
 
-    return `${origin}/?path=${href}`;
+    return `${origin}${pathname}?path=${href}`;
   }
 
   return href;


### PR DESCRIPTION
## Hva er gjort?

På [FormNavigation-dokumentasjonen i main](https://design.udir.no/main/?path=/docs/components-formnavigation--docs) virker ikkje lenkene til `useFormNavigation` og "hjelpefunksjoner for skjema" fordi pathen blir `https://design.udir.no/?path=...` som redirecter til `https://design.udir.no/beta/?path=...`.

Generelt er det jo også lurt at main-dokumentasjon lenker videre til samme versjon av dokumentasjonen, og ikkje til beta. 

Denne PRen skal fikse dette, men det er vanskeleg å få testa lokalt.