### PR TITLE
refactor: replace u-details with details in ReadMore and FormNavigation

### DIFF
--- a/@udir-design/react/src/components/formNavigation/FormNavigationGroup.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigationGroup.tsx
@@ -2,7 +2,7 @@ import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import type { FormNavigationState } from './FormNavigation';
-import '@u-elements/u-details';
+import '@u-elements/u-details/polyfill';
 import { STEP_STATE_ATTRIBUTE } from './FormNavigationStep';
 
 export type FormNavigationGroupProps = HTMLAttributes<HTMLDetailsElement> & {
@@ -69,18 +69,18 @@ export const FormNavigationGroup = forwardRef<
   }, []);
 
   return (
-    <u-details
+    <details
       data-state={state}
-      class={cl('uds-form-navigation__group', className)}
+      className={cl('uds-form-navigation__group', className)}
       ref={innerRef}
       open={open}
       {...rest}
     >
-      <u-summary aria-invalid={state === 'invalid' || undefined}>
+      <summary aria-invalid={state === 'invalid' || undefined}>
         <span>{title}</span>
-      </u-summary>
+      </summary>
       {children}
-    </u-details>
+    </details>
   );
 });
 

--- a/@udir-design/react/src/components/formNavigation/__snapshots__/FormNavigation.stories.tsx.snap
+++ b/@udir-design/react/src/components/formNavigation/__snapshots__/FormNavigation.stories.tsx.snap
@@ -119,21 +119,15 @@ exports[`All States 1`] = `
     </div>
     <div>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="idle"
             data-variant="default"
@@ -166,24 +160,18 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="completed"
             data-variant="default"
@@ -216,24 +204,18 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
       <div>
-        <u-details
+        <details
           data-state="completed"
           open
-          role="group"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="completed"
             data-variant="default"
@@ -266,25 +248,18 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
       <div>
-        <u-details
+        <details
           data-state="invalid"
           open
-          role="group"
         >
-          <u-summary
-            aria-invalid
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary aria-invalid="true">
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="invalid"
             data-variant="default"
@@ -321,25 +296,18 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
       <div>
-        <u-details
+        <details
           data-state="invalid"
           open
-          role="group"
         >
-          <u-summary
-            aria-invalid
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary aria-invalid="true">
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="completed"
             data-variant="default"
@@ -374,28 +342,151 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
     </div>
     <div>
       <div>
-        <u-details
+        <details data-state="idle">
+          <summary>
+            <span>
+              Seksjon
+            </span>
+          </summary>
+          <button
+            data-state="idle"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Første steg
+          </button>
+          <button
+            data-state="idle"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Andre steg
+          </button>
+          <button
+            data-state="idle"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Tredje steg
+          </button>
+          <button
+            data-state="idle"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Fjerde steg
+          </button>
+        </details>
+      </div>
+      <div>
+        <details data-state="completed">
+          <summary>
+            <span>
+              Seksjon
+            </span>
+          </summary>
+          <button
+            data-state="completed"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Første steg
+          </button>
+          <button
+            data-state="completed"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Andre steg
+          </button>
+          <button
+            data-state="completed"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Tredje steg
+          </button>
+          <button
+            data-state="completed"
+            data-variant="default"
+          >
+            <div>
+            </div>
+            Fjerde steg
+          </button>
+        </details>
+      </div>
+      <div>
+        <details data-state="invalid">
+          <summary aria-invalid="true">
+            <span>
+              Seksjon
+            </span>
+          </summary>
+          <button
+            data-state="invalid"
+            data-variant="default"
+            aria-invalid="true"
+          >
+            <div>
+            </div>
+            Første steg
+          </button>
+          <button
+            data-state="invalid"
+            data-variant="default"
+            aria-invalid="true"
+          >
+            <div>
+            </div>
+            Andre steg
+          </button>
+          <button
+            data-state="invalid"
+            data-variant="default"
+            aria-invalid="true"
+          >
+            <div>
+            </div>
+            Tredje steg
+          </button>
+          <button
+            data-state="invalid"
+            data-variant="default"
+            aria-invalid="true"
+          >
+            <div>
+            </div>
+            Fjerde steg
+          </button>
+        </details>
+      </div>
+      <div>
+        <details
           data-state="idle"
-          role="group"
+          data-active-step-label="Første steg"
         >
-          <u-summary
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
-            data-state="idle"
+            data-state="active"
             data-variant="default"
+            aria-current="step"
           >
             <div>
             </div>
@@ -425,26 +516,22 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
       <div>
-        <u-details
+        <details
           data-state="completed"
-          role="group"
+          data-active-step-label="Første steg"
         >
-          <u-summary
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
-            data-state="completed"
+            data-state="active"
             data-variant="default"
+            aria-current="step"
           >
             <div>
             </div>
@@ -474,181 +561,18 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
       <div>
-        <u-details
+        <details
           data-state="invalid"
-          role="group"
-        >
-          <u-summary
-            aria-invalid
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
-            <span>
-              Seksjon
-            </span>
-          </u-summary>
-          <button
-            data-state="invalid"
-            data-variant="default"
-            aria-invalid="true"
-          >
-            <div>
-            </div>
-            Første steg
-          </button>
-          <button
-            data-state="invalid"
-            data-variant="default"
-            aria-invalid="true"
-          >
-            <div>
-            </div>
-            Andre steg
-          </button>
-          <button
-            data-state="invalid"
-            data-variant="default"
-            aria-invalid="true"
-          >
-            <div>
-            </div>
-            Tredje steg
-          </button>
-          <button
-            data-state="invalid"
-            data-variant="default"
-            aria-invalid="true"
-          >
-            <div>
-            </div>
-            Fjerde steg
-          </button>
-        </u-details>
-      </div>
-      <div>
-        <u-details
-          data-state="idle"
-          role="group"
           data-active-step-label="Første steg"
         >
-          <u-summary
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary aria-invalid="true">
             <span>
               Seksjon
             </span>
-          </u-summary>
-          <button
-            data-state="active"
-            data-variant="default"
-            aria-current="step"
-          >
-            <div>
-            </div>
-            Første steg
-          </button>
-          <button
-            data-state="idle"
-            data-variant="default"
-          >
-            <div>
-            </div>
-            Andre steg
-          </button>
-          <button
-            data-state="idle"
-            data-variant="default"
-          >
-            <div>
-            </div>
-            Tredje steg
-          </button>
-          <button
-            data-state="idle"
-            data-variant="default"
-          >
-            <div>
-            </div>
-            Fjerde steg
-          </button>
-        </u-details>
-      </div>
-      <div>
-        <u-details
-          data-state="completed"
-          role="group"
-          data-active-step-label="Første steg"
-        >
-          <u-summary
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
-            <span>
-              Seksjon
-            </span>
-          </u-summary>
-          <button
-            data-state="active"
-            data-variant="default"
-            aria-current="step"
-          >
-            <div>
-            </div>
-            Første steg
-          </button>
-          <button
-            data-state="completed"
-            data-variant="default"
-          >
-            <div>
-            </div>
-            Andre steg
-          </button>
-          <button
-            data-state="completed"
-            data-variant="default"
-          >
-            <div>
-            </div>
-            Tredje steg
-          </button>
-          <button
-            data-state="completed"
-            data-variant="default"
-          >
-            <div>
-            </div>
-            Fjerde steg
-          </button>
-        </u-details>
-      </div>
-      <div>
-        <u-details
-          data-state="invalid"
-          role="group"
-          data-active-step-label="Første steg"
-        >
-          <u-summary
-            aria-invalid
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
-            <span>
-              Seksjon
-            </span>
-          </u-summary>
+          </summary>
           <button
             data-state="active"
             data-variant="default"
@@ -685,7 +609,7 @@ exports[`All States 1`] = `
             </div>
             Fjerde steg
           </button>
