### PR TITLE
fix/progressbar 

### DIFF
--- a/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
@@ -23,7 +23,7 @@ export const Preview = meta.story({
   args: {
     value: 3,
     max: 10,
-    label: ({ value, max }) => `Steg ${value} av ${max}`,
+    progressText: ({ value, max }) => `Steg ${value} av ${max}`,
   },
   render: (args) => <ProgressBar {...args} />,
   play: async ({ canvasElement, step, args }) => {
@@ -47,7 +47,7 @@ export const Percentage = meta.story({
   args: {
     value: 2,
     max: 10,
-    label: ({ percentage }) => `${percentage}%`,
+    progressText: ({ percentage }) => `${percentage}%`,
   },
   render: (args) => <ProgressBar {...args} />,
   play: async ({ canvasElement, step }) => {
@@ -72,7 +72,7 @@ const DATA_ASSERTIONS = [
 export const FormExample = meta.story({
   args: {
     'data-color': 'accent',
-    label: ({ value, max }) => `Side ${value} av ${max}`,
+    progressText: ({ value, max }) => `Side ${value} av ${max}`,
     value: 1,
     max: 7,
   },

--- a/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { expect, within } from 'storybook/test';
 import { ArrowLeftIcon, ArrowRightIcon } from '@udir-design/icons';
 import preview from '.storybook/preview';
 import { Button } from '../button/Button';
@@ -22,9 +23,39 @@ export const Preview = meta.story({
   args: {
     value: 3,
     max: 10,
-    prefix: 'Steg',
+    label: ({ value, max }) => `Steg ${value} av ${max}`,
   },
   render: (args) => <ProgressBar {...args} />,
+  play: async ({ canvasElement, step, args }) => {
+    const canvas = within(canvasElement);
+
+    await step('Label is rendered correctly', async () => {
+      expect(canvas.getByText('Steg 3 av 10')).toBeInTheDocument();
+    });
+
+    await step('u-progress is rendered with correct attributes', async () => {
+      const el = canvasElement.querySelector('u-progress');
+      expect(el).toBeTruthy();
+      expect(el).toHaveAttribute('value', String(args.value));
+      expect(el).toHaveAttribute('max', String(args.max));
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+    });
+  },
+});
+
+export const Percentage = meta.story({
+  args: {
+    value: 2,
+    max: 10,
+    label: ({ percentage }) => `${percentage}%`,
+  },
+  render: (args) => <ProgressBar {...args} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('Percentage is rendered', async () => {
+      expect(canvas.getByText('20%')).toBeInTheDocument();
+    });
+  },
 });
 
 const DATA_RANKINGS = ['Uenig', 'Nøytral', 'Enig'];
@@ -41,7 +72,7 @@ const DATA_ASSERTIONS = [
 export const FormExample = meta.story({
   args: {
     'data-color': 'accent',
-    prefix: 'Side',
+    label: ({ value, max }) => `Side ${value} av ${max}`,
     value: 1,
     max: 7,
   },

--- a/@udir-design/react/src/components/progressBar/ProgressBar.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.tsx
@@ -29,26 +29,19 @@ export type ProgressBarProps = Omit<
    */
   value: number;
   /**
-   * Text to display before the current step number
+   * Format the label text with `value`, `max` and `percentage` as arguments: `label: ({ value, max, percentage }) => \`Steg ${value} av ${max}\``
    */
-  prefix?: string;
-  /**
-   * Show the progress as a percentage instead of step numbers
-   * @default false
-   */
-  percentage?: boolean;
+  label?: (args: { value: number; max: number; percentage: number }) => string;
 };
 
 export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
-  function ProgressBar(
-    { className, max, value, prefix = '', percentage = false, ...rest },
-    ref,
-  ) {
-    const progress = ((value / max) * 100).toFixed(0);
-    const progressText = percentage ? `${progress}%` : `${value} av ${max}`;
+  function ProgressBar({ className, max, value, label, ...rest }, ref) {
+    const percentage = max > 0 ? Math.round((value / max) * 100) : 0;
+    const labelText =
+      label?.({ value, max, percentage }) ?? `${value} av ${max}`;
     return (
       <div className={cl(`uds-progressBar`, className)} ref={ref} {...rest}>
-        <span>{`${prefix} ${progressText}`}</span>
+        <span>{labelText}</span>
         <u-progress
           value={value}
           max={max}

--- a/@udir-design/react/src/components/progressBar/ProgressBar.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.tsx
@@ -29,19 +29,23 @@ export type ProgressBarProps = Omit<
    */
   value: number;
   /**
-   * Format the label text with `value`, `max` and `percentage` as arguments: `label: ({ value, max, percentage }) => \`Steg ${value} av ${max}\``
+   * Format the progress text with `value`, `max` and `percentage` as arguments: `progressText: ({ value, max, percentage }) => \`Steg ${value} av ${max}\``
    */
-  label?: (args: { value: number; max: number; percentage: number }) => string;
+  progressText?: (args: {
+    value: number;
+    max: number;
+    percentage: number;
+  }) => string;
 };
 
 export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
-  function ProgressBar({ className, max, value, label, ...rest }, ref) {
+  function ProgressBar({ className, max, value, progressText, ...rest }, ref) {
     const percentage = max > 0 ? Math.round((value / max) * 100) : 0;
-    const labelText =
-      label?.({ value, max, percentage }) ?? `${value} av ${max}`;
+    const text =
+      progressText?.({ value, max, percentage }) ?? `${value} av ${max}`;
     return (
       <div className={cl(`uds-progressBar`, className)} ref={ref} {...rest}>
-        <span>{labelText}</span>
+        <span>{text}</span>
         <u-progress
           value={value}
           max={max}

--- a/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
+++ b/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
@@ -19,7 +19,7 @@ exports[`Form Example 1`] = `
       </span>
       <u-progress
         value="1"
-        id=":u-progress2"
+        id=":u-progress3"
         aria-busy="false"
         aria-label
         aria-valuemax="100"
@@ -202,6 +202,39 @@ exports[`Form Example 1`] = `
       </svg>
     </button>
   </div>
+</div>
+`;
+
+exports[`Percentage 1`] = `
+<div>
+  <span>
+    20%
+  </span>
+  <u-progress
+    value="2"
+    id=":u-progress2"
+    aria-busy="false"
+    aria-label
+    aria-valuemax="100"
+    aria-valuemin="0"
+    aria-valuenow="20"
+    role="progressbar"
+    max="10"
+    aria-hidden="true"
+    style="--percentage: 20%;"
+  >
+    <template shadowrootmode="open">
+      <slot>
+      </slot>
+      <style>
+        :host(:not([hidden])) { box-sizing: border-box; border: 1px solid; display: inline-block; height: .5em; width: 10em; overflow: hidden }
+:host::before { content: ''; display: block; height: 100%; background: currentColor; width: var(--percentage, 0%); transition: width .2s }
+:host(:not([value])) { background: linear-gradient(90deg,currentColor 25%, transparent 50%, currentColor 75%) 50%/400% }
+@media (prefers-reduced-motion: no-preference) { :host { animation: indeterminate 2s linear infinite }  }
+@keyframes indeterminate { from { background-position-x: 100% } to { background-position-x: 0 } }
+      </style>
+    </template>
+  </u-progress>
 </div>
 `;
 

--- a/test-apps/nextjs/src/app/page.tsx
+++ b/test-apps/nextjs/src/app/page.tsx
@@ -8,7 +8,7 @@ export default function Index() {
     <div className={styles.page}>
       <h1>Test app for Next.js setup with @udir-design/react</h1>
       <Button onClick={() => console.log('clicked')}>Click me</Button>
-      <ProgressBar prefix="Steg" max={10} value={1} />
+      <ProgressBar max={10} value={1} />
     </div>
   );
 }


### PR DESCRIPTION
## Hva er gjort?

- Legger til interaction test 
- For at Progressbar skal fungere med bytte av språk så må "av" ("Steg 2 av 4") også være mulig endre. Vi kunne lagt til enda en prop, men det da blir det litt mange props. Noen språk vil også mest sannsynlig ha rekkefølgen av tall og ord forskjellig fra de nordiske språkene. 

Forslag om å endre fra `prefix` og `percentage` til `label?: (args: { value: number; max: number; percentage: number }) => string;` 
