### PR TITLE
fix: changes to typing for data-color

### DIFF
--- a/@udir-design/react/src/components/badge/Badge.mdx
+++ b/@udir-design/react/src/components/badge/Badge.mdx
@@ -39,12 +39,11 @@ import { Badge } from '@udir-design/react';
 
 ### Fargar
 
-`Badge` finst kun i neutral og accent, i tillegg til varselfargane. Du kan endre fargen med `data-color`.
-Du kan òg setje `variant` direkte for å endre bakgrunnsfargen til `tinted` variant, som er noko lysare.
+`Badge` finst i neutral, i tillegg til varselfargane. Du kan endre fargen med `data-color`. Du kan òg setje `variant` direkte for å endre bakgrunnsfargen til `tinted` variant, som er noko lysare.
+
+Fordi raud er godt etablert som farge for å indikere notifikasjonar, vik den tilrådde bruken her noko frå standard semantikk for varselfargar. For notifikasjonar plasserte på ikon eller avatarar blir fargen `danger` tilrådd. Ved bruk inline er hovudregelen å nytte `neutral`. I enkelte tilfelle kan det vere aktuelt å nytte dei andre varselfargane.
 
 <Canvas of={BadgeStories.ColorVariants} />
-
-<Canvas of={BadgeStories.SemanticColorVariants} />
 
 ### Vise staus
 
@@ -57,7 +56,7 @@ Dersom du ikkje sender inn `count`, blir berre ein sirkel vist. Dette kan brukas
 ### Flytande over element
 
 Du kan setje plassering med `placement`. Dersom du plasserer `Badge` over eit sirkulært element kan du setje `overlap="circle"` for at badgen skal flyte over elementet.
-Det er vanleg å bruke raud farge på `Badge` som flyt over eit element.
+Det er vanleg å bruke raud farge, altså `data-color="danger"` på `Badge` som flyt over eit element.
 
 <Canvas of={BadgeStories.Floating} />
 
@@ -71,6 +70,10 @@ Dette fungerer og når du bruker `overlap="circle"`.
 Du kan òg bruke komponenten inline.
 
 <Canvas of={BadgeStories.InTabs} />