-        </u-details>
+        </details>
       </div>
     </div>
   </div>
@@ -697,22 +621,16 @@ exports[`Full 1`] = `
   <div>
     <div>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
           data-active-step-label="Første steg"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Første seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="active"
             data-variant="default"
@@ -730,22 +648,16 @@ exports[`Full 1`] = `
             </div>
             Andre steg
           </button>
-        </u-details>
-        <u-details
+        </details>
+        <details
           data-state="idle"
           open
-          role="group"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Andre seksjon
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="idle"
             data-variant="default"
@@ -770,7 +682,7 @@ exports[`Full 1`] = `
             </div>
             Tredje steg
           </button>
-        </u-details>
+        </details>
         <button
           data-state="idle"
           data-variant="submission"
@@ -837,22 +749,16 @@ exports[`Full 1`] = `
             Naviger
           </h2>
           <div>
-            <u-details
+            <details
               data-state="idle"
               open
-              role="group"
               data-active-step-label="Første steg"
             >
-              <u-summary
-                aria-expanded="true"
-                role="button"
-                slot="summary"
-                tabindex="0"
-              >
+              <summary>
                 <span>
                   Første seksjon
                 </span>
-              </u-summary>
+              </summary>
               <button
                 data-state="active"
                 data-variant="default"
@@ -870,22 +776,16 @@ exports[`Full 1`] = `
                 </div>
                 Andre steg
               </button>
-            </u-details>
-            <u-details
+            </details>
+            <details
               data-state="idle"
               open
-              role="group"
             >
-              <u-summary
-                aria-expanded="true"
-                role="button"
-                slot="summary"
-                tabindex="0"
-              >
+              <summary>
                 <span>
                   Andre seksjon
                 </span>
-              </u-summary>
+              </summary>
               <button
                 data-state="idle"
                 data-variant="default"
@@ -910,7 +810,7 @@ exports[`Full 1`] = `
                 </div>
                 Tredje steg
               </button>
