### PR TITLE
feat: selected variant of Dropdown

### DIFF
--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -70,6 +70,12 @@ Fordi `Dropdown` bruker popover API-et, kan du også bruke `Dropdown` uten `Drop
 
 <Canvas of={DropdownStories.WithoutTrigger} />
 
+### Vis aktivt element
+
+Du kan bruke `aria-current="true"` på et `Dropdown.Item` for å indikere hvilket element som er aktivt/valgt.
+
+<Canvas of={DropdownStories.Selected} />
+
 ## Tilgjengelighet
 
 Det er innebygd tilgjengelighet i `Dropdown.Trigger` med `aria-expanded={true/false}` i henhold til åpnet/lukket tilstand, og `aria-haspopup='menu'`. Du kan lese mer om Popover API-et i mozilla sin [dokumentasjon](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API).

--- a/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
@@ -173,6 +173,34 @@ export const Avatars = meta.story({
   },
 });
 
+export const Selected = meta.story({
+  args: {
+    placement: 'bottom-end',
+  },
+  render: (args) => {
+    return (
+      <Dropdown.TriggerContext>
+        <Dropdown.Trigger variant="secondary">
+          Velg bakgrunnsfarge
+        </Dropdown.Trigger>
+        <Dropdown {...args}>
+          <Dropdown.List>
+            <Dropdown.Item>
+              <Dropdown.Button>Blå</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item aria-current="true">
+              <Dropdown.Button>Grønn</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Dropdown.Button>Svart</Dropdown.Button>
+            </Dropdown.Item>
+          </Dropdown.List>
+        </Dropdown>
+      </Dropdown.TriggerContext>
+    );
+  },
+});
+
 export const Controlled = meta.story({
   render: function Render(args) {
     const [open, setOpen] = useState(false);

--- a/@udir-design/react/src/components/dropdown/__snapshots__/Dropdown.stories.tsx.snap
+++ b/@udir-design/react/src/components/dropdown/__snapshots__/Dropdown.stories.tsx.snap
@@ -132,7 +132,7 @@ exports[`Controlled 1`] = `
 <button
   data-variant="secondary"
   type="button"
-  popovertarget="_r_a_"
+  popovertarget="_r_b_"
 >
   Utdanningsløp
   <svg
@@ -155,7 +155,7 @@ exports[`Controlled 1`] = `
   </svg>
 </button>
 <div
-  id="_r_a_"
+  id="_r_b_"
   popover="manual"
   data-variant="default"
   data-placement="bottom"
@@ -339,6 +339,50 @@ exports[`Preview 1`] = `
         type="button"
       >
         .docx
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Selected 1`] = `
+<button
+  data-variant="secondary"
+  type="button"
+  popovertarget="_r_a_"
+>
+  Velg bakgrunnsfarge
+</button>
+<div
+  id="_r_a_"
+  popover="manual"
+  data-variant="default"
+  data-placement="bottom"
+  style="--ds-popover-arrow-x: <removed>; --ds-popover-arrow-y: <removed>; translate: <removed>;"
+>
+  <ul>
+    <li>
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Blå
+      </button>
+    </li>
+    <li aria-current="true">
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Grønn
+      </button>
+    </li>
+    <li>
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Svart
       </button>
     </li>
   </ul>

--- a/@udir-design/react/src/components/dropdown/dropdown.css
+++ b/@udir-design/react/src/components/dropdown/dropdown.css
@@ -3,4 +3,23 @@
     color: var(--ds-color-neutral-text-default);
     font-weight: 600;
   }
+  [aria-current='true'] button::before {
+    content: '';
+    position: absolute;
+    inset-inline-start: var(--ds-size-3);
+    display: inline-block;
+    width: 1.3em;
+    height: 1.3em;
+    background: currentColor;
+    mask: center / 100% no-repeat
+      url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M18.9983 6.93945C19.3079 7.21464 19.3357 7.68869 19.0606 7.99828L11.0606 16.9983C10.9233 17.1527 10.7285 17.2436 10.522 17.2497C10.3156 17.2558 10.1157 17.1764 9.96967 17.0303L4.96967 12.0303C4.67678 11.7374 4.67678 11.2626 4.96967 10.9697C5.26256 10.6768 5.73744 10.6768 6.03033 10.9697L10.4679 15.4072L17.9394 7.00174C18.2146 6.69215 18.6887 6.66426 18.9983 6.93945Z' fill='%23202733'/%3E%3C/svg%3E%0A");
+    vertical-align: middle;
+  }
+  [aria-current='true'],
+  [aria-current='true'] ~ li,
+  li:has(~ [aria-current='true']) {
+    :is(a, button, [role='button']) {
+      padding-inline-start: var(--ds-size-7);
+    }
+  }
 }

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -124,6 +124,22 @@ Bruk `Tag` til å indikere at en tjeneste vises i et annet kjøretidsmiljø enn 
 
 <Canvas story={{ inline: false, height: '150px' }} of={HeaderStories.WithTag} />
 
