### PR TITLE
fix: support right to left in css 

### DIFF
--- a/@udir-design/react/src/components/alert/alert.css
+++ b/@udir-design/react/src/components/alert/alert.css
@@ -1,5 +1,5 @@
 .ds-alert {
   :is(h1, h2, h3, h4, h5, h6) {
-    margin-bottom: var(--ds-size-2);
+    margin-block-end: var(--ds-size-2);
   }
 }

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -70,10 +70,10 @@
   }
 
   & > div > .ds-button {
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 
   > * + * {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 }

--- a/@udir-design/react/src/components/footer/footer.css
+++ b/@udir-design/react/src/components/footer/footer.css
@@ -1,7 +1,7 @@
 .uds-footer {
   background-color: var(--ds-color-accent-surface-tinted);
-  left: 0;
-  bottom: 0;
+  inset-inline-start: 0;
+  inset-block-end: 0;
   padding-inline: var(--ds-size-5);
   padding-block: var(--ds-size-10);
 
@@ -25,7 +25,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
-    padding-right: calc(10.5rem + var(--ds-size-22));
+    padding-inline-end: calc(10.5rem + var(--ds-size-22));
   }
 
   .uds-footer__list {
@@ -41,8 +41,8 @@
     &[data-variant='social'] {
       display: flex;
       position: absolute;
-      bottom: 0;
-      right: 0;
+      inset-block-end: 0;
+      inset-inline-end: 0;
       flex-direction: row;
       justify-content: flex-end;
     }
@@ -50,8 +50,8 @@
 
   .uds-footer__logo {
     position: absolute;
-    top: 0;
-    right: 0;
+    inset-block-start: 0;
+    inset-inline-end: 0;
     height: fit-content;
 
     @composes ds-focus from '@digdir/designsystemet-css/base.css';
@@ -94,8 +94,8 @@
 
     .uds-footer__logo {
       position: relative;
-      top: initial;
-      right: initial;
+      inset-block-start: initial;
+      inset-inline-end: initial;
       .uds-logo {
         --uds-logo-size: var(--ds-size-10);
       }

--- a/@udir-design/react/src/components/footer/footer.css
+++ b/@udir-design/react/src/components/footer/footer.css
@@ -4,6 +4,7 @@
   inset-block-end: 0;
   padding-inline: var(--ds-size-5);
   padding-block: var(--ds-size-10);
+  min-height: 4.25rem;
 
   & .ds-link {
     --dsc-link-color--visited: var(--dsc-link-color);

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -348,8 +348,8 @@
         }
 
         &::after {
-          margin-top: var(--ds-size-1);
-          margin-left: calc(
+          margin-block-start: var(--ds-size-1);
+          margin-inline-start: calc(
             var(--uds-form-navigation-icon-size) + var(--ds-size-2)
           );
           opacity: 1;
@@ -366,10 +366,10 @@
         &::before {
           content: '';
           position: absolute;
-          bottom: calc(
+          inset-block-end: calc(
             100% + (var(--uds-form-navigation-connector) / 2) - var(--ds-size-1)
           );
-          left: 50%;
+          inset-inline-start: 50%;
           transform: translateX(-50%);
           width: 1px;
           height: var(--uds-form-navigation-connector);
@@ -378,7 +378,7 @@
       }
 
       &:first-of-type {
-        margin-top: var(--uds-form-navigation-connector);
+        margin-block-start: var(--uds-form-navigation-connector);
       }
     }
   }

--- a/@udir-design/react/src/components/formNavigation/formNavigation.stories.module.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.stories.module.css
@@ -11,10 +11,10 @@
 }
 
 .navigation {
-  padding-top: 1.5rem;
+  padding-block-start: 1.5rem;
   position: sticky;
   @media (min-width: 768px) {
-    padding-top: 3rem;
+    padding-block-start: 3rem;
   }
 }
 
@@ -42,7 +42,7 @@
   display: flex;
   gap: var(--ds-size-2);
   width: 100%;
-  margin-top: var(--ds-size-2);
+  margin-block-start: var(--ds-size-2);
   > button {
     flex: 1;
   }

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -43,7 +43,7 @@
     justify-content: flex-end;
 
     > .ds-tag {
-      margin-right: auto;
+      margin-inline-end: auto;
     }
   }
 
@@ -56,7 +56,7 @@
     }
 
     > input {
-      padding-right: var(--ds-size-1);
+      padding-inline-end: var(--ds-size-1);
     }
 
     &:focus-within,
@@ -66,7 +66,7 @@
       }
       width: calc(var(--ds-size-18) * 4);
       > input {
-        padding-right: var(--ds-size-10);
+        padding-inline-end: var(--ds-size-10);
       }
     }
 