-            </u-details>
+            </details>
             <button
               data-state="idle"
               data-variant="submission"
@@ -982,22 +882,16 @@ exports[`Full 1`] = `
 exports[`Grouping 1`] = `
 <div data-size="auto">
   <div>
-    <u-details
+    <details
       data-state="idle"
       open
-      role="group"
       data-active-step-label="Første steg"
     >
-      <u-summary
-        aria-expanded="true"
-        role="button"
-        slot="summary"
-        tabindex="0"
-      >
+      <summary>
         <span>
           Seksjon
         </span>
-      </u-summary>
+      </summary>
       <button
         data-state="active"
         data-variant="default"
@@ -1015,7 +909,7 @@ exports[`Grouping 1`] = `
         </div>
         Andre steg
       </button>
-    </u-details>
+    </details>
   </div>
 </div>
 `;
@@ -1032,21 +926,15 @@ exports[`Preview 1`] = `
       </div>
       Steg
     </button>
-    <u-details
+    <details
       data-state="idle"
       open
-      role="group"
     >
-      <u-summary
-        aria-expanded="true"
-        role="button"
-        slot="summary"
-        tabindex="0"
-      >
+      <summary>
         <span>
           Seksjon
         </span>
-      </u-summary>
+      </summary>
       <button
         data-state="idle"
         data-variant="default"
@@ -1063,7 +951,7 @@ exports[`Preview 1`] = `
         </div>
         Andre steg
       </button>
-    </u-details>
+    </details>
   </div>
 </div>
 `;
@@ -1072,22 +960,16 @@ exports[`Simple Navigation 1`] = `
 <div data-size="auto">
   <div>
     <div>
-      <u-details
+      <details
         data-state="idle"
         open
-        role="group"
         data-active-step-label="Steg 1"
       >
-        <u-summary
-          aria-expanded="true"
-          role="button"
-          slot="summary"
-          tabindex="0"
-        >
+        <summary>
           <span>
             Seksjon
           </span>
-        </u-summary>
+        </summary>
         <button
           data-state="active"
           data-variant="default"
@@ -1113,7 +995,7 @@ exports[`Simple Navigation 1`] = `
           </div>
           Innsending
         </button>
-      </u-details>
+      </details>
     </div>
     <div>
       <h2 data-size="sm">
@@ -1192,21 +1074,15 @@ exports[`States 1`] = `
       </div>
       Frittstående steg
     </button>
-    <u-details
+    <details
       data-state="completed"
       open
-      role="group"
     >
-      <u-summary
-        aria-expanded="true"
-        role="button"
-        slot="summary"
-        tabindex="0"
-      >
+      <summary>
         <span>
           Første seksjon
         </span>
-      </u-summary>
+      </summary>
       <button
         data-state="idle"
         data-variant="info"