+
+Under ser du et eksempel på bruk av varselfargene til `Badge` inline.
+
+<Canvas of={BadgeStories.SystemAlerts} />
 
 ## Retningslinjer
 

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -9,7 +9,12 @@ import {
 import preview from '.storybook/preview';
 import { Avatar } from '../avatar/Avatar';
 import { Button } from '../button/Button';
+import { Card } from '../card/Card';
+import { Details } from '../details/Details';
 import { Tabs } from '../tabs/Tabs';
+import { Tag } from '../tag/Tag';
+import { Heading } from '../typography/heading/Heading';
+import { Paragraph } from '../typography/paragraph/Paragraph';
 import { Badge } from './Badge';
 
 const meta = preview.meta({
@@ -142,7 +147,7 @@ export const Status = meta.story({
 });
 
 export const InTabs = meta.story({
-  args: { 'data-color': 'accent' },
+  args: { 'data-color': 'neutral' },
   render: (args) => (
     <Tabs defaultValue="value1">
       <Tabs.List>
@@ -201,18 +206,6 @@ const ColorsMap: {
     'data-color': 'neutral',
     'data-variant': 'tinted',
   },
-  accentBase: {
-    'data-color': 'accent',
-  },
-  accentTinted: {
-    'data-color': 'accent',
-    'data-variant': 'tinted',
-  },
-};
-
-const SemanticColorsMap: {
-  [key: string]: { [key: string]: string };
-} = {
   dangerBase: {
     'data-color': 'danger',
   },
@@ -262,21 +255,81 @@ export const ColorVariants = meta.story({
   ),
 });
 
-export const SemanticColorVariants = meta.story({
+export const SystemAlerts = meta.story({
   render: () => (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(4, 60px)',
-        gap: 'var(--ds-size-2)',
-        justifyContent: 'center',
-        height: '100%',
-        width: '100%',
-      }}
-    >
-      {Object.entries(SemanticColorsMap).map(([key, value]) => (
-        <Badge key={key} {...value} count={15} maxCount={9} />
-      ))}
+    <div style={{ display: 'flex', flexDirection: 'column', width: '30rem' }}>
+      <Heading style={{ marginBlockEnd: 'var(--ds-size-4' }}>
+        Systemvarsler
+      </Heading>
+      <Details>
+        <Details.Summary>
+          Kritisk <Badge count={2} maxCount={9} data-color="danger" />
+        </Details.Summary>
+        <Details.Content
+          style={{
+            gap: 'var(--ds-size-4)',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {Array.from({ length: 2 }, (_) => (
+            <Varsel importance="danger" />
+          ))}
+        </Details.Content>
+      </Details>
+      <Details>
+        <Details.Summary>
+          Advarsler <Badge count={6} maxCount={9} data-color="warning" />
+        </Details.Summary>
+        <Details.Content
+          style={{
+            gap: 'var(--ds-size-4)',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {Array.from({ length: 6 }, (_) => (
+            <Varsel importance="warning" />
+          ))}
+        </Details.Content>
+      </Details>
+      <Details>
+        <Details.Summary>
+          Andre hendelser <Badge count={11} maxCount={9} data-color="info" />
+        </Details.Summary>
+        <Details.Content>
+          <Details.Content
+            style={{
+              gap: 'var(--ds-size-4)',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            {Array.from({ length: 11 }, (_) => (
+              <Varsel importance="info" />
+            ))}
+          </Details.Content>
+        </Details.Content>
+      </Details>
     </div>
   ),
 });
+
+function Varsel({ importance }: { importance: 'danger' | 'warning' | 'info' }) {
+  const tagText = importance === 'danger' ? 'Kritisk' : 'Advarsler';
+  return (
+    <Card>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Heading level={3} data-size="xs">
+          Varsel
+        </Heading>
+        {importance !== 'info' && (
+          <Tag data-color={importance} data-size="sm">
+            {tagText}
+          </Tag>
+        )}
+      </div>
+      <Paragraph>Dette er et varsel.</Paragraph>
+    </Card>
+  );
+}

--- a/@udir-design/react/src/components/badge/Badge.tsx
+++ b/@udir-design/react/src/components/badge/Badge.tsx
@@ -12,13 +12,7 @@ type BadgeProps = Omit<DigdirBadgeProps, 'data-color'> & {
   /**
    * Change the color scheme of badge
    */
-  'data-color'?:
-    | 'neutral'
-    | 'accent'
-    | 'success'
-    | 'danger'
-    | 'info'
-    | 'warning';
+  'data-color'?: 'neutral' | 'success' | 'danger' | 'info' | 'warning';
 };
 
 const Badge = DigdirBadge as ForwardRefExoticComponent<

--- a/@udir-design/react/src/components/badge/__snapshots__/Badge.stories.tsx.snap
+++ b/@udir-design/react/src/components/badge/__snapshots__/Badge.stories.tsx.snap
@@ -17,13 +17,49 @@ exports[`Color Variants 1`] = `
   <span
     data-count="9+"
     data-variant="base"
-    data-color="accent"
+    data-color="danger"
   >
   </span>
   <span
     data-count="9+"
     data-variant="tinted"
-    data-color="accent"
+    data-color="danger"
+  >
+  </span>
+  <span
+    data-count="9+"
+    data-variant="base"
+    data-color="info"
+  >
+  </span>
+  <span
+    data-count="9+"
+    data-variant="tinted"
+    data-color="info"
+  >
+  </span>
+  <span
+    data-count="9+"
+    data-variant="base"
+    data-color="warning"
+  >
+  </span>
+  <span
+    data-count="9+"
+    data-variant="tinted"
+    data-color="warning"
+  >
+  </span>
+  <span
+    data-count="9+"
+    data-variant="base"
+    data-color="success"
+  >
+  </span>
+  <span
+    data-count="9+"
+    data-variant="tinted"
+    data-color="success"
   >
   </span>
 </div>
@@ -396,7 +432,7 @@ exports[`In Tabs 1`] = `
       <span
         data-count="10+"
         data-variant="base"
-        data-color="accent"
+        data-color="neutral"
       >
       </span>
     </button>
@@ -413,7 +449,7 @@ exports[`In Tabs 1`] = `
       <span
         data-count="2"
         data-variant="base"
-        data-color="accent"
+        data-color="neutral"
       >
       </span>
     </button>
@@ -438,59 +474,6 @@ exports[`Preview 1`] = `
   data-variant="base"
 >
 </span>
-`;
-
-exports[`Semantic Color Variants 1`] = `
-<div style="display: grid; grid-template-columns: repeat(4, 60px); gap: var(--ds-size-2); justify-content: center; height: 100%; width: 100%;">
-  <span
-    data-count="9+"
-    data-variant="base"
-    data-color="danger"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="tinted"
-    data-color="danger"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="base"
-    data-color="info"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="tinted"
-    data-color="info"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="base"
-    data-color="warning"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="tinted"
-    data-color="warning"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="base"
-    data-color="success"
-  >
-  </span>
-  <span
-    data-count="9+"
-    data-variant="tinted"
-    data-color="success"
-  >
-  </span>
-</div>
 `;
 
 exports[`Status 1`] = `
@@ -527,5 +510,324 @@ exports[`Status 1`] = `
       </path>
     </svg>
   </span>
+</div>
+`;
+
+exports[`System Alerts 1`] = `
+<div style="display: flex; flex-direction: column; width: 30rem;">
+  <h2 style="margin-block-end: var(--ds-size-4;">
+    Systemvarsler
+  </h2>
+  <u-details
+    data-variant="default"
+    role="group"
+  >
+    <u-summary
+      aria-expanded="false"
+      role="button"
+      slot="summary"
+      tabindex="0"
+    >
+      Kritisk
+      <span
+        data-count="2"
+        data-variant="base"
+        data-color="danger"
+      >
+      </span>
+    </u-summary>
+    <div style="gap: var(--ds-size-4); display: flex; flex-direction: column;">
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="danger"
+            data-size="sm"
+          >
+            Kritisk
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="danger"
+            data-size="sm"
+          >
+            Kritisk
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+    </div>
+  </u-details>
+  <u-details
+    data-variant="default"
+    role="group"
+  >
+    <u-summary
+      aria-expanded="false"
+      role="button"
+      slot="summary"
+      tabindex="0"
+    >
+      Advarsler
+      <span
+        data-count="6"
+        data-variant="base"
+        data-color="warning"
+      >
+      </span>
+    </u-summary>
+    <div style="gap: var(--ds-size-4); display: flex; flex-direction: column;">
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="warning"
+            data-size="sm"
+          >
+            Advarsler
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="warning"
+            data-size="sm"
+          >
+            Advarsler
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="warning"
+            data-size="sm"
+          >
+            Advarsler
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="warning"
+            data-size="sm"
+          >
+            Advarsler
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="warning"
+            data-size="sm"
+          >
+            Advarsler
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="display: flex; justify-content: space-between;">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
+          <span
+            data-variant="default"
+            data-color="warning"
+            data-size="sm"
+          >
+            Advarsler
+          </span>
+        </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+    </div>
+  </u-details>
+  <u-details
+    data-variant="default"
+    role="group"
+  >
+    <u-summary
+      aria-expanded="false"
+      role="button"
+      slot="summary"
+      tabindex="0"
+    >
+      Andre hendelser
+      <span
+        data-count="9+"
+        data-variant="base"
+        data-color="info"
+      >
+      </span>
+    </u-summary>
+    <div>
+      <div style="gap: var(--ds-size-4); display: flex; flex-direction: column;">
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+        <div data-variant="default">
+          <div style="display: flex; justify-content: space-between;">
+            <h3 data-size="xs">
+              Varsel
+            </h3>
+          </div>
+          <p data-variant="default">
+            Dette er et varsel.
+          </p>
+        </div>
+      </div>
+    </div>
+  </u-details>
 </div>
 `;

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -78,6 +78,10 @@ Dersom lenken viser til et spesifikt innhold hos kommunen, som for eksempel info
 
 Du må informere brukere når lenken leder til et dokument (PDF, Excel, osv.). Det er i tillegg god praksis å informere brukeren om dokumentets størrelse. Det enkleste er å skrive informasjonen i selv lenken. Inkluder gjerne også et ikon.
 
+### Besøkte lenker
+
+Som default har besøkte lenker en annen farge enn ikke-besøkte lenker. Dette hjelper brukerne med å holde oversikt over hvilke lenker de allerede har klikket på. I noen tilfeller, slik som der lenker brukes som navigasjonselementer, kan det være hensiktsmessig å overskrive dette.
+
 ## Tekst i Link
 
 En god lenketekst gjør det lettere for folk å bestemme om de ønsker å klikke på lenken eller ikke. Det kan være særlig kostbart for de med nedsatt funksjonsevne å følge en lenke til noe uforventet.

--- a/@udir-design/react/src/components/progressBar/ProgressBar.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import './progressBar.css';
 import '@u-elements/u-progress';
 import { type Size } from '@digdir/designsystemet-react';
+import type { Color } from '@digdir/designsystemet-types';
 import { UHTMLProgressShadowRoot } from '@u-elements/u-progress';
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
@@ -18,7 +19,7 @@ export type ProgressBarProps = Omit<
   /**
    * Changes color of the bar and background
    */
-  'data-color'?: 'neutral' | 'support1' | 'accent';
+  'data-color'?: Color;
   /**
    * Total number of steps in the process
    */

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.tsx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.tsx
@@ -1,3 +1,4 @@
+import type { Color } from '@digdir/designsystemet-types';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
 import { ArrowDownRightIcon } from '@udir-design/icons';
@@ -22,7 +23,7 @@ export type TableOfContentsProps = Omit<
    * in the TableOfContents
    */
   headings: TocHeading[];
-  'data-color'?: 'neutral' | 'accent' | 'support1';
+  'data-color'?: Color;
   /* Defaults the TableOfContents to closed
    * @default false
    */

--- a/@udir-design/react/src/components/tabs/Tabs.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.tsx
@@ -1,14 +1,31 @@
 import {
-  Tabs,
+  Tabs as DigdirTabs,
   TabsList,
   type TabsListProps,
   TabsPanel,
   type TabsPanelProps,
-  type TabsProps,
+  type TabsProps as DigdirTabsProps,
   TabsTab,
   type TabsTabProps,
 } from '@digdir/designsystemet-react';
 import './tabs.css';
+import type {
+  ComponentRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from 'react';
+
+type TabsProps = Omit<DigdirTabsProps, 'data-color'> & {
+  /**
+   * Change the color scheme of the button
+   */
+  'data-color'?: 'neutral' | 'accent';
+};
+
+const Tabs = DigdirTabs as ForwardRefExoticComponent<
+  TabsProps & RefAttributes<ComponentRef<typeof DigdirTabs>>
+> &
+  Pick<typeof DigdirTabs, 'List' | 'Tab' | 'Panel'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Tabs.displayName = 'Tabs';

--- a/@udir-design/react/src/demo/table-demo/TableDemo.tsx
+++ b/@udir-design/react/src/demo/table-demo/TableDemo.tsx
@@ -3,7 +3,6 @@ import type { HTMLAttributes } from 'react';
 import { useMemo, useState } from 'react';
 import { Alert } from 'src/components/alert';
 import { Avatar } from 'src/components/avatar/Avatar';
-import { Badge } from 'src/components/badge/Badge';
 import { Checkbox } from 'src/components/checkbox/Checkbox';
 import { Chip } from 'src/components/chip/Chip';
 import { Divider } from 'src/components/divider/Divider';
@@ -200,18 +199,7 @@ export const TableDemo = ({ ...props }: TableDemoProps) => {
                   </Table.Cell>
                   <Table.Cell>
                     <div className={classes.student}>
-                      <Badge.Position placement="top-right" overlap="circle">
-                        {student.new && (
-                          <Badge data-color="accent" data-size="md" />
-                        )}
-                        <Avatar
-                          aria-label={
-                            student.new
-                              ? `Ny elev ${student.name}`
-                              : student.name
-                          }
-                        />
-                      </Badge.Position>
+                      <Avatar aria-label={student.name} />
                       {student.name}
                     </div>
                   </Table.Cell>

--- a/@udir-design/react/src/demo/table-demo/__snapshots__/TableDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/table-demo/__snapshots__/TableDemo.stories.tsx.snap
@@ -117,21 +117,10 @@ exports[`Table Story 1`] = `
             <td>
               <div>
                 <span
-                  data-overlap="circle"
-                  data-placement="top-right"
+                  data-variant="circle"
+                  role="img"
+                  aria-label="Lise Nordmann"
                 >
-                  <span
-                    data-variant="base"
-                    data-color="accent"
-                    data-size="md"
-                  >
-                  </span>
-                  <span
-                    data-variant="circle"
-                    role="img"
-                    aria-label="Ny elev Lise Nordmann"
-                  >
-                  </span>
                 </span>
                 Lise Nordmann
               </div>
@@ -243,15 +232,10 @@ exports[`Table Story 1`] = `
             <td>
               <div>
                 <span
-                  data-overlap="circle"
-                  data-placement="top-right"
+                  data-variant="circle"
+                  role="img"
+                  aria-label="Ola Nordmann"
                 >
-                  <span
-                    data-variant="circle"
-                    role="img"
-                    aria-label="Ola Nordmann"
-                  >
-                  </span>
                 </span>
                 Ola Nordmann
               </div>
@@ -363,21 +347,10 @@ exports[`Table Story 1`] = `
             <td>
               <div>
                 <span
-                  data-overlap="circle"
-                  data-placement="top-right"
+                  data-variant="circle"
+                  role="img"
+                  aria-label="Kari Nordmann"
                 >
-                  <span
-                    data-variant="base"
-                    data-color="accent"
-                    data-size="md"
-                  >
-                  </span>
-                  <span
-                    data-variant="circle"
-                    role="img"
-                    aria-label="Ny elev Kari Nordmann"
-                  >
-                  </span>
                 </span>
                 Kari Nordmann
               </div>
@@ -489,15 +462,10 @@ exports[`Table Story 1`] = `
             <td>
               <div>
                 <span
-                  data-overlap="circle"
-                  data-placement="top-right"
+                  data-variant="circle"
+                  role="img"
+                  aria-label="Per Nordmann"
                 >
-                  <span
-                    data-variant="circle"
-                    role="img"
-                    aria-label="Per Nordmann"
-                  >
-                  </span>
                 </span>
                 Per Nordmann
               </div>
@@ -609,15 +577,10 @@ exports[`Table Story 1`] = `
             <td>
               <div>
                 <span
-                  data-overlap="circle"
-                  data-placement="top-right"
+                  data-variant="circle"
+                  role="img"
+                  aria-label="Anne Nordmann"
                 >
-                  <span
-                    data-variant="circle"
-                    role="img"
-                    aria-label="Anne Nordmann"
-                  >
-                  </span>
                 </span>
                 Anne Nordmann
               </div>


### PR DESCRIPTION
## Hva er gjort?

Oppdatert typing for noen komponenter etter å ha diskutert fargevalg. 
- `ProgressBar` og `TableOfContents` har nå også Support2
- `Badge` har ikke lenger en Accent variant 
- `Tabs` har nå bare Neutral og Accent

Gjort endringer i dokumentasjon 
- Oppdatert `Link` til å skildre use case for å overskrive `:visited` fargen
- Oppdatert `Badge` dokumentasjon til å skildre tenkt use case for de ulike fargene, siden `danger` ikke nødvendigvis brukes som danger for akkurat denne komponenten 
- Fjernet `Badge` fra `TableDemo.tsx` siden den uansett skulle fjernes og var data-color="accent"
 - Har oppdatert Jira task til å være obs på at man får med `Badge` inn igjen i en demoside i oppgaven om å bruke demo i testapper 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
