### PR TITLE
fix(Logo): use prefers-color-scheme only when data-color-scheme='auto'

### DIFF
--- a/@udir-design/react/src/components/logo/logo.css
+++ b/@udir-design/react/src/components/logo/logo.css
@@ -18,6 +18,33 @@
     display: none;
   }
 
+  /* Different color modes set on the component */
+
+  &[data-color-scheme='auto'] {
+    @media (prefers-color-scheme: dark) {
+      > img:first-of-type {
+        display: none;
+      }
+
+      > img:last-of-type {
+        display: block;
+      }
+    }
+  }
+
+  &[data-color-scheme='dark'] {
+    > img:first-of-type {
+      display: none;
+    }
+    > img:last-of-type {
+      display: block;
+    }
+  }
+}
+
+/* Different color modes infered from parent component */
+
+[data-color-scheme='auto'] .uds-logo {
   @media (prefers-color-scheme: dark) {
     > img:first-of-type {
       display: none;


### PR DESCRIPTION
## Hva er gjort?

Lagt til `data-color-scheme='auto'` i css'en til `Logo` slik at dark-mode varianten av Logo blir en opt-in for utviklerne. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