@@ -1231,23 +1107,16 @@ exports[`States 1`] = `
         </div>
         Andre steg
       </button>
-    </u-details>
-    <u-details
+    </details>
+    <details
       data-state="invalid"
       open
-      role="group"
     >
-      <u-summary
-        aria-invalid
-        aria-expanded="true"
-        role="button"
-        slot="summary"
-        tabindex="0"
-      >
+      <summary aria-invalid="true">
         <span>
           Andre seksjon
         </span>
-      </u-summary>
+      </summary>
       <button
         data-state="completed"
         data-variant="default"
@@ -1274,23 +1143,17 @@ exports[`States 1`] = `
         </div>
         Tredje steg
       </button>
-    </u-details>
-    <u-details
+    </details>
+    <details
       data-state="idle"
       open
-      role="group"
       data-active-step-label="Tredje steg"
     >
-      <u-summary
-        aria-expanded="true"
-        role="button"
-        slot="summary"
-        tabindex="0"
-      >
+      <summary>
         <span>
           Tredje seksjon
         </span>
-      </u-summary>
+      </summary>
       <button
         data-state="completed"
         data-variant="default"
@@ -1316,7 +1179,7 @@ exports[`States 1`] = `
         </div>
         Tredje steg
       </button>
-    </u-details>
+    </details>
     <button
       data-state="idle"
       data-variant="summary"

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -198,7 +198,7 @@
     width: fit-content;
 
     /* Details content - container for the steps inside the group */
-    &::part(details-content) {
+    &::details-content {
       block-size: 0;
       overflow-y: hidden;
       display: flex;
@@ -209,19 +209,17 @@
         height 400ms;
     }
 
-    &[open]::part(details-content) {
+    &[open]::details-content {
       height: auto;
     }
 
     /* Make sure focusstyles for steps inside details-content dont get clipped */
-    &[open]:has(:focus-visible:not(u-summary, u-summary *))::part(
-        details-content
-      ) {
+    &[open]:has(:focus-visible:not(summary, summary *))::details-content {
       overflow: visible;
     }
 
     /* Summary - title button of the group */
-    & u-summary {
+    & summary {
       all: unset;
       width: fit-content;
       cursor: pointer;
@@ -266,21 +264,21 @@
     }
 
     /* Chevron toggle */
-    &[open] > u-summary::after {
+    &[open] > summary::after {
       rotate: 180deg;
     }
 
     /**
       * Group state styles
       */
-    &[data-state='invalid'] > u-summary {
+    &[data-state='invalid'] > summary {
       color: var(--ds-color-danger-text-subtle);
       &:hover {
         color: var(--ds-color-danger-text-default);
       }
     }
 
-    &[data-state='completed'] > u-summary {
+    &[data-state='completed'] > summary {
       color: var(--ds-color-success-text-subtle);
       &:hover {
         color: var(--ds-color-success-text-default);

--- a/@udir-design/react/src/components/readMore/ReadMore.tsx
+++ b/@udir-design/react/src/components/readMore/ReadMore.tsx
@@ -1,6 +1,6 @@
 import type { Size } from '@digdir/designsystemet-react';
 import cl from 'clsx/lite';
-import '@u-elements/u-details';
+import '@u-elements/u-details/polyfill';
 import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import './readMore.css';
@@ -37,10 +37,10 @@ export type ReadMoreProps = HTMLAttributes<HTMLDetailsElement> & {
 export const ReadMore = forwardRef<HTMLDetailsElement, ReadMoreProps>(
   function ReadMore({ className, summary, children, ...rest }, ref) {
     return (
-      <u-details className={cl('uds-readmore', className)} ref={ref} {...rest}>
-        <u-summary>{summary}</u-summary>
+      <details className={cl('uds-readmore', className)} ref={ref} {...rest}>
+        <summary>{summary}</summary>
         <div>{children}</div>
-      </u-details>
+      </details>
     );
   },
 );

--- a/@udir-design/react/src/components/readMore/__snapshots__/ReadMore.stories.tsx.snap
+++ b/@udir-design/react/src/components/readMore/__snapshots__/ReadMore.stories.tsx.snap
@@ -33,34 +33,24 @@ exports[`Example 1`] = `
       Nei
     </label>
   </div>
-  <u-details role="group">
-    <u-summary
-      aria-expanded="false"
-      role="button"
-      slot="summary"
-      tabindex="0"
-    >
+  <details>
+    <summary>
       Dette er individuelt tilrettelagt opplæring