+### Språkvelger
+
+Bruk `Button` sammen med `Dropdown` for å lage en språkvelger i `Header`.
+
+<Canvas
+  story={{ inline: false, height: '350px' }}
+  of={HeaderStories.WithLanguagePicker}
+/>
+
+Dersom det bare finnes to språk i tjenesten, kan du bruke en `Button` som bytter språk ved klikk.
+
+<Canvas
+  story={{ inline: false, height: '150px' }}
+  of={HeaderStories.WithTwoLanguages}
+/>
+
 ### Responsivt innhold
 
 For å håndtere ulike skjermstørrelser og enheter er det satt opp noen predefinerte breakpoints for når innhold skal vises eller skjules. Dette brukes ved å sette `data-show=[size]` eller `data-hide=[size]` på komponentene du legger inn i `Header`. De tilgjengelige verdiene for `size` er:

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { BriefcaseIcon, LeaveIcon } from '@udir-design/icons';
+import { BriefcaseIcon, LanguageIcon, LeaveIcon } from '@udir-design/icons';
 import { withResponsiveDataSize } from '.storybook/decorators/withResponsiveDataSize';
 import preview from '.storybook/preview';
 import { Avatar } from '../avatar/Avatar';
@@ -584,6 +584,57 @@ export const WithTag = meta.story({
     return (
       <Header {...args}>
         <Tag data-color="accent">Dev</Tag>
+      </Header>
+    );
+  },
+});
+
+export const WithLanguagePicker = meta.story({
+  render(args) {
+    return (
+      <Header {...args}>
+        <Button variant="tertiary" popoverTarget="language-picker" lang="en">
+          <LanguageIcon aria-hidden />
+          Language
+        </Button>
+        <Dropdown id="language-picker">
+          <Dropdown.List>
+            <Dropdown.Item>
+              <Dropdown.Button lang="nb">Bokmål</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item aria-current="true">
+              <Dropdown.Button lang="nn">Nynorsk</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Dropdown.Button lang="se">Davvisámegiella</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Dropdown.Button lang="en">English</Dropdown.Button>
+            </Dropdown.Item>
+          </Dropdown.List>
+        </Dropdown>
+      </Header>
+    );
+  },
+});
+
+export const WithTwoLanguages = meta.story({
+  render(args) {
+    const [language, setLanguage] = useState<'nb' | 'nn'>('nb');
+    const text = {
+      nn: 'Bytt til bokmål',
+      nb: 'Bytt til nynorsk',
+    };
+    return (
+      <Header {...args}>
+        <Button
+          variant="tertiary"
+          lang={language}
+          onClick={() => setLanguage((prev) => (prev === 'nb' ? 'nn' : 'nb'))}
+        >
+          <LanguageIcon aria-hidden />
+          {text[language]}
+        </Button>
       </Header>
     );
   },

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -2581,6 +2581,106 @@ exports[`Udir No 1`] = `
 </div>
 `;
 
+exports[`With Language Picker 1`] = `
+<div data-size="auto">
+  <header
+    data-scroll-direction="up"
+    data-top="true"
+    style="--udsc-header-max-width: 80rem;"
+  >
+    <div>
+      <a href="/">
+        <div style="--uds-logo-padding: 0;">
+          <img
+            alt="Utdanningsdirektoratet"
+            src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-3&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-2&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+          >
+          <img
+            alt="Utdanningsdirektoratet"
+            src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-2&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-3&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+          >
+        </div>
+        <span data-size="xs">
+          Tjenestenavn
+        </span>
+      </a>
+      <div>
+        <button
+          data-variant="tertiary"
+          type="button"
+          popovertarget="language-picker"
+          lang="en"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M10 4.75a.75.75 0 0 1 .75.75v1.25H16a.75.75 0 0 1 0 1.5h-1.948a14.6 14.6 0 0 1-2.995 5.197q.22.198.448.386a.75.75 0 0 1-.953 1.158 15 15 0 0 1-.552-.478 14.6 14.6 0 0 1-4.212 2.68.75.75 0 0 1-.576-1.385 13.1 13.1 0 0 0 3.73-2.361A14.6 14.6 0 0 1 5.949 8.25H4a.75.75 0 0 1 0-1.5h5.25V5.5a.75.75 0 0 1 .75-.75m2.464 3.5A13.1 13.1 0 0 1 10 12.378 13.1 13.1 0 0 1 7.536 8.25zm3.036 1.5a.75.75 0 0 1 .685.445l4 9a.75.75 0 0 1-1.37.61L17.9 17.75H13.1l-.914 2.055a.75.75 0 0 1-1.37-.61l4-9a.75.75 0 0 1 .685-.445m0 2.597 1.735 3.903h-3.47z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+          Language
+        </button>
+        <div
+          id="language-picker"
+          popover="manual"
+          data-variant="default"
+        >
+          <ul>
+            <li>
+              <button
+                data-variant="tertiary"
+                type="button"
+                lang="nb"
+              >
+                Bokmål
+              </button>
+            </li>
+            <li aria-current="true">
+              <button
+                data-variant="tertiary"
+                type="button"
+                lang="nn"
+              >
+                Nynorsk
+              </button>
+            </li>
+            <li>
+              <button
+                data-variant="tertiary"
+                type="button"
+                lang="se"
+              >
+                Davvisámegiella
+              </button>
+            </li>
+            <li>
+              <button
+                data-variant="tertiary"
+                type="button"
+                lang="en"
+              >
+                English
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
 exports[`With Menu 1`] = `
 <div data-size="auto">
   <header
@@ -4561,6 +4661,61 @@ exports[`With Theme Menus 1`] = `
             </div>
           </nav>
         </div>
+      </div>
+    </div>
+  </header>
+</div>
+`;
+
+exports[`With Two Languages 1`] = `
+<div data-size="auto">
+  <header
+    data-scroll-direction="up"
+    data-top="true"
+    style="--udsc-header-max-width: 80rem;"
+  >
+    <div>
+      <a href="/">
+        <div style="--uds-logo-padding: 0;">
+          <img
+            alt="Utdanningsdirektoratet"
+            src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-3&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-2&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+          >
+          <img
+            alt="Utdanningsdirektoratet"
+            src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-2&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-3&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+          >
+        </div>
+        <span data-size="xs">
+          Tjenestenavn
+        </span>
+      </a>
+      <div>
+        <button
+          data-variant="tertiary"
+          type="button"
+          lang="nb"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M10 4.75a.75.75 0 0 1 .75.75v1.25H16a.75.75 0 0 1 0 1.5h-1.948a14.6 14.6 0 0 1-2.995 5.197q.22.198.448.386a.75.75 0 0 1-.953 1.158 15 15 0 0 1-.552-.478 14.6 14.6 0 0 1-4.212 2.68.75.75 0 0 1-.576-1.385 13.1 13.1 0 0 0 3.73-2.361A14.6 14.6 0 0 1 5.949 8.25H4a.75.75 0 0 1 0-1.5h5.25V5.5a.75.75 0 0 1 .75-.75m2.464 3.5A13.1 13.1 0 0 1 10 12.378 13.1 13.1 0 0 1 7.536 8.25zm3.036 1.5a.75.75 0 0 1 .685.445l4 9a.75.75 0 0 1-1.37.61L17.9 17.75H13.1l-.914 2.055a.75.75 0 0 1-1.37-.61l4-9a.75.75 0 0 1 .685-.445m0 2.597 1.735 3.903h-3.47z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+          Bytt til nynorsk
+        </button>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## Hva er gjort?

`Dropdown.Item` sin styling tar nå høyde for attributt `aria-current="true"`. Dette elementet får et checkmark før seg, alle elementer i menyen får et innrykk. 

Oppdatert dokumentasjon for `Header` med et eksempel på hvordan språkvalg kan løses, f.eks. med den nye "varianten" av dropdown. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er testet i test-app
- [x] Komponenten er testet med skjermleser og/eller annet UU-verktøy