@@ -106,11 +106,11 @@
     position: fixed;
     width: 100%;
     border: none;
-    top: calc(var(--udsc-header-padding) - var(--ds-size-3));
+    inset-block-start: calc(var(--udsc-header-padding) - var(--ds-size-3));
     max-height: 0;
     overflow: hidden;
     background-color: var(--ds-color-background-default);
-    left: 0;
+    inset-inline-start: 0;
 
     & ul {
       margin: 0;
@@ -198,7 +198,7 @@
     }
 
     > svg {
-      margin-left: var(--ds-size-1);
+      margin-inline-start: var(--ds-size-1);
       flex-shrink: 0;
     }
 
@@ -266,7 +266,7 @@
   /* Sticky auto hide header */
   &[data-scroll-direction] {
     position: sticky;
-    top: 0;
+    inset-block-start: 0;
     transition:
       transform 200ms ease,
       box-shadow 200ms ease;

--- a/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
@@ -103,18 +103,28 @@ export const FormExample = meta.story({
         }}
       >
         <Fieldset id="rankings">
-          <Fieldset.Legend>
-            <Heading level={4}>Skjema</Heading>
-          </Fieldset.Legend>
-          <ProgressBar
-            {...args}
-            tabIndex={-1}
-            ref={progressRef}
-            value={page}
-            style={{ marginInline: 'var(--ds-size-8)' }}
-            aria-label="Skjemafremgang"
-          />
-          <Table>
+          <div
+            style={{
+              display: 'flex',
+              width: '100%',
+              justifyContent: 'space-between',
+              alignItems: 'flex-end',
+              marginBlockEnd: 'var(--ds-size-4)',
+            }}
+          >
+            <Fieldset.Legend>
+              <Heading level={4}>Skjema</Heading>
+            </Fieldset.Legend>
+            <ProgressBar
+              {...args}
+              tabIndex={-1}
+              ref={progressRef}
+              value={page}
+              style={{ width: '30%' }}
+              aria-label="Skjemafremgang"
+            />
+          </div>
+          <Table border>
             <Table.Head>
               <Table.Row>
                 <Table.HeaderCell>Påstander</Table.HeaderCell>

--- a/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
+++ b/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
@@ -3,47 +3,49 @@
 exports[`Form Example 1`] = `
 <div style="display: flex; flex-direction: column; gap: var(--ds-size-6);">
   <fieldset id="rankings">
-    <legend data-weight="medium">
-      <h4>
-        Skjema
-      </h4>
-    </legend>
-    <div
-      data-color="accent"
-      tabindex="-1"
-      aria-label="Skjemafremgang"
-      style="margin-inline: var(--ds-size-8);"
-    >
-      <span>
-        Side 1 av 7
-      </span>
-      <u-progress
-        value="1"
-        id=":u-progress3"
-        aria-busy="false"
-        aria-label
-        aria-valuemax="100"
-        aria-valuemin="0"
-        aria-valuenow="14"
-        role="progressbar"
-        max="7"
-        aria-hidden="true"
-        style="--percentage: 14%;"
+    <div style="display: flex; width: 100%; justify-content: space-between; align-items: flex-end; margin-block-end: var(--ds-size-4);">
+      <legend data-weight="medium">
+        <h4>
+          Skjema
+        </h4>
+      </legend>
+      <div
+        data-color="accent"
+        tabindex="-1"
+        aria-label="Skjemafremgang"
+        style="width: 30%;"
       >
-        <template shadowrootmode="open">
-          <slot>
-          </slot>
-          <style>
-            :host(:not([hidden])) { box-sizing: border-box; border: 1px solid; display: inline-block; height: .5em; width: 10em; overflow: hidden }
+        <span>
+          Side 1 av 7
+        </span>
+        <u-progress
+          value="1"
+          id=":u-progress3"
+          aria-busy="false"
+          aria-label
+          aria-valuemax="100"
+          aria-valuemin="0"
+          aria-valuenow="14"
+          role="progressbar"
+          max="7"
+          aria-hidden="true"
+          style="--percentage: 14%;"
+        >
+          <template shadowrootmode="open">
+            <slot>
+            </slot>
+            <style>
+              :host(:not([hidden])) { box-sizing: border-box; border: 1px solid; display: inline-block; height: .5em; width: 10em; overflow: hidden }
 :host::before { content: ''; display: block; height: 100%; background: currentColor; width: var(--percentage, 0%); transition: width .2s }
 :host(:not([value])) { background: linear-gradient(90deg,currentColor 25%, transparent 50%, currentColor 75%) 50%/400% }
 @media (prefers-reduced-motion: no-preference) { :host { animation: indeterminate 2s linear infinite }  }
 @keyframes indeterminate { from { background-position-x: 100% } to { background-position-x: 0 } }
-          </style>
-        </template>
-      </u-progress>
+            </style>
+          </template>
+        </u-progress>
+      </div>
     </div>
-    <table>
+    <table data-border="true">
       <thead>
         <tr>
           <th>

--- a/@udir-design/react/src/components/progressBar/progressBar.css
+++ b/@udir-design/react/src/components/progressBar/progressBar.css
@@ -28,8 +28,8 @@
       transition: 0.5s;
       /* avoid being placed offset due to border of background bar */
       position: absolute;
-      top: -1px;
-      left: -1px;
+      inset-block-start: -1px;
+      inset-inline-start: -1px;
     }
   }
   /**

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -30,7 +30,7 @@
     th[scope='row'] {
       background-color: var(--ds-color-neutral-background-default);
       position: sticky;
-      left: 0;
+      inset-inline-start: 0;
     }
 
     &[data-tinted-column-header] > thead > tr > :is(th, td) {

--- a/@udir-design/react/src/components/tableOfContents/tableOfContents.css
+++ b/@udir-design/react/src/components/tableOfContents/tableOfContents.css
@@ -28,12 +28,12 @@
     }
 
     & li:not(:last-child) {
-      margin-bottom: var(--ds-size-3);
+      margin-block-end: var(--ds-size-3);
     }
   }
 
   & li.level-3,
   li.level-4 {
-    margin-left: var(--ds-size-3);
+    margin-inline-start: var(--ds-size-3);
   }
 }

--- a/@udir-design/react/src/components/typography/prose/prose.css
+++ b/@udir-design/react/src/components/typography/prose/prose.css
@@ -1,41 +1,41 @@
 .uds-prose {
   & > * {
-    margin-bottom: var(--ds-size-5);
+    margin-block-end: var(--ds-size-5);
   }
 
   & .ds-heading {
-    margin-bottom: var(--ds-size-4);
+    margin-block-end: var(--ds-size-4);
 
     &[data-size='2xl'] {
-      margin-top: var(--ds-size-12);
+      margin-block-start: var(--ds-size-12);
     }
 
     &[data-size='xl'] {
-      margin-top: var(--ds-size-11);
+      margin-block-start: var(--ds-size-11);
     }
 
     &[data-size='lg'] {
-      margin-top: var(--ds-size-10);
+      margin-block-start: var(--ds-size-10);
     }
 
     &[data-size='md'] {
-      margin-top: var(--ds-size-9);
+      margin-block-start: var(--ds-size-9);
     }
 
     &[data-size='sm'] {
-      margin-top: var(--ds-size-8);
+      margin-block-start: var(--ds-size-8);
     }
 
     &[data-size='xs'] {
-      margin-top: var(--ds-size-7);
+      margin-block-start: var(--ds-size-7);
     }
 
     &[data-size='2xs'] {
-      margin-top: var(--ds-size-6);
+      margin-block-start: var(--ds-size-6);
     }
 
     &:first-child {
-      margin-top: 0;
+      margin-block-start: 0;
     }
   }
 }


### PR DESCRIPTION
## Hva er gjort?

Oppdatert css til å bruke `margin-block-end` osv. for å støtte `dir="rtl"` for tjenester som har språk med denne retningen. 
- Kjørte en `ctrl+shift+f` og endret alle _våre_ komponenter, det gjaldt en del. Lurt å være obs på fremover. 

Har også oppdatert et eksempel på `ProgressBar` for å følge retningen vi gikk for i arbeidet med PBU elevundersøkelsen ved å ha ProgressBar på samme linje som overskrift. 

Folk er litt uenige, men tenker det er fair å følge Material Design og snu retningen på progressBar ved `dir="rtl"` 
- https://m2.material.io/design/usability/bidirectionality.html#mirroring-layout
  - Hevder progressbar og annen directional UI skal flippes
- https://github.com/w3c/alreq/issues/259
  - Arabisk-talende person her argumenterer for hvorfor det IKKE burde flippes 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
  - Fikk ikke tatt med fult navn på alle komponenter pga. grense på 100 tegn 