-    </u-summary>
+    </summary>
     <div>
       Elever som ikke har eller kan få tilfredsstillende utbytte av det ordinære opplæringstilbudet har rett til individuell tilrettelegging. Før det fattes vedtak om individuell tilrettelagt opplæring skal det foreligge en sakkyndig vurdering utarbeidet av Pedagogisk-psykologisk tjeneste.
     </div>
-  </u-details>
+  </details>
 </fieldset>
 `;
 
 exports[`Preview 1`] = `
-<u-details role="group">
-  <u-summary
-    aria-expanded="false"
-    role="button"
-    slot="summary"
-    tabindex="0"
-  >
+<details>
+  <summary>
     Dette er en ReadMore
-  </u-summary>
+  </summary>
   <div>
     Dette er innhold i en ReadMore
   </div>
-</u-details>
+</details>
 `;

--- a/@udir-design/react/src/components/readMore/readMore.css
+++ b/@udir-design/react/src/components/readMore/readMore.css
@@ -9,7 +9,7 @@
 
   margin-inline-start: calc(var(--uds-readmore-padding) * -1);
 
-  & > :is(summary, u-summary) {
+  & > :is(summary) {
     color: var(--uds-readmore-summary-color);
     align-items: center;
     box-sizing: border-box;
@@ -58,7 +58,7 @@
     }
   }
 
-  &[open] > :is(summary, u-summary) {
+  &[open] > :is(summary) {
     &::before {
       rotate: 180deg;
     }

--- a/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -4,22 +4,16 @@ exports[`Form Page 2 1`] = `
 <div data-size="auto">
   <div>
     <div>
-      <u-details
+      <details
         data-state="idle"
         open
-        role="group"
         data-active-step-label="Prosjektet"
       >
-        <u-summary
-          aria-expanded="true"
-          role="button"
-          slot="summary"
-          tabindex="0"
-        >
+        <summary>
           <span>
             Testsøknad
           </span>
-        </u-summary>
+        </summary>
         <button
           data-state="idle"
           data-variant="default"
@@ -62,7 +56,7 @@ exports[`Form Page 2 1`] = `
           </div>
           Kvittering
         </button>
-      </u-details>
+      </details>
     </div>
   </div>
   <div>
@@ -111,22 +105,16 @@ exports[`Form Page 2 1`] = `
         Skjemanavigasjon
       </h2>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
           data-active-step-label="Prosjektet"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Testsøknad
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="idle"
             data-variant="default"
@@ -169,7 +157,7 @@ exports[`Form Page 2 1`] = `
             </div>
             Kvittering
           </button>
-        </u-details>
+        </details>
       </div>
     </dialog>
   </div>
@@ -264,19 +252,14 @@ exports[`Form Page 2 1`] = `
             Aktivitet
           </label>
         </div>
-        <u-details role="group">
-          <u-summary
-            aria-expanded="false"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+        <details>
+          <summary>
             Grunnen til at vi spør om dette
-          </u-summary>
+          </summary>
           <div>
             Tilskuddsordningen skal dekke et bredt spekter av tilbud. For å ha oversikt over fordelingen av budsjettposten trenger vi å vite hvilket tilbud det søkes om å utvide.
           </div>
-        </u-details>
+        </details>
       </fieldset>
       <div>
         <label
@@ -631,22 +614,16 @@ exports[`Form Page 3 1`] = `
 <div data-size="auto">
   <div>
     <div>
-      <u-details
+      <details
         data-state="idle"
         open
-        role="group"
         data-active-step-label="Dokumentasjon"
       >
-        <u-summary
-          aria-expanded="true"
-          role="button"
-          slot="summary"
-          tabindex="0"
-        >
+        <summary>
           <span>
             Testsøknad
           </span>
-        </u-summary>
+        </summary>
         <button
           data-state="idle"
           data-variant="default"
@@ -689,7 +666,7 @@ exports[`Form Page 3 1`] = `
           </div>
           Kvittering
         </button>
-      </u-details>
+      </details>
     </div>
   </div>
   <div>
@@ -738,22 +715,16 @@ exports[`Form Page 3 1`] = `
         Skjemanavigasjon
       </h2>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
           data-active-step-label="Dokumentasjon"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Testsøknad
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="idle"
             data-variant="default"
@@ -796,7 +767,7 @@ exports[`Form Page 3 1`] = `
             </div>
             Kvittering
           </button>
-        </u-details>
+        </details>
       </div>
     </dialog>
   </div>
@@ -988,22 +959,16 @@ exports[`Form Page 4 1`] = `
 <div data-size="auto">
   <div>
     <div>
-      <u-details
+      <details
         data-state="idle"
         open
-        role="group"
         data-active-step-label="Innsending"
       >
-        <u-summary
-          aria-expanded="true"
-          role="button"
-          slot="summary"
-          tabindex="0"
-        >
+        <summary>
           <span>
             Testsøknad
           </span>
-        </u-summary>
+        </summary>
         <button
           data-state="idle"
           data-variant="default"
@@ -1046,7 +1011,7 @@ exports[`Form Page 4 1`] = `
           </div>
           Kvittering
         </button>
-      </u-details>
+      </details>
     </div>
   </div>
   <div>
@@ -1095,22 +1060,16 @@ exports[`Form Page 4 1`] = `
         Skjemanavigasjon
       </h2>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
           data-active-step-label="Innsending"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Testsøknad
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="idle"
             data-variant="default"
@@ -1153,7 +1112,7 @@ exports[`Form Page 4 1`] = `
             </div>
             Kvittering
           </button>
-        </u-details>
+        </details>
       </div>
     </dialog>
   </div>
@@ -1273,22 +1232,16 @@ exports[`Form Page 5 1`] = `
 <div data-size="auto">
   <div>
     <div>
-      <u-details
+      <details
         data-state="idle"
         open
-        role="group"
         data-active-step-label="Kvittering"
       >
-        <u-summary
-          aria-expanded="true"
-          role="button"
-          slot="summary"
-          tabindex="0"
-        >
+        <summary>
           <span>
             Testsøknad
           </span>
-        </u-summary>
+        </summary>
         <button
           data-state="idle"
           data-variant="default"
@@ -1331,7 +1284,7 @@ exports[`Form Page 5 1`] = `
           </div>
           Kvittering
         </button>
-      </u-details>
+      </details>
     </div>
   </div>
   <div>
@@ -1380,22 +1333,16 @@ exports[`Form Page 5 1`] = `
         Skjemanavigasjon
       </h2>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
           data-active-step-label="Kvittering"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Testsøknad
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="idle"
             data-variant="default"
@@ -1438,7 +1385,7 @@ exports[`Form Page 5 1`] = `
             </div>
             Kvittering
           </button>
-        </u-details>
+        </details>
       </div>
     </dialog>
   </div>
@@ -1518,22 +1465,16 @@ exports[`Form Story 1`] = `
 <div data-size="auto">
   <div>
     <div>
-      <u-details
+      <details
         data-state="idle"
         open
-        role="group"
         data-active-step-label="Kontaktinfo"
       >
-        <u-summary
-          aria-expanded="true"
-          role="button"
-          slot="summary"
-          tabindex="0"
-        >
+        <summary>
           <span>
             Testsøknad
           </span>
-        </u-summary>
+        </summary>
         <button
           data-state="active"
           data-variant="default"
@@ -1576,7 +1517,7 @@ exports[`Form Story 1`] = `
           </div>
           Kvittering
         </button>
-      </u-details>
+      </details>
     </div>
   </div>
   <div>
@@ -1625,22 +1566,16 @@ exports[`Form Story 1`] = `
         Skjemanavigasjon
       </h2>
       <div>
-        <u-details
+        <details
           data-state="idle"
           open
-          role="group"
           data-active-step-label="Kontaktinfo"
         >
-          <u-summary
-            aria-expanded="true"
-            role="button"
-            slot="summary"
-            tabindex="0"
-          >
+          <summary>
             <span>
               Testsøknad
             </span>
-          </u-summary>
+          </summary>
           <button
             data-state="active"
             data-variant="default"
@@ -1683,7 +1618,7 @@ exports[`Form Story 1`] = `
             </div>
             Kvittering
           </button>
-        </u-details>
+        </details>
       </div>
     </dialog>
   </div>

--- a/@udir-design/react/src/utilities/hooks/useFormNavigation/__snapshots__/useFormNavigation.stories.tsx.snap
+++ b/@udir-design/react/src/utilities/hooks/useFormNavigation/__snapshots__/useFormNavigation.stories.tsx.snap
@@ -12,21 +12,15 @@ exports[`Preview 1`] = `
       </div>
       Infoside
     </button>
-    <u-details
+    <details
       data-state="idle"
       open
-      role="group"
     >
-      <u-summary
-        aria-expanded="true"
-        role="button"
-        slot="summary"
-        tabindex="0"
-      >
+      <summary>
         <span>
           Seksjon
         </span>
-      </u-summary>
+      </summary>
       <button
         data-state="idle"
         data-variant="default"
@@ -43,7 +37,7 @@ exports[`Preview 1`] = `
         </div>
         Andre steg
       </button>
-    </u-details>
+    </details>
   </div>
 </div>
 `;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ catalogs:
       specifier: 7.0.0-dev.20260119.1
       version: 7.0.0-dev.20260119.1
     '@u-elements/u-details':
-      specifier: ^0.1.5
-      version: 0.1.5
+      specifier: ^0.2.1
+      version: 0.2.1
     '@u-elements/u-progress':
       specifier: ^0.0.6
       version: 0.0.6
@@ -579,7 +579,7 @@ importers:
         version: 1.9.0
       '@u-elements/u-details':
         specifier: 'catalog:'
-        version: 0.1.5
+        version: 0.2.1
       '@u-elements/u-progress':
         specifier: 'catalog:'
         version: 0.0.6
@@ -3944,6 +3944,9 @@ packages:
 
   '@u-elements/u-details@0.1.5':
     resolution: {integrity: sha512-08sBhbc4u3VFlXIvH//m2yCDBHOJlQigs8QiKVLAVk2hMSg+fcRPggcgeBmtVPuy7iN3u/VURP6G2Ajlfbr6xg==}
+
+  '@u-elements/u-details@0.2.1':
+    resolution: {integrity: sha512-ugzflbOjHQgst07IoTFzikYmvVEILQQvrayd+N29XxIbpabIoRbYLr6h389PG9dIg4tRO3Lw/qT4uTcDWX+Syg==}
 
   '@u-elements/u-progress@0.0.6':
     resolution: {integrity: sha512-WJUxmHPgkgi/hKaOsjSJc5XGbfSg1/fgTs9SynmLRFn+1Dxaq7JPu98JqKPQLMDCVLaSY+Iz4EKJawgmNolbvA==}
@@ -12184,6 +12187,8 @@ snapshots:
 
   '@u-elements/u-details@0.1.5': {}
 
+  '@u-elements/u-details@0.2.1': {}
+
   '@u-elements/u-progress@0.0.6': {}
 
   '@udir-design/icons@file:@udir-design/icons(@types/react@18.3.27)(react@18.3.1)':
@@ -12197,7 +12202,7 @@ snapshots:
     dependencies:
       '@digdir/designsystemet-react': 1.9.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@digdir/designsystemet-types': 1.9.0
-      '@u-elements/u-details': 0.1.5
+      '@u-elements/u-details': 0.2.1
       '@u-elements/u-progress': 0.0.6
       '@udir-design/css': link:@udir-design/css
       '@udir-design/icons': link:@udir-design/icons
@@ -12211,7 +12216,7 @@ snapshots:
     dependencies:
       '@digdir/designsystemet-react': 1.9.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@digdir/designsystemet-types': 1.9.0
-      '@u-elements/u-details': 0.1.5
+      '@u-elements/u-details': 0.2.1
       '@u-elements/u-progress': 0.0.6
       '@udir-design/css': link:@udir-design/css
       '@udir-design/icons': link:@udir-design/icons

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   '@typescript-eslint/eslint-plugin': ^8.53.0
   '@typescript-eslint/parser': ^8.53.0
   '@typescript/native-preview': 7.0.0-dev.20260119.1
-  '@u-elements/u-details': ^0.1.5
+  '@u-elements/u-details': ^0.2.1
   '@u-elements/u-progress': ^0.0.6
   '@vitejs/plugin-react-swc': ^4.2.2
   '@vitest/browser': ^4.0.17


### PR DESCRIPTION
## Hva er gjort?

Fjernet `u-details` til fordel for `details` og importert polyfill i stedet 🎉  Måtte gjøre [små tweaks på css også](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::details-content)

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
