### PR TITLE
feat: new component FieldNecessity to automatically show necessity tags in forms

### DIFF
--- a/@udir-design/react/.storybook/preview-head.html
+++ b/@udir-design/react/.storybook/preview-head.html
@@ -3,3 +3,6 @@
   as="style"
   href="https://altinncdn.no/fonts/inter/v4/inter.css"
 />
+<script>
+  document.documentElement.lang = 'nb';
+</script>

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@digdir/designsystemet-react": "catalog:",
     "@digdir/designsystemet-types": "catalog:",
+    "@radix-ui/react-slot": "catalog:",
     "@u-elements/u-details": "catalog:",
     "@u-elements/u-progress": "catalog:",
     "@udir-design/css": "workspace:*",

--- a/@udir-design/react/src/components/alpha.ts
+++ b/@udir-design/react/src/components/alpha.ts
@@ -5,6 +5,7 @@
 export * from './fileUpload';
 export * from './footer';
 export * from './header';
+export * from './fieldNecessity';
 export * from './formNavigation';
 export * from './logo';
 export * from './progressBar/ProgressBar';

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -40,7 +40,7 @@ Med bakgrunn i bruksmønsteret for obligatoriske felter er standard at markering
 <Canvas of={FieldNecessityStories.AllRequired} />
 <Canvas of={FieldNecessityStories.AllOptional} />
 
-Dersom du ikke ønsker å ha oppsumeringen helt øverst, kan du plassere `<FieldNecessity.Summary />` der du ønsker at `Tag`en skal vises. F.eks. dersom du har en felles beskrivelse av skjemafeltene slik som i eksempelet under.
+Dersom du ikke ønsker å ha oppsumeringen helt øverst, kan du plassere `<FieldNecessity.Summary />` der du ønsker at oppsummeringen skal vises. F.eks. dersom du har en felles beskrivelse av skjemafeltene slik som i eksempelet under.
 
 <Canvas of={FieldNecessityStories.ManualSummaryPlacement} />
 
@@ -76,7 +76,7 @@ I noen tilfeller, slik som i eksempelet under, vil kun enkelte `Checkbox`er vær
 
 ### Outline
 
-På noen bakgrunner skiller `Tag` seg ikke like godt ut. I disse tilfellene kan du bruke `variant="outline"`.
+På noen bakgrunner skiller ikke feltmarkeringen seg like godt ut. I disse tilfellene kan du bruke `variant="outline"`.
 
 <Canvas of={FieldNecessityStories.Outline} />
 

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -1,0 +1,62 @@
+import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as FieldNecessityStories from './FieldNecessity.stories';
+import { Field } from '@digdir/designsystemet-react';
+
+<Meta of={FieldNecessityStories} />
+
+# FieldNecessity
+
+`FieldNecessity` brukes sammen med input-felter for å automatisk markere skjemafelter som obligatoriske eller valgfrie. Les mer om hvilke felter som må merkes i [bruksmønster for obligatoriske felter](/docs/patterns-obligatoriske-felt--docs).
+
+**Passer til å**
+
+- markere skjemafelter som obligatoriske eller valgfrie
+
+## Slik bruker du FieldNecessity
+
+<Primary />
+<Controls />
+
+```tsx
+import { FieldNecessity } from '@udir-design/react';
+
+<FieldNecessity>
+  <Textfield label="Fornavn" required />
+  <Textfield label="Etternavn" required />
+</FieldNecessity>;
+```
+
+Komponenten bruker attributtene `required` eller `aria-required` på `input` inni komponenten for å bestemme hvilke `Tag`s som skal vises.
+
+## Eksempler
+
+### Oppsummering
+
+Med bakgrunn i bruksmønsteret for obligatoriske felter er standard at markeringen vises som en oppsummering øverst på skjemasiden. Dette forutsetter at alle skjemafelter enten er obligatorske eller valgfrie.
+
+<Canvas of={FieldNecessityStories.AllRequired} />
+<Canvas of={FieldNecessityStories.AllOptional} />
+
+Dersom du ikke ønsker å ha oppsumeringen helt øverst, kan du plassere `<FieldNecessity.Summary />` der du ønsker at `Tag`en skal vises. F.eks. dersom du har en felles beskrivelse av skjemafeltene slik som i eksempelet under.
+
+<Canvas of={FieldNecessityStories.ManualSummaryPlacement} />
+
+### Kombinasjon av obligatoriske og valgfrie felter
+
+Dersom kun noen av feltene på en skjemaside er obligatoriske, settes `showSummary` til `false`.
+
+### Checkboxer
+
+Dersom det er obligatorisk å huke av på minst én `Checkbox`, men ikke obligatorisk å huke av på enkeltbokser løses dette ved å sette `required` på alle `Checkbox`er.
+
+<Canvas of={FieldNecessityStories.FieldsetCheckboxes} />
+
+I noen tilfeller, slik som i eksempelet under, vil kun enkelte `Checkbox`er være obligatoriske å huke av. Da setter du `required` på de individuelle `Checkbox`ene det gjelder.
+
+<Canvas of={FieldNecessityStories.IndividualCheckboxes} />
+
+### Outline
+
+På noen bakgrunner skiller `Tag` seg ikke like godt ut. I disse tilfellene kan du bruke `vairant="outline"`.
+
+<Canvas of={FieldNecessityStories.Outline} />

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -21,12 +21,15 @@ import { Field } from '@digdir/designsystemet-react';
 import { FieldNecessity } from '@udir-design/react';
 
 <FieldNecessity>
-  <Textfield label="Fornavn" required />
-  <Textfield label="Etternavn" required />
+  <Textfield label={<span>Fornavn</span>} required />
+  <Textfield label={<span>Etternavn</span>} required />
 </FieldNecessity>;
 ```
 
 Komponenten leser attributtene `required` eller `aria-required` på skjemafeltene du legger inni komponenten for å bestemme hvilken markering som skal vises.
+
+**Legg merke til:** du bør legge en `<span>` rundt `label`-teksten for å få penest mulig resultat. Uten dette
+vil du kunne komme i situasjoner der feltmarkeringen får et innrykk når den havner på en egen linje.
 
 ## Eksempler
 

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -26,7 +26,7 @@ import { FieldNecessity } from '@udir-design/react';
 </FieldNecessity>;
 ```
 
-Komponenten bruker attributtene `required` eller `aria-required` på `input` inni komponenten for å bestemme hvilke `Tag`s som skal vises.
+Komponenten leser attributtene `required` eller `aria-required` på skjemafeltene du legger inni komponenten for å bestemme hvilken markering som skal vises.
 
 ## Eksempler
 
@@ -41,15 +41,31 @@ Dersom du ikke ønsker å ha oppsumeringen helt øverst, kan du plassere `<Field
 
 <Canvas of={FieldNecessityStories.ManualSummaryPlacement} />
 
+### Ett enkelt felt
+
+Når det kun finnes ett felt er det bedre å markere feltet, heller enn å vise oppsummering.
+Dette gjør du ved å sette `showSummary={false}` (merk: i eksemplene kommer ikke `showSummary={false}` med i kodevisningen på grunn av en bug i Storybook).
+
+<Canvas of={FieldNecessityStories.SingleRequiredField} />
+
+Dersom det kun finnes ett enkelt felt, og dette er valgfritt, kan man i tillegg vurdere å skru på
+markering av valgfri felt med `showOptional={true}`. Dette er kun nødvendig dersom det ikke er åpenbart
+fra teksten at feltet er valgfritt.
+
+<Canvas of={FieldNecessityStories.SingleOptionalField} />
+
 ### Kombinasjon av obligatoriske og valgfrie felter
 
-Dersom kun noen av feltene på en skjemaside er obligatoriske, settes `showSummary` til `false`.
+Dersom kun noen av feltene på en skjemaside er obligatoriske, markerer vi automatisk disse feltene og skjuler oppsummeringen.
 
-### Checkboxer
+### Markering av Fieldset
 
-Dersom det er obligatorisk å huke av på minst én `Checkbox`, men ikke obligatorisk å huke av på enkeltbokser løses dette ved å sette `required` på alle `Checkbox`er.
+Dersom det er obligatorisk å huke av på minst én `Checkbox` eller velge en `Radio` i et `Fieldset` løses dette ved å sette `required` på hver enkelt `Checkbox` eller `Radio`. Den enkleste måten å gjøre det er å sende inn `required: true` som prop til `useCheckboxGroup` eller `useRadioGroup`.
 
 <Canvas of={FieldNecessityStories.FieldsetCheckboxes} />
+<Canvas of={FieldNecessityStories.FieldsetRadios} />
+
+### Individuelle checkboxer
 
 I noen tilfeller, slik som i eksempelet under, vil kun enkelte `Checkbox`er være obligatoriske å huke av. Da setter du `required` på de individuelle `Checkbox`ene det gjelder.
 
@@ -57,6 +73,14 @@ I noen tilfeller, slik som i eksempelet under, vil kun enkelte `Checkbox`er vær
 
 ### Outline
 
-På noen bakgrunner skiller `Tag` seg ikke like godt ut. I disse tilfellene kan du bruke `vairant="outline"`.
+På noen bakgrunner skiller `Tag` seg ikke like godt ut. I disse tilfellene kan du bruke `variant="outline"`.
 
 <Canvas of={FieldNecessityStories.Outline} />
+
+## Tilgjengelighet
+
+Markeringen av obligatoriske felter er skjult for skjermlesere, siden de allerede leser opp `required` eller `aria-required`. Slik unngår vi å lese dette opp dobbelt.
+
+Dersom man skrur på markering av valgfri felter med `showOptional={true}` vil disse leses opp av skjermleser.
+
+Oppsummeringen vil alltid leses av skjermlesere dersom den er synlig.

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
@@ -1,0 +1,239 @@
+import type { StoryContext } from '@storybook/react-vite';
+import preview from '.storybook/preview';
+import { useCheckboxGroup } from 'src/utilities/hooks/useCheckboxGroup/useCheckboxGroup';
+import { Card } from '../card/Card';
+import { Checkbox } from '../checkbox/Checkbox';
+import { Fieldset } from '../fieldset/Fieldset';
+import { Textfield } from '../textfield/Textfield';
+import { Heading } from '../typography/heading/Heading';
+import { Paragraph } from '../typography/paragraph/Paragraph';
+import { ValidationMessage } from '../typography/validationMessage/ValidationMessage';
+import { FieldNecessity } from '.';
+
+const meta = preview.meta({
+  component: FieldNecessity,
+  tags: ['alpha', 'udir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'self',
+    },
+    layout: 'centered',
+  },
+});
+
+function id(context: StoryContext, id: string) {
+  const prefix = context.id.split('--')[1] ?? context.id;
+  return `${prefix}-${id}`;
+}
+
+export const Preview = meta.story({
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Textfield id={id(context, 'first')} label="Fornavn" required />
+      <Textfield id={id(context, 'middle')} label="Mellomnavn" />
+      <Textfield id={id(context, 'last')} label="Etternavn" required />
+    </FieldNecessity>
+  ),
+});
+
+export const Outline = meta.story({
+  args: { variant: 'outline' },
+  render: (args, context) => (
+    <Card variant="tinted">
+      <FieldNecessity
+        {...args}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: 'var(--ds-size-4)',
+        }}
+      >
+        <Textfield id={id(context, 'first')} label="Fornavn" required />
+        <Textfield id={id(context, 'middle')} label="Mellomnavn" />
+        <Textfield id={id(context, 'last')} label="Etternavn" required />
+      </FieldNecessity>
+    </Card>
+  ),
+});
+
+export const AllRequired = meta.story({
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Textfield id={id(context, 'first')} label="Fornavn" required />
+      <Textfield id={id(context, 'last')} label="Etternavn" required />
+    </FieldNecessity>
+  ),
+});
+
+export const AllOptional = meta.story({
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Textfield
+        id={id(context, 'opinion')}
+        multiline
+        label="Hva synes du om skjemaet?"
+      />
+      <Textfield
+        id={id(context, 'other')}
+        multiline
+        label="Har du noen andre innspill?"
+      />
+    </FieldNecessity>
+  ),
+});
+
+export const SingleOptionalField = meta.story({
+  args: { showSummary: false },
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Textfield
+        id={id(context, 'comments')}
+        multiline
+        label="Har du noen kommentarer?"
+      />
+    </FieldNecessity>
+  ),
+});
+
+export const SingleRequiredField = meta.story({
+  args: { showSummary: false },
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Textfield
+        id={id(context, 'events')}
+        multiline
+        label="Beskriv hendelsesforløpet"
+        required
+      />
+    </FieldNecessity>
+  ),
+});
+
+export const FieldsetCheckboxes = meta.story({
+  args: { showSummary: false },
+  render: (args, context) => {
+    const { getCheckboxProps, validationMessageProps } = useCheckboxGroup({
+      required: true,
+    });
+
+    return (
+      <FieldNecessity
+        {...args}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: 'var(--ds-size-4)',
+        }}
+      >
+        <Fieldset>
+          <Fieldset.Legend>
+            Hvordan vil du helst at vi skal kontakte deg?
+          </Fieldset.Legend>
+          <Fieldset.Description>
+            Velg de alternativene som er relevante for deg.
+          </Fieldset.Description>
+          <Checkbox
+            id={id(context, 'email')}
+            label="E-post"
+            {...getCheckboxProps('epost')}
+          />
+          <Checkbox
+            id={id(context, 'telefon')}
+            label="Telefon"
+            {...getCheckboxProps('telefon')}
+          />
+          <Checkbox
+            id={id(context, 'sms')}
+            label="SMS"
+            {...getCheckboxProps('sms')}
+          />
+          <ValidationMessage {...validationMessageProps} />
+        </Fieldset>
+      </FieldNecessity>
+    );
+  },
+});
+
+export const IndividualCheckboxes = meta.story({
+  render: (args, context) => {
+    return (
+      <FieldNecessity
+        {...args}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: 'var(--ds-size-4)',
+        }}
+      >
+        <Checkbox
+          id={id(context, 'terms-conditions')}
+          label="Jeg bekrefter at opplysningene i søknaden er korrekt"
+          required
+        />
+        <Checkbox
+          id={id(context, 'contact')}
+          label="Jeg er villig til å delta i en spørreundersøkelse i etterkant av søknadsprosessen"
+        />
+      </FieldNecessity>
+    );
+  },
+});
+
+export const ManualSummaryPlacement = meta.story({
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Heading level={2} data-size="md">
+        Kontaktinformasjon
+      </Heading>
+      <Paragraph>
+        Vi trenger å vite hvordan vi kan kontakte deg i etterkant av søknaden.
+      </Paragraph>
+      <FieldNecessity.Summary />
+      <Textfield id={id(context, 'first')} label="Fornavn" required />
+      <Textfield id={id(context, 'middle')} label="Etternavn" required />
+      <Textfield id={id(context, 'last')} label="E-postadresse" required />
+    </FieldNecessity>
+  ),
+});

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
@@ -1,9 +1,12 @@
 import type { StoryContext } from '@storybook/react-vite';
 import preview from '.storybook/preview';
+import { formatReactSource } from '.storybook/utils/sourceTransformers';
 import { useCheckboxGroup } from 'src/utilities/hooks/useCheckboxGroup/useCheckboxGroup';
+import { useRadioGroup } from 'src/utilities/hooks/useRadioGroup/useRadioGroup';
 import { Card } from '../card/Card';
 import { Checkbox } from '../checkbox/Checkbox';
 import { Fieldset } from '../fieldset/Fieldset';
+import { Radio } from '../radio/Radio';
 import { Textfield } from '../textfield/Textfield';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
@@ -104,16 +107,9 @@ export const AllOptional = meta.story({
 });
 
 export const SingleOptionalField = meta.story({
-  args: { showSummary: false },
+  args: { showSummary: false, showOptional: true },
   render: (args, context) => (
-    <FieldNecessity
-      {...args}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        rowGap: 'var(--ds-size-4)',
-      }}
-    >
+    <FieldNecessity {...args}>
       <Textfield
         id={id(context, 'comments')}
         multiline
@@ -126,14 +122,7 @@ export const SingleOptionalField = meta.story({
 export const SingleRequiredField = meta.story({
   args: { showSummary: false },
   render: (args, context) => (
-    <FieldNecessity
-      {...args}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        rowGap: 'var(--ds-size-4)',
-      }}
-    >
+    <FieldNecessity {...args}>
       <Textfield
         id={id(context, 'events')}
         multiline
@@ -145,21 +134,18 @@ export const SingleRequiredField = meta.story({
 });
 
 export const FieldsetCheckboxes = meta.story({
+  parameters: {
+    docs: { source: { type: 'code', transform: formatReactSource } },
+  },
   args: { showSummary: false },
   render: (args, context) => {
     const { getCheckboxProps, validationMessageProps } = useCheckboxGroup({
       required: true,
+      name: 'checkbox-group',
     });
 
     return (
-      <FieldNecessity
-        {...args}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          rowGap: 'var(--ds-size-4)',
-        }}
-      >
+      <FieldNecessity {...args}>
         <Fieldset>
           <Fieldset.Legend>
             Hvordan vil du helst at vi skal kontakte deg?
@@ -189,17 +175,45 @@ export const FieldsetCheckboxes = meta.story({
   },
 });
 
+export const FieldsetRadios = meta.story({
+  parameters: {
+    docs: { source: { type: 'code', transform: formatReactSource } },
+  },
+  args: { showSummary: false },
+  render: (args, context) => {
+    const ageGroups = [
+      { value: '10-20', label: '10-20 år' },
+      { value: '21-45', label: '21-45 år' },
+      { value: '46-80', label: '46-80 år' },
+    ];
+    const { getRadioProps, validationMessageProps } = useRadioGroup({
+      required: true,
+      name: 'radio-group',
+    });
+
+    return (
+      <FieldNecessity {...args}>
+        <Fieldset>
+          <Fieldset.Legend>Velg din aldersgruppe</Fieldset.Legend>
+          {ageGroups.map((group) => (
+            <Radio
+              key={group.value}
+              id={id(context, group.value)}
+              label={group.label}
+              {...getRadioProps(group.value)}
+            />
+          ))}
+          <ValidationMessage {...validationMessageProps} />
+        </Fieldset>
+      </FieldNecessity>
+    );
+  },
+});
+
 export const IndividualCheckboxes = meta.story({
   render: (args, context) => {
     return (
-      <FieldNecessity
-        {...args}
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          rowGap: 'var(--ds-size-4)',
-        }}
-      >
+      <FieldNecessity {...args}>
         <Checkbox
           id={id(context, 'terms-conditions')}
           label="Jeg bekrefter at opplysningene i søknaden er korrekt"

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
@@ -39,9 +39,17 @@ export const Preview = meta.story({
         rowGap: 'var(--ds-size-4)',
       }}
     >
-      <Textfield id={id(context, 'first')} label="Fornavn" required />
-      <Textfield id={id(context, 'middle')} label="Mellomnavn" />
-      <Textfield id={id(context, 'last')} label="Etternavn" required />
+      <Textfield
+        id={id(context, 'first')}
+        label={<span>Fornavn</span>}
+        required
+      />
+      <Textfield id={id(context, 'middle')} label={<span>Mellomnavn</span>} />
+      <Textfield
+        id={id(context, 'last')}
+        label={<span>Etternavn</span>}
+        required
+      />
     </FieldNecessity>
   ),
 });
@@ -58,9 +66,17 @@ export const Outline = meta.story({
           rowGap: 'var(--ds-size-4)',
         }}
       >
-        <Textfield id={id(context, 'first')} label="Fornavn" required />
-        <Textfield id={id(context, 'middle')} label="Mellomnavn" />
-        <Textfield id={id(context, 'last')} label="Etternavn" required />
+        <Textfield
+          id={id(context, 'first')}
+          label={<span>Fornavn</span>}
+          required
+        />
+        <Textfield id={id(context, 'middle')} label={<span>Mellomnavn</span>} />
+        <Textfield
+          id={id(context, 'last')}
+          label={<span>Etternavn</span>}
+          required
+        />
       </FieldNecessity>
     </Card>
   ),
@@ -76,8 +92,16 @@ export const AllRequired = meta.story({
         rowGap: 'var(--ds-size-4)',
       }}
     >
-      <Textfield id={id(context, 'first')} label="Fornavn" required />
-      <Textfield id={id(context, 'last')} label="Etternavn" required />
+      <Textfield
+        id={id(context, 'first')}
+        label={<span>Fornavn</span>}
+        required
+      />
+      <Textfield
+        id={id(context, 'last')}
+        label={<span>Etternavn</span>}
+        required
+      />
     </FieldNecessity>
   ),
 });
@@ -95,12 +119,12 @@ export const AllOptional = meta.story({
       <Textfield
         id={id(context, 'opinion')}
         multiline
-        label="Hva synes du om skjemaet?"
+        label={<span>Hva synes du om skjemaet?</span>}
       />
       <Textfield
         id={id(context, 'other')}
         multiline
-        label="Har du noen andre innspill?"
+        label={<span>Har du noen andre innspill?</span>}
       />
     </FieldNecessity>
   ),
@@ -113,7 +137,7 @@ export const SingleOptionalField = meta.story({
       <Textfield
         id={id(context, 'comments')}
         multiline
-        label="Har du noen kommentarer?"
+        label={<span>Har du noen kommentarer?</span>}
       />
     </FieldNecessity>
   ),
@@ -126,7 +150,7 @@ export const SingleRequiredField = meta.story({
       <Textfield
         id={id(context, 'events')}
         multiline
-        label="Beskriv hendelsesforløpet"
+        label={<span>Beskriv hendelsesforløpet</span>}
         required
       />
     </FieldNecessity>
@@ -148,24 +172,24 @@ export const FieldsetCheckboxes = meta.story({
       <FieldNecessity {...args}>
         <Fieldset>
           <Fieldset.Legend>
-            Hvordan vil du helst at vi skal kontakte deg?
+            <span>Hvordan vil du helst at vi skal kontakte deg?</span>
           </Fieldset.Legend>
           <Fieldset.Description>
             Velg de alternativene som er relevante for deg.
           </Fieldset.Description>
           <Checkbox
             id={id(context, 'email')}
-            label="E-post"
+            label={<span>E-post</span>}
             {...getCheckboxProps('epost')}
           />
           <Checkbox
             id={id(context, 'telefon')}
-            label="Telefon"
+            label={<span>Telefon</span>}
             {...getCheckboxProps('telefon')}
           />
           <Checkbox
             id={id(context, 'sms')}
-            label="SMS"
+            label={<span>SMS</span>}
             {...getCheckboxProps('sms')}
           />
           <ValidationMessage {...validationMessageProps} />
@@ -194,7 +218,9 @@ export const FieldsetRadios = meta.story({
     return (
       <FieldNecessity {...args}>
         <Fieldset>
-          <Fieldset.Legend>Velg din aldersgruppe</Fieldset.Legend>
+          <Fieldset.Legend>
+            <span>Velg din aldersgruppe</span>
+          </Fieldset.Legend>
           {ageGroups.map((group) => (
             <Radio
               key={group.value}
@@ -216,12 +242,19 @@ export const IndividualCheckboxes = meta.story({
       <FieldNecessity {...args}>
         <Checkbox
           id={id(context, 'terms-conditions')}
-          label="Jeg bekrefter at opplysningene i søknaden er korrekt"
+          label={
+            <span>Jeg bekrefter at opplysningene i søknaden er korrekt</span>
+          }
           required
         />
         <Checkbox
           id={id(context, 'contact')}
-          label="Jeg er villig til å delta i en spørreundersøkelse i etterkant av søknadsprosessen"
+          label={
+            <span>
+              Jeg er villig til å delta i en spørreundersøkelse i etterkant av
+              søknadsprosessen
+            </span>
+          }
         />
       </FieldNecessity>
     );
@@ -245,9 +278,21 @@ export const ManualSummaryPlacement = meta.story({
         Vi trenger å vite hvordan vi kan kontakte deg i etterkant av søknaden.
       </Paragraph>
       <FieldNecessity.Summary />
-      <Textfield id={id(context, 'first')} label="Fornavn" required />
-      <Textfield id={id(context, 'middle')} label="Etternavn" required />
-      <Textfield id={id(context, 'last')} label="E-postadresse" required />
+      <Textfield
+        id={id(context, 'first')}
+        label={<span>Fornavn</span>}
+        required
+      />
+      <Textfield
+        id={id(context, 'middle')}
+        label={<span>Etternavn</span>}
+        required
+      />
+      <Textfield
+        id={id(context, 'last')}
+        label={<span>E-postadresse</span>}
+        required
+      />
     </FieldNecessity>
   ),
 });

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.tsx
@@ -1,0 +1,62 @@
+import { Slot } from '@radix-ui/react-slot';
+import clsx from 'clsx/lite';
+import type { HTMLProps } from 'react';
+import { forwardRef } from 'react';
+
+export type FieldNecessityProps = HTMLProps<HTMLDivElement> & {
+  /**
+   * The visual variant of the necessity tags
+   *
+   * @default 'default'
+   */
+  variant?: 'default' | 'outline';
+  /**
+   * Show "required" tags on required fields
+   * @default true
+   */
+  showRequired?: boolean;
+  /**
+   * Show "optional" tags on optional fields
+   * @default false
+   */
+  showOptional?: boolean;
+  /**
+   * Show summary instead of individual tags if all fields have the same necessity
+   * @default true
+   */
+  showSummary?: boolean;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild?: boolean;
+};
+
+export const FieldNecessityComponent = forwardRef<
+  HTMLDivElement,
+  FieldNecessityProps
+>(function FieldNecessity(
+  {
+    className,
+    variant,
+    showRequired = true,
+    showOptional = false,
+    showSummary = true,
+    asChild,
+    ...props
+  },
+  ref,
+) {
+  const Component = asChild ? Slot : 'div';
+  return (
+    <Component
+      className={clsx(className, 'ds-field-necessity')}
+      ref={ref}
+      data-variant={variant}
+      data-show-required={showRequired}
+      data-show-optional={showOptional}
+      data-show-summary={showSummary}
+      {...props}
+    />
+  );
+});

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessitySummary.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessitySummary.tsx
@@ -1,0 +1,16 @@
+import clsx from 'clsx/lite';
+import type { HTMLProps } from 'react';
+import { forwardRef } from 'react';
+
+export const FieldNecessitySummary = forwardRef<
+  HTMLDivElement,
+  Omit<HTMLProps<HTMLDivElement>, 'children'>
+>(function FieldNecessity({ className, ...props }, ref) {
+  return (
+    <div
+      className={clsx(className, 'ds-field-necessity-summary')}
+      ref={ref}
+      {...props}
+    />
+  );
+});

--- a/@udir-design/react/src/components/fieldNecessity/__snapshots__/FieldNecessity.stories.tsx.snap
+++ b/@udir-design/react/src/components/fieldNecessity/__snapshots__/FieldNecessity.stories.tsx.snap
@@ -12,7 +12,9 @@ exports[`All Optional 1`] = `
       data-weight="medium"
       for="all-optional-opinion"
     >
-      Hva synes du om skjemaet?
+      <span>
+        Hva synes du om skjemaet?
+      </span>
     </label>
     <div>
       <textarea id="all-optional-opinion">
@@ -24,7 +26,9 @@ exports[`All Optional 1`] = `
       data-weight="medium"
       for="all-optional-other"
     >
-      Har du noen andre innspill?
+      <span>
+        Har du noen andre innspill?
+      </span>
     </label>
     <div>
       <textarea id="all-optional-other">
@@ -46,7 +50,9 @@ exports[`All Required 1`] = `
       data-weight="medium"
       for="all-required-first"
     >
-      Fornavn
+      <span>
+        Fornavn
+      </span>
     </label>
     <div>
       <input
@@ -61,7 +67,9 @@ exports[`All Required 1`] = `
       data-weight="medium"
       for="all-required-last"
     >
-      Etternavn
+      <span>
+        Etternavn
+      </span>
     </label>
     <div>
       <input
@@ -79,11 +87,12 @@ exports[`Fieldset Checkboxes 1`] = `
   data-show-required="true"
   data-show-optional="false"
   data-show-summary="false"
-  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
 >
   <fieldset>
     <legend data-weight="medium">
-      Hvordan vil du helst at vi skal kontakte deg?
+      <span>
+        Hvordan vil du helst at vi skal kontakte deg?
+      </span>
     </legend>
     <p data-variant="default">
       Velg de alternativene som er relevante for deg.
@@ -94,13 +103,15 @@ exports[`Fieldset Checkboxes 1`] = `
         required
         type="checkbox"
         value="epost"
-        name="_r_2_"
+        name="checkbox-group"
       >
       <label
         data-weight="regular"
         for="fieldset-checkboxes-email"
       >
-        E-post
+        <span>
+          E-post
+        </span>
       </label>
     </div>
     <div>
@@ -109,13 +120,15 @@ exports[`Fieldset Checkboxes 1`] = `
         required
         type="checkbox"
         value="telefon"
-        name="_r_2_"
+        name="checkbox-group"
       >
       <label
         data-weight="regular"
         for="fieldset-checkboxes-telefon"
       >
-        Telefon
+        <span>
+          Telefon
+        </span>
       </label>
     </div>
     <div>
@@ -124,13 +137,15 @@ exports[`Fieldset Checkboxes 1`] = `
         required
         type="checkbox"
         value="sms"
-        name="_r_2_"
+        name="checkbox-group"
       >
       <label
         data-weight="regular"
         for="fieldset-checkboxes-sms"
       >
-        SMS
+        <span>
+          SMS
+        </span>
       </label>
     </div>
     <p
@@ -143,24 +158,92 @@ exports[`Fieldset Checkboxes 1`] = `
 </div>
 `;
 
+exports[`Fieldset Radios 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="false"
+>
+  <fieldset>
+    <legend data-weight="medium">
+      <span>
+        Velg din aldersgruppe
+      </span>
+    </legend>
+    <div>
+      <input
+        id="fieldset-radios-10-20"
+        required
+        type="radio"
+        value="10-20"
+        name="radio-group"
+      >
+      <label
+        data-weight="regular"
+        for="fieldset-radios-10-20"
+      >
+        10-20 år
+      </label>
+    </div>
+    <div>
+      <input
+        id="fieldset-radios-21-45"
+        required
+        type="radio"
+        value="21-45"
+        name="radio-group"
+      >
+      <label
+        data-weight="regular"
+        for="fieldset-radios-21-45"
+      >
+        21-45 år
+      </label>
+    </div>
+    <div>
+      <input
+        id="fieldset-radios-46-80"
+        required
+        type="radio"
+        value="46-80"
+        name="radio-group"
+      >
+      <label
+        data-weight="regular"
+        for="fieldset-radios-46-80"
+      >
+        46-80 år
+      </label>
+    </div>
+    <p
+      data-field="validation"
+      hidden
+      id="_r_6_"
+    >
+    </p>
+  </fieldset>
+</div>
+`;
+
 exports[`Individual Checkboxes 1`] = `
 <div
   data-show-required="true"
   data-show-optional="false"
   data-show-summary="true"
-  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
 >
   <div>
     <input
-      id="components-fieldnecessity--individual-checkboxes-terms-conditions"
+      id="individual-checkboxes-terms-conditions"
       required
       type="checkbox"
     >
     <label
       data-weight="regular"
-      for="components-fieldnecessity--individual-checkboxes-terms-conditions"
+      for="individual-checkboxes-terms-conditions"
     >
-      Jeg bekrefter at opplysningene i søknaden er korrekt
+      <span>
+        Jeg bekrefter at opplysningene i søknaden er korrekt
+      </span>
     </label>
   </div>
   <div>
@@ -172,7 +255,9 @@ exports[`Individual Checkboxes 1`] = `
       data-weight="regular"
       for="individual-checkboxes-contact"
     >
-      Jeg er villig til å delta i en spørreundersøkelse i etterkant av søknadsprosessen
+      <span>
+        Jeg er villig til å delta i en spørreundersøkelse i etterkant av søknadsprosessen
+      </span>
     </label>
   </div>
 </div>
@@ -198,7 +283,9 @@ exports[`Manual Summary Placement 1`] = `
       data-weight="medium"
       for="manual-summary-placement-first"
     >
-      Fornavn
+      <span>
+        Fornavn
+      </span>
     </label>
     <div>
       <input
@@ -213,7 +300,9 @@ exports[`Manual Summary Placement 1`] = `
       data-weight="medium"
       for="manual-summary-placement-middle"
     >
-      Etternavn
+      <span>
+        Etternavn
+      </span>
     </label>
     <div>
       <input
@@ -228,7 +317,9 @@ exports[`Manual Summary Placement 1`] = `
       data-weight="medium"
       for="manual-summary-placement-last"
     >
-      E-postadresse
+      <span>
+        E-postadresse
+      </span>
     </label>
     <div>
       <input
@@ -255,7 +346,9 @@ exports[`Outline 1`] = `
         data-weight="medium"
         for="outline-first"
       >
-        Fornavn
+        <span>
+          Fornavn
+        </span>
       </label>
       <div>
         <input
@@ -270,7 +363,9 @@ exports[`Outline 1`] = `
         data-weight="medium"
         for="outline-middle"
       >
-        Mellomnavn
+        <span>
+          Mellomnavn
+        </span>
       </label>
       <div>
         <input
@@ -284,7 +379,9 @@ exports[`Outline 1`] = `
         data-weight="medium"
         for="outline-last"
       >
-        Etternavn
+        <span>
+          Etternavn
+        </span>
       </label>
       <div>
         <input
@@ -310,7 +407,9 @@ exports[`Preview 1`] = `
       data-weight="medium"
       for="preview-first"
     >
-      Fornavn
+      <span>
+        Fornavn
+      </span>
     </label>
     <div>
       <input
@@ -325,7 +424,9 @@ exports[`Preview 1`] = `
       data-weight="medium"
       for="preview-middle"
     >
-      Mellomnavn
+      <span>
+        Mellomnavn
+      </span>
     </label>
     <div>
       <input
@@ -339,7 +440,9 @@ exports[`Preview 1`] = `
       data-weight="medium"
       for="preview-last"
     >
-      Etternavn
+      <span>
+        Etternavn
+      </span>
     </label>
     <div>
       <input
@@ -355,16 +458,17 @@ exports[`Preview 1`] = `
 exports[`Single Optional Field 1`] = `
 <div
   data-show-required="true"
-  data-show-optional="false"
+  data-show-optional="true"
   data-show-summary="false"
-  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
 >
   <div>
     <label
       data-weight="medium"
       for="single-optional-field-comments"
     >
-      Har du noen kommentarer?
+      <span>
+        Har du noen kommentarer?
+      </span>
     </label>
     <div>
       <textarea id="single-optional-field-comments">
@@ -379,14 +483,15 @@ exports[`Single Required Field 1`] = `
   data-show-required="true"
   data-show-optional="false"
   data-show-summary="false"
-  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
 >
   <div>
     <label
       data-weight="medium"
       for="single-required-field-events"
     >
-      Beskriv hendelsesforløpet
+      <span>
+        Beskriv hendelsesforløpet
+      </span>
     </label>
     <div>
       <textarea

--- a/@udir-design/react/src/components/fieldNecessity/__snapshots__/FieldNecessity.stories.tsx.snap
+++ b/@udir-design/react/src/components/fieldNecessity/__snapshots__/FieldNecessity.stories.tsx.snap
@@ -1,0 +1,400 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`All Optional 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="true"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <label
+      data-weight="medium"
+      for="all-optional-opinion"
+    >
+      Hva synes du om skjemaet?
+    </label>
+    <div>
+      <textarea id="all-optional-opinion">
+      </textarea>
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="all-optional-other"
+    >
+      Har du noen andre innspill?
+    </label>
+    <div>
+      <textarea id="all-optional-other">
+      </textarea>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`All Required 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="true"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <label
+      data-weight="medium"
+      for="all-required-first"
+    >
+      Fornavn
+    </label>
+    <div>
+      <input
+        id="all-required-first"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="all-required-last"
+    >
+      Etternavn
+    </label>
+    <div>
+      <input
+        id="all-required-last"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Fieldset Checkboxes 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="false"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <fieldset>
+    <legend data-weight="medium">
+      Hvordan vil du helst at vi skal kontakte deg?
+    </legend>
+    <p data-variant="default">
+      Velg de alternativene som er relevante for deg.
+    </p>
+    <div>
+      <input
+        id="fieldset-checkboxes-email"
+        required
+        type="checkbox"
+        value="epost"
+        name="_r_2_"
+      >
+      <label
+        data-weight="regular"
+        for="fieldset-checkboxes-email"
+      >
+        E-post
+      </label>
+    </div>
+    <div>
+      <input
+        id="fieldset-checkboxes-telefon"
+        required
+        type="checkbox"
+        value="telefon"
+        name="_r_2_"
+      >
+      <label
+        data-weight="regular"
+        for="fieldset-checkboxes-telefon"
+      >
+        Telefon
+      </label>
+    </div>
+    <div>
+      <input
+        id="fieldset-checkboxes-sms"
+        required
+        type="checkbox"
+        value="sms"
+        name="_r_2_"
+      >
+      <label
+        data-weight="regular"
+        for="fieldset-checkboxes-sms"
+      >
+        SMS
+      </label>
+    </div>
+    <p
+      data-field="validation"
+      hidden
+      id="_r_3_"
+    >
+    </p>
+  </fieldset>
+</div>
+`;
+
+exports[`Individual Checkboxes 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="true"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <input
+      id="components-fieldnecessity--individual-checkboxes-terms-conditions"
+      required
+      type="checkbox"
+    >
+    <label
+      data-weight="regular"
+      for="components-fieldnecessity--individual-checkboxes-terms-conditions"
+    >
+      Jeg bekrefter at opplysningene i søknaden er korrekt
+    </label>
+  </div>
+  <div>
+    <input
+      id="individual-checkboxes-contact"
+      type="checkbox"
+    >
+    <label
+      data-weight="regular"
+      for="individual-checkboxes-contact"
+    >
+      Jeg er villig til å delta i en spørreundersøkelse i etterkant av søknadsprosessen
+    </label>
+  </div>
+</div>
+`;
+
+exports[`Manual Summary Placement 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="true"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <h2 data-size="md">
+    Kontaktinformasjon
+  </h2>
+  <p data-variant="default">
+    Vi trenger å vite hvordan vi kan kontakte deg i etterkant av søknaden.
+  </p>
+  <div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="manual-summary-placement-first"
+    >
+      Fornavn
+    </label>
+    <div>
+      <input
+        id="manual-summary-placement-first"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="manual-summary-placement-middle"
+    >
+      Etternavn
+    </label>
+    <div>
+      <input
+        id="manual-summary-placement-middle"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="manual-summary-placement-last"
+    >
+      E-postadresse
+    </label>
+    <div>
+      <input
+        id="manual-summary-placement-last"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Outline 1`] = `
+<div data-variant="tinted">
+  <div
+    data-variant="outline"
+    data-show-required="true"
+    data-show-optional="false"
+    data-show-summary="true"
+    style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+  >
+    <div>
+      <label
+        data-weight="medium"
+        for="outline-first"
+      >
+        Fornavn
+      </label>
+      <div>
+        <input
+          id="outline-first"
+          required
+          type="text"
+        >
+      </div>
+    </div>
+    <div>
+      <label
+        data-weight="medium"
+        for="outline-middle"
+      >
+        Mellomnavn
+      </label>
+      <div>
+        <input
+          id="outline-middle"
+          type="text"
+        >
+      </div>
+    </div>
+    <div>
+      <label
+        data-weight="medium"
+        for="outline-last"
+      >
+        Etternavn
+      </label>
+      <div>
+        <input
+          id="outline-last"
+          required
+          type="text"
+        >
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Preview 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="true"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <label
+      data-weight="medium"
+      for="preview-first"
+    >
+      Fornavn
+    </label>
+    <div>
+      <input
+        id="preview-first"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="preview-middle"
+    >
+      Mellomnavn
+    </label>
+    <div>
+      <input
+        id="preview-middle"
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="preview-last"
+    >
+      Etternavn
+    </label>
+    <div>
+      <input
+        id="preview-last"
+        required
+        type="text"
+      >
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Single Optional Field 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="false"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <label
+      data-weight="medium"
+      for="single-optional-field-comments"
+    >
+      Har du noen kommentarer?
+    </label>
+    <div>
+      <textarea id="single-optional-field-comments">
+      </textarea>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Single Required Field 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="false"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <label
+      data-weight="medium"
+      for="single-required-field-events"
+    >
+      Beskriv hendelsesforløpet
+    </label>
+    <div>
+      <textarea
+        id="single-required-field-events"
+        required
+      >
+      </textarea>
+    </div>
+  </div>
+</div>
+`;

--- a/@udir-design/react/src/components/fieldNecessity/fieldNecessity.css
+++ b/@udir-design/react/src/components/fieldNecessity/fieldNecessity.css
@@ -1,0 +1,197 @@
+/* Translations are defined outside component class so users can easily add translations */
+:root,
+[lang='nb'] {
+  --ds-field-necessity-required-text: 'Må fylles ut';
+  --ds-field-necessity-optional-text: 'Valgfritt';
+  --ds-field-necessity-all-required-text: 'Alle felt må fylles ut';
+  --ds-field-necessity-all-optional-text: 'Alle felt er valgfri';
+}
+
+[lang='nn'] {
+  --ds-field-necessity-required-text: 'Må fyllast ut';
+  --ds-field-necessity-optional-text: 'Valfritt';
+  --ds-field-necessity-all-required-text: 'Alle felt må fyllast ut';
+  --ds-field-necessity-all-optional-text: 'Alle felt er valfri';
+}
+
+[lang='en'] {
+  --ds-field-necessity-required-text: 'Required';
+  --ds-field-necessity-optional-text: 'Optional';
+  --ds-field-necessity-all-required-text: 'All fields are required';
+  --ds-field-necessity-all-optional-text: 'All fields are optional';
+}
+
+.ds-field-necessity {
+  /* When we are showing tags for individual fields, we need to adjust the label styling */
+  &[data-show-required='true'],
+  &[data-show-optional='true'] {
+    .ds-label {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      column-gap: var(--ds-size-2);
+    }
+  }
+
+  /****
+   * Necessity tags on individual fields and fieldsets
+   *****/
+
+  .ds-label:is(label, legend)::after {
+    content: var(--ds-field-necessity-text) / var(--ds-field-necessity-alt-text);
+  }
+
+  /* required input fields */
+  .ds-field:has(:required, [aria-required='true']),
+  /* fieldsets where all inputs are required */ 
+  .ds-fieldset:has(input:required, [aria-required='true']):not(
+    :has(input:optional:not([aria-required='true']), [aria-required='false'])
+  ) {
+    .ds-label:is(label, legend)::after {
+      --dsc-tag-background: var(--ds-color-warning-surface-tinted);
+      --dsc-tag-color: var(--ds-color-warning-text-default);
+      --dsc-tag-border-color--outline: var(--ds-color-warning-border-subtle);
+      --ds-field-necessity-text: var(--ds-field-necessity-required-text);
+      --ds-field-necessity-alt-text: ''; /* required fields are already announced by screen reader */
+      display: var(--ds-field-necessity-display--required, none);
+    }
+    /* Hide individual field labels nested in fieldset when all are required */
+    .ds-field label.ds-label::after {
+      display: none;
+    }
+  }
+
+  /* optional input fields */
+  .ds-field:has(:optional:not([aria-required='true']), [aria-required='false']),
+  /* fieldsets where all inputs are optional */
+  .ds-fieldset:has(
+    :optional:not([aria-required='true']),
+    [aria-required='false']
+  ):not(:has(:required, [aria-required='true'])) {
+    .ds-label:is(label, legend)::after {
+      --dsc-tag-background: var(--ds-color-info-surface-tinted);
+      --dsc-tag-color: var(--ds-color-info-text-default);
+      --dsc-tag-border-color--outline: var(--ds-color-info-border-subtle);
+      --ds-field-necessity-text: var(--ds-field-necessity-optional-text);
+      --ds-field-necessity-alt-text: var(--ds-field-necessity-text);
+      display: var(--ds-field-necessity-display--optional, none);
+    }
+    /* Hide individual field labels nested in fieldset when all are optional */
+    .ds-field label.ds-label::after {
+      display: none;
+    }
+  }
+
+  &[data-show-required='true'] {
+    --ds-field-necessity-display--required: inline-flex;
+  }
+
+  &[data-show-optional='true'] {
+    --ds-field-necessity-display--optional: inline-flex;
+  }
+
+  /******
+   * Summary tag if all fields are required or all are optional
+   ******/
+  &[data-show-summary='true']:has(input, textarea) {
+    /* manually placed summary tag */
+    .ds-field-necessity-summary::before,
+    /* automatically placed summary, if no manually placed exists */
+    &:not(:has(.ds-field-necessity-summary))::before {
+      content: var(--ds-field-necessity-summary-text);
+    }
+
+    /* All fields are required */
+    &:has(:is(input, textarea):required, [aria-required='true']):not(
+        :has(
+          :is(input, textarea):optional:not([aria-required='true']),
+          [aria-required='false']
+        )
+      ) {
+      .ds-field-necessity-summary,
+      &:not(:has(.ds-field-necessity-summary))::before {
+        --dsc-tag-background: var(--ds-color-warning-surface-tinted);
+        --dsc-tag-color: var(--ds-color-warning-text-default);
+        --dsc-tag-border-color--outline: var(--ds-color-warning-border-subtle);
+        --ds-field-necessity-summary-text: var(
+          --ds-field-necessity-all-required-text
+        );
+        display: inline-flex;
+      }
+      /* Hide individual necessity tags when all are required */
+      .ds-label:is(label, legend)::after {
+        --ds-field-necessity-display--required: none;
+      }
+    }
+
+    /* All fields are optional */
+    &:has(:optional:not([aria-required='true']), [aria-required='false']):not(
+        :has(:required, [aria-required='true'])
+      ) {
+      .ds-field-necessity-summary,
+      &:not(:has(.ds-field-necessity-summary))::before {
+        --dsc-tag-background: var(--ds-color-info-surface-tinted);
+        --dsc-tag-color: var(--ds-color-info-text-default);
+        --dsc-tag-border-color--outline: var(--ds-color-info-border-subtle);
+        --ds-field-necessity-summary-text: var(
+          --ds-field-necessity-all-optional-text
+        );
+        display: inline-flex;
+      }
+      /* Hide individual necessity tags when all are optional */
+      .ds-label:is(label, legend)::after {
+        --ds-field-necessity-display--optional: none;
+      }
+    }
+  }
+
+  /***
+   * Shared
+   ***/
+  .ds-field-necessity-summary,
+  &:not(:has(.ds-field-necessity-summary))::before,
+  .ds-label:is(label, legend)::after {
+    /* copied from .ds-tag */
+    --dsc-tag-background: var(--ds-color-surface-tinted);
+    --dsc-tag-color: var(--ds-color-text-default);
+    --dsc-tag-min-height: var(--ds-size-8);
+    --dsc-tag-padding: 0 var(--ds-size-2);
+    --dsc-tag-border-width: var(--ds-border-width-default);
+    --dsc-tag-border-color: transparent;
+    --dsc-tag-border-style: solid;
+
+    align-items: center;
+    background: var(--dsc-tag-background);
+    border-radius: var(--ds-border-radius-sm);
+    border-width: var(--dsc-tag-border-width);
+    border-color: var(--dsc-tag-border-color);
+    border-style: var(--dsc-tag-border-style);
+    box-sizing: border-box;
+    color: var(--dsc-tag-color);
+    height: fit-content; /* In case placed in display: flex */
+    font-size: var(--ds-body-sm-font-size);
+    line-height: var(--ds-line-height-sm);
+    min-height: var(--dsc-tag-min-height);
+    padding: var(--dsc-tag-padding);
+    width: max-content;
+    word-break: break-word;
+
+    @media (forced-colors: active) {
+      border-width: var(--ds-border-width-default);
+      border-style: solid;
+      border-color: CanvasText;
+    }
+    /* end of copied code */
+
+    display: none;
+    font-weight: var(--ds-font-weight-regular);
+  }
+
+  &[data-variant='outline'] {
+    .ds-field-necessity-summary,
+    &:not(:has(.ds-field-necessity-summary))::before,
+    .ds-label:is(label, legend)::after {
+      --dsc-tag-border-color: var(--dsc-tag-border-color--outline);
+    }
+  }
+}

--- a/@udir-design/react/src/components/fieldNecessity/fieldNecessity.css
+++ b/@udir-design/react/src/components/fieldNecessity/fieldNecessity.css
@@ -26,10 +26,18 @@
   &[data-show-required='true'],
   &[data-show-optional='true'] {
     .ds-label {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: baseline;
-      column-gap: var(--ds-size-2);
+      > :last-child {
+        /* If the label has a non-text element, add spacing to that element */
+        margin-right: var(--ds-size-2);
+      }
+      &:not(:has(> :last-child)) {
+        /* If the label doesn't have a non-text element, add spacing to the necessity tag */
+        &::after {
+          margin-left: var(--ds-size-2);
+        }
+        /* Try to keep the tag on the same line as the last word to avoid indented tag */
+        text-wrap: pretty;
+      }
     }
   }
 

--- a/@udir-design/react/src/components/fieldNecessity/index.ts
+++ b/@udir-design/react/src/components/fieldNecessity/index.ts
@@ -1,0 +1,20 @@
+import { FieldNecessityComponent } from './FieldNecessity';
+import './fieldNecessity.css';
+import { FieldNecessitySummary } from './FieldNecessitySummary';
+
+export type FieldNecessity = typeof FieldNecessityComponent & {
+  Summary: typeof FieldNecessitySummary;
+};
+
+export const FieldNecessity: FieldNecessity = Object.assign(
+  FieldNecessityComponent,
+  {
+    Summary: FieldNecessitySummary,
+  },
+);
+
+FieldNecessity.displayName = 'FieldNecessity';
+FieldNecessity.Summary.displayName = 'FieldNecessity.Summary';
+
+export { type FieldNecessityProps } from './FieldNecessity';
+export { FieldNecessitySummary } from './FieldNecessitySummary';

--- a/@udir-design/react/src/demo/form-demo/FormDemo.module.css
+++ b/@udir-design/react/src/demo/form-demo/FormDemo.module.css
@@ -56,6 +56,11 @@
   flex-direction: column;
   gap: var(--ds-size-8);
   padding: var(--ds-size-3);
+
+  :global(.ds-field-necessity-summary) {
+    margin-block-start: calc(-1 * var(--ds-size-6));
+    margin-block-end: calc(-1 * var(--ds-size-2));
+  }
 }
 
 @container (min-width: 23.5rem) {

--- a/@udir-design/react/src/demo/form-demo/FormDemo.tsx
+++ b/@udir-design/react/src/demo/form-demo/FormDemo.tsx
@@ -12,6 +12,7 @@ import {
 } from '@udir-design/icons';
 import { Button } from 'src/components/button/Button';
 import { Dialog } from 'src/components/dialog/Dialog';
+import { FieldNecessity } from 'src/components/fieldNecessity/index.js';
 import type { FieldsetProps } from 'src/components/fieldset/Fieldset';
 import { FormNavigation } from 'src/components/formNavigation';
 import { Heading } from 'src/components/typography/heading/Heading';
@@ -284,28 +285,21 @@ export const FormDemo = ({
           <Heading level={1} data-size="md">
             Testsøknad
           </Heading>
-          <form className={classes.form} onSubmit={handleSubmit(onSubmit)}>
-            {renderCurrentPage()}
-            <div className={classes.navigateButtons}>
-              {hasPrev() && id !== 'confirmation' && (
-                <Button variant="secondary" onClick={prev} style={{ flex: 1 }}>
-                  <ArrowLeftIcon aria-hidden />
-                  Forrige
-                </Button>
-              )}
-              {hasNext() && id !== 'deliver' && id !== 'confirmation' && (
-                <Button variant="secondary" onClick={next} style={{ flex: 1 }}>
-                  Neste
-                  <ArrowRightIcon aria-hidden />
-                </Button>
-              )}
-              {id === 'deliver' &&
-                (!isSubmitSuccessful ? (
-                  <Button style={{ flex: 2 }} onClick={onDeliver}>
-                    Send inn skjema
-                    <PaperplaneIcon aria-hidden />
+          <FieldNecessity variant="outline" asChild>
+            <form className={classes.form} onSubmit={handleSubmit(onSubmit)}>
+              {renderCurrentPage()}
+              <div className={classes.navigateButtons}>
+                {hasPrev() && id !== 'confirmation' && (
+                  <Button
+                    variant="secondary"
+                    onClick={prev}
+                    style={{ flex: 1 }}
+                  >
+                    <ArrowLeftIcon aria-hidden />
+                    Forrige
                   </Button>
-                ) : (
+                )}
+                {hasNext() && id !== 'deliver' && id !== 'confirmation' && (
                   <Button
                     variant="secondary"
                     onClick={next}
@@ -314,33 +308,50 @@ export const FormDemo = ({
                     Neste
                     <ArrowRightIcon aria-hidden />
                   </Button>
-                ))}
-            </div>
-            <Dialog
-              closeButton={false}
-              ref={dialogDeliverRef}
-              style={{ width: 'fit-content' }}
-            >
-              <Dialog.Block className={classes.dialog}>
-                <Heading data-size="xs">
-                  Er du sikker på at du vil sende inn skjema?
-                </Heading>
-                <div className={classes.dialogActions}>
-                  <Button
-                    onClick={() => dialogDeliverRef.current?.close()}
-                    variant="secondary"
-                    style={{ flex: 1 }}
-                  >
-                    Avbryt
-                  </Button>
-                  <Button autoFocus type="submit" style={{ flex: 2 }}>
-                    Send inn
-                    <PaperplaneIcon aria-hidden />
-                  </Button>
-                </div>
-              </Dialog.Block>
-            </Dialog>
-          </form>
+                )}
+                {id === 'deliver' &&
+                  (!isSubmitSuccessful ? (
+                    <Button style={{ flex: 2 }} onClick={onDeliver}>
+                      Send inn skjema
+                      <PaperplaneIcon aria-hidden />
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="secondary"
+                      onClick={next}
+                      style={{ flex: 1 }}
+                    >
+                      Neste
+                      <ArrowRightIcon aria-hidden />
+                    </Button>
+                  ))}
+              </div>
+              <Dialog
+                closeButton={false}
+                ref={dialogDeliverRef}
+                style={{ width: 'fit-content' }}
+              >
+                <Dialog.Block className={classes.dialog}>
+                  <Heading data-size="xs">
+                    Er du sikker på at du vil sende inn skjema?
+                  </Heading>
+                  <div className={classes.dialogActions}>
+                    <Button
+                      onClick={() => dialogDeliverRef.current?.close()}
+                      variant="secondary"
+                      style={{ flex: 1 }}
+                    >
+                      Avbryt
+                    </Button>
+                    <Button autoFocus type="submit" style={{ flex: 2 }}>
+                      Send inn
+                      <PaperplaneIcon aria-hidden />
+                    </Button>
+                  </div>
+                </Dialog.Block>
+              </Dialog>
+            </form>
+          </FieldNecessity>
 
           <ErrorSummaryContent
             attemptedSubmit={attemptedSubmit}

--- a/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -181,7 +181,9 @@ exports[`Form Page 2 1`] = `
           data-weight="medium"
           for="projectTitle"
         >
-          Tittel på prosjektet
+          <span>
+            Tittel på prosjektet
+          </span>
         </label>
         <div>
           <input
@@ -197,7 +199,9 @@ exports[`Form Page 2 1`] = `
           data-weight="medium"
           for="projectDescription"
         >
-          Beskrivelse av prosjektet
+          <span>
+            Beskrivelse av prosjektet
+          </span>
         </label>
         <div>
           <textarea
@@ -214,7 +218,9 @@ exports[`Form Page 2 1`] = `
         tabindex="-1"
       >
         <legend data-weight="medium">
-          Kategori
+          <span>
+            Kategori
+          </span>
         </legend>
         <p data-variant="default">
           Hvilken kategori hører prosjektet til?
@@ -231,7 +237,9 @@ exports[`Form Page 2 1`] = `
             data-weight="regular"
             for="radio-learning"
           >
-            Opplæring
+            <span>
+              Opplæring
+            </span>
           </label>
         </div>
         <div>
@@ -246,7 +254,9 @@ exports[`Form Page 2 1`] = `
             data-weight="regular"
             for="radio-social"
           >
-            Sosialt
+            <span>
+              Sosialt
+            </span>
           </label>
         </div>
         <div>
@@ -261,7 +271,9 @@ exports[`Form Page 2 1`] = `
             data-weight="regular"
             for="radio-activity"
           >
-            Aktivitet
+            <span>
+              Aktivitet
+            </span>
           </label>
         </div>
         <details>
@@ -278,7 +290,9 @@ exports[`Form Page 2 1`] = `
           data-weight="medium"
           for="county"
         >
-          Gjennomføringssted
+          <span>
+            Gjennomføringssted
+          </span>
         </label>
         <div
           data-field="description"
@@ -488,7 +502,9 @@ exports[`Form Page 2 1`] = `
           data-weight="medium"
           for="ageGroup"
         >
-          Aldersgruppe
+          <span>
+            Aldersgruppe
+          </span>
         </label>
         <div
           data-field="description"
@@ -809,7 +825,9 @@ exports[`Form Page 3 1`] = `
           data-weight="medium"
           for="dokumentasjon-dropzone"
         >
-          Last opp dokumentasjon
+          <span>
+            Last opp dokumentasjon
+          </span>
         </label>
         <div
           data-field="description"
@@ -863,7 +881,9 @@ exports[`Form Page 3 1`] = `
           data-weight="medium"
           for="addition"
         >
-          Kommentarer til dokumentasjon
+          <span>
+            Kommentarer til dokumentasjon
+          </span>
         </label>
         <div
           data-field="description"
@@ -1674,7 +1694,9 @@ exports[`Form Story 1`] = `
           data-weight="medium"
           for="firstName"
         >
-          Fornavn
+          <span>
+            Fornavn
+          </span>
         </label>
         <div>
           <input
@@ -1691,7 +1713,9 @@ exports[`Form Story 1`] = `
           data-weight="medium"
           for="lastName"
         >
-          Etternavn
+          <span>
+            Etternavn
+          </span>
         </label>
         <input
           id="lastName"
@@ -1707,7 +1731,9 @@ exports[`Form Story 1`] = `
         tabindex="-1"
       >
         <legend data-weight="medium">
-          Hvordan ønsker du at vi skal kontakte deg?
+          <span>
+            Hvordan ønsker du at vi skal kontakte deg?
+          </span>
         </legend>
         <p data-variant="default">
           Velg ett eller flere alternativer
@@ -1725,7 +1751,9 @@ exports[`Form Story 1`] = `
             data-weight="regular"
             for="contactMethodsEmail"
           >
-            E-post
+            <span>
+              E-post
+            </span>
           </label>
         </div>
         <div>
@@ -1741,7 +1769,9 @@ exports[`Form Story 1`] = `
             data-weight="regular"
             for="contactMethodsTelefon"
           >
-            Telefon
+            <span>
+              Telefon
+            </span>
           </label>
         </div>
         <div>
@@ -1757,7 +1787,9 @@ exports[`Form Story 1`] = `
             data-weight="regular"
             for="contactMethodsSms"
           >
-            SMS
+            <span>
+              SMS
+            </span>
           </label>
         </div>
       </fieldset>

--- a/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/form-demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -165,10 +165,17 @@ exports[`Form Page 2 1`] = `
     <h1 data-size="md">
       Testsøknad
     </h1>
-    <form>
+    <form
+      data-variant="outline"
+      data-show-required="true"
+      data-show-optional="false"
+      data-show-summary="true"
+    >
       <h2 data-size="sm">
         Prosjektet
       </h2>
+      <div>
+      </div>
       <div>
         <label
           data-weight="medium"
@@ -179,6 +186,7 @@ exports[`Form Page 2 1`] = `
         <div>
           <input
             id="projectTitle"
+            required
             type="text"
             name="projectTitle"
           >
@@ -196,6 +204,7 @@ exports[`Form Page 2 1`] = `
             id="projectDescription"
             rows="4"
             name="projectDescription"
+            required
           >
           </textarea>
         </div>
@@ -213,6 +222,7 @@ exports[`Form Page 2 1`] = `
         <div>
           <input
             id="radio-learning"
+            required
             type="radio"
             value="Learning"
             name="projectCategory"
@@ -227,6 +237,7 @@ exports[`Form Page 2 1`] = `
         <div>
           <input
             id="radio-social"
+            required
             type="radio"
             value="social"
             name="projectCategory"
@@ -241,6 +252,7 @@ exports[`Form Page 2 1`] = `
         <div>
           <input
             id="radio-activity"
+            required
             type="radio"
             value="activity"
             name="projectCategory"
@@ -279,6 +291,7 @@ exports[`Form Page 2 1`] = `
             placeholder
             aria-invalid="false"
             id="county"
+            required
             type="text"
             aria-describedby="county:description:1"
             data-label="Gjennomføringssted"
@@ -488,6 +501,7 @@ exports[`Form Page 2 1`] = `
           aria-label="Velg aldersgruppe"
           name="ageGroup"
           aria-invalid="false"
+          required
           aria-describedby="ageGroup:description:1"
         >
           <option
@@ -775,10 +789,17 @@ exports[`Form Page 3 1`] = `
     <h1 data-size="md">
       Testsøknad
     </h1>
-    <form>
+    <form
+      data-variant="outline"
+      data-show-required="true"
+      data-show-optional="false"
+      data-show-summary="true"
+    >
       <h2 data-size="sm">
         Dokumentasjon
       </h2>
+      <div>
+      </div>
       <div
         role="presentation"
         tabindex="0"
@@ -831,6 +852,7 @@ exports[`Form Page 3 1`] = `
           accept="application/pdf"
           multiple
           tabindex="-1"
+          required
           type="file"
           aria-describedby="dokumentasjon-dropzone:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
@@ -1120,7 +1142,12 @@ exports[`Form Page 4 1`] = `
     <h1 data-size="md">
       Testsøknad
     </h1>
-    <form>
+    <form
+      data-variant="outline"
+      data-show-required="true"
+      data-show-optional="false"
+      data-show-summary="true"
+    >
       <h2>
         Innsending
       </h2>
@@ -1393,7 +1420,12 @@ exports[`Form Page 5 1`] = `
     <h1 data-size="md">
       Testsøknad
     </h1>
-    <form>
+    <form
+      data-variant="outline"
+      data-show-required="true"
+      data-show-optional="false"
+      data-show-summary="true"
+    >
       <div>
         <h2 data-size="sm">
           Kvittering
@@ -1626,10 +1658,17 @@ exports[`Form Story 1`] = `
     <h1 data-size="md">
       Testsøknad
     </h1>
-    <form>
+    <form
+      data-variant="outline"
+      data-show-required="true"
+      data-show-optional="false"
+      data-show-summary="true"
+    >
       <h2 data-size="sm">
         Kontaktinfo
       </h2>
+      <div>
+      </div>
       <div>
         <label
           data-weight="medium"
@@ -1641,6 +1680,7 @@ exports[`Form Story 1`] = `
           <input
             id="firstName"
             autocomplete="given-name"
+            required
             type="text"
             name="firstName"
           >
@@ -1655,6 +1695,7 @@ exports[`Form Story 1`] = `
         </label>
         <input
           id="lastName"
+          required
           autocomplete="family-name"
           aria-invalid="false"
           type="text"
@@ -1675,6 +1716,7 @@ exports[`Form Story 1`] = `
           <input
             id="contactMethodsEmail"
             aria-invalid="false"
+            required
             type="checkbox"
             value="epost"
             name="contactMethods"
@@ -1690,6 +1732,7 @@ exports[`Form Story 1`] = `
           <input
             id="contactMethodsTelefon"
             aria-invalid="false"
+            required
             type="checkbox"
             value="telefon"
             name="contactMethods"
@@ -1705,6 +1748,7 @@ exports[`Form Story 1`] = `
           <input
             id="contactMethodsSms"
             aria-invalid="false"
+            required
             type="checkbox"
             value="sms"
             name="contactMethods"

--- a/@udir-design/react/src/demo/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/DocumentationPage.tsx
@@ -3,6 +3,7 @@ import type { FileRejection, FileWithPath } from 'react-dropzone';
 import { useDropzone } from 'react-dropzone';
 import { useFormContext } from 'react-hook-form';
 import { Field } from 'src/components/field/Field';
+import { FieldNecessity } from 'src/components/fieldNecessity';
 import { FileUpload } from 'src/components/fileUpload';
 import { Textarea } from 'src/components/textarea/Textarea';
 import { Heading } from 'src/components/typography/heading/Heading';
@@ -52,13 +53,14 @@ export const DocumentationPage = ({
       <Heading level={2} data-size="sm">
         Dokumentasjon
       </Heading>
+      <FieldNecessity.Summary />
       <FileUpload.Dropzone
         id="dokumentasjon-dropzone"
         label="Last opp dokumentasjon"
         description="Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB."
         {...getRootProps()}
         error={errors.documentation?.message}
-        inputProps={getInputProps()}
+        inputProps={getInputProps({ required: true })}
         aria-invalid={!!errors.documentation}
         readOnly={isSubmitSuccessful}
       />

--- a/@udir-design/react/src/demo/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/DocumentationPage.tsx
@@ -56,7 +56,7 @@ export const DocumentationPage = ({
       <FieldNecessity.Summary />
       <FileUpload.Dropzone
         id="dokumentasjon-dropzone"
-        label="Last opp dokumentasjon"
+        label={<span>Last opp dokumentasjon</span>}
         description="Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB."
         {...getRootProps()}
         error={errors.documentation?.message}
@@ -97,7 +97,9 @@ export const DocumentationPage = ({
         </>
       )}
       <Field>
-        <Label>Kommentarer til dokumentasjon</Label>
+        <Label>
+          <span>Kommentarer til dokumentasjon</span>
+        </Label>
         <Field.Description>
           Ytterlige kommentarer til dokumentasjonen du har lastet opp.
         </Field.Description>

--- a/@udir-design/react/src/demo/form-demo/pages/PersonalInfoPage.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/PersonalInfoPage.tsx
@@ -29,7 +29,7 @@ export const PersonalInfoPage = ({
       <FieldNecessity.Summary />
       <Textfield
         id="firstName"
-        label="Fornavn"
+        label={<span>Fornavn</span>}
         {...register('firstName')}
         autoComplete="given-name"
         error={errors.firstName?.message}
@@ -37,7 +37,9 @@ export const PersonalInfoPage = ({
         required
       />
       <Field>
-        <Label>Etternavn</Label>
+        <Label>
+          <span>Etternavn</span>
+        </Label>
         <Input
           id="lastName"
           {...register('lastName')}
@@ -52,14 +54,14 @@ export const PersonalInfoPage = ({
       </Field>
       <Fieldset id="contactMethods" {...focusableFieldsetProps}>
         <Fieldset.Legend>
-          Hvordan ønsker du at vi skal kontakte deg?
+          <span>Hvordan ønsker du at vi skal kontakte deg?</span>
         </Fieldset.Legend>
         <Fieldset.Description>
           Velg ett eller flere alternativer
         </Fieldset.Description>
         <Checkbox
           id="contactMethodsEmail"
-          label="E-post"
+          label={<span>E-post</span>}
           {...register('contactMethods')}
           aria-invalid={isInvalid}
           readOnly={isSubmitSuccessful}
@@ -68,7 +70,7 @@ export const PersonalInfoPage = ({
         />
         <Checkbox
           id="contactMethodsTelefon"
-          label="Telefon"
+          label={<span>Telefon</span>}
           {...register('contactMethods')}
           aria-invalid={isInvalid}
           readOnly={isSubmitSuccessful}
@@ -77,7 +79,7 @@ export const PersonalInfoPage = ({
         />
         <Checkbox
           id="contactMethodsSms"
-          label="SMS"
+          label={<span>SMS</span>}
           {...register('contactMethods')}
           aria-invalid={isInvalid}
           readOnly={isSubmitSuccessful}

--- a/@udir-design/react/src/demo/form-demo/pages/PersonalInfoPage.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/PersonalInfoPage.tsx
@@ -1,6 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 import { Checkbox } from 'src/components/checkbox/Checkbox';
 import { Field } from 'src/components/field/Field';
+import { FieldNecessity } from 'src/components/fieldNecessity';
 import { Fieldset } from 'src/components/fieldset/Fieldset';
 import { Input } from 'src/components/input/Input';
 import { Textfield } from 'src/components/textfield/Textfield';
@@ -25,6 +26,7 @@ export const PersonalInfoPage = ({
       <Heading level={2} data-size="sm">
         Kontaktinfo
       </Heading>
+      <FieldNecessity.Summary />
       <Textfield
         id="firstName"
         label="Fornavn"
@@ -32,12 +34,14 @@ export const PersonalInfoPage = ({
         autoComplete="given-name"
         error={errors.firstName?.message}
         readOnly={isSubmitSuccessful}
+        required
       />
       <Field>
         <Label>Etternavn</Label>
         <Input
           id="lastName"
           {...register('lastName')}
+          required
           autoComplete="family-name"
           aria-invalid={!!errors.lastName}
           readOnly={isSubmitSuccessful}
@@ -60,6 +64,7 @@ export const PersonalInfoPage = ({
           aria-invalid={isInvalid}
           readOnly={isSubmitSuccessful}
           value="epost"
+          required
         />
         <Checkbox
           id="contactMethodsTelefon"
@@ -68,6 +73,7 @@ export const PersonalInfoPage = ({
           aria-invalid={isInvalid}
           readOnly={isSubmitSuccessful}
           value="telefon"
+          required
         />
         <Checkbox
           id="contactMethodsSms"
@@ -76,6 +82,7 @@ export const PersonalInfoPage = ({
           aria-invalid={isInvalid}
           readOnly={isSubmitSuccessful}
           value="sms"
+          required
         />
         {errors.contactMethods && (
           <ValidationMessage>{errors.contactMethods.message}</ValidationMessage>

--- a/@udir-design/react/src/demo/form-demo/pages/ProjectPage.tsx.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/ProjectPage.tsx.tsx
@@ -1,6 +1,7 @@
 import { Controller, useFormContext } from 'react-hook-form';
 import { counties } from '.storybook/data';
 import { Field } from 'src/components/field/Field';
+import { FieldNecessity } from 'src/components/fieldNecessity';
 import { Fieldset } from 'src/components/fieldset/Fieldset';
 import { Radio } from 'src/components/radio/Radio';
 import { ReadMore } from 'src/components/readMore/ReadMore';
@@ -24,12 +25,14 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
       <Heading level={2} data-size="sm">
         Prosjektet
       </Heading>
+      <FieldNecessity.Summary />
       <Textfield
         id="projectTitle"
         label="Tittel på prosjektet"
         {...register('projectTitle')}
         error={errors.projectTitle?.message}
         readOnly={isSubmitSuccessful}
+        required
       />
       <Textfield
         label="Beskrivelse av prosjektet"
@@ -39,6 +42,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
         {...register('projectDescription')}
         error={errors.projectDescription?.message}
         readOnly={isSubmitSuccessful}
+        required
       />
       <Fieldset id="projectCategory" {...focusableFieldsetProps}>
         <Fieldset.Legend>Kategori</Fieldset.Legend>
@@ -51,6 +55,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
           value="Learning"
           readOnly={isSubmitSuccessful}
           {...register('projectCategory')}
+          required
         />
         <Radio
           id="radio-social"
@@ -58,6 +63,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
           value="social"
           readOnly={isSubmitSuccessful}
           {...register('projectCategory')}
+          required
         />
         <Radio
           id="radio-activity"
@@ -65,6 +71,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
           value="activity"
           readOnly={isSubmitSuccessful}
           {...register('projectCategory')}
+          required
         />
         <ReadMore summary="Grunnen til at vi spør om dette">
           Tilskuddsordningen skal dekke et bredt spekter av tilbud. For å ha
@@ -98,6 +105,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
                 aria-invalid={!!errors.county}
                 id="county"
                 readOnly={isSubmitSuccessful}
+                required
               />
               <Suggestion.Clear />
               <Suggestion.List>
@@ -127,6 +135,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
           aria-invalid={!!errors.ageGroup}
           defaultValue="blank"
           readOnly={isSubmitSuccessful}
+          required
         >
           <Select.Option value="blank" disabled>
             Velg aldersgruppe

--- a/@udir-design/react/src/demo/form-demo/pages/ProjectPage.tsx.tsx
+++ b/@udir-design/react/src/demo/form-demo/pages/ProjectPage.tsx.tsx
@@ -28,14 +28,14 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
       <FieldNecessity.Summary />
       <Textfield
         id="projectTitle"
-        label="Tittel på prosjektet"
+        label={<span>Tittel på prosjektet</span>}
         {...register('projectTitle')}
         error={errors.projectTitle?.message}
         readOnly={isSubmitSuccessful}
         required
       />
       <Textfield
-        label="Beskrivelse av prosjektet"
+        label={<span>Beskrivelse av prosjektet</span>}
         id="projectDescription"
         multiline
         rows={4}
@@ -45,13 +45,15 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
         required
       />
       <Fieldset id="projectCategory" {...focusableFieldsetProps}>
-        <Fieldset.Legend>Kategori</Fieldset.Legend>
+        <Fieldset.Legend>
+          <span>Kategori</span>
+        </Fieldset.Legend>
         <Fieldset.Description>
           Hvilken kategori hører prosjektet til?
         </Fieldset.Description>
         <Radio
           id="radio-learning"
-          label="Opplæring"
+          label={<span>Opplæring</span>}
           value="Learning"
           readOnly={isSubmitSuccessful}
           {...register('projectCategory')}
@@ -59,7 +61,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
         />
         <Radio
           id="radio-social"
-          label="Sosialt"
+          label={<span>Sosialt</span>}
           value="social"
           readOnly={isSubmitSuccessful}
           {...register('projectCategory')}
@@ -67,7 +69,7 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
         />
         <Radio
           id="radio-activity"
-          label="Aktivitet"
+          label={<span>Aktivitet</span>}
           value="activity"
           readOnly={isSubmitSuccessful}
           {...register('projectCategory')}
@@ -85,7 +87,9 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
         )}
       </Fieldset>
       <Field>
-        <Label>Gjennomføringssted</Label>
+        <Label>
+          <span>Gjennomføringssted</span>
+        </Label>
         <Field.Description>
           Hvilket fylke vil prosjektet gjennomføres i?
         </Field.Description>
@@ -124,7 +128,9 @@ export const ProjectPage = ({ showErrors, isSubmitSuccessful }: PageProps) => {
         )}
       </Field>
       <Field>
-        <Label>Aldersgruppe</Label>
+        <Label>
+          <span>Aldersgruppe</span>
+        </Label>
         <Field.Description>
           Hvilken aldersgruppe er prosjektet rettet mot?
         </Field.Description>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     '@nx/eslint-plugin':
       specifier: 22.4.5
       version: 22.4.5
+    '@radix-ui/react-slot':
+      specifier: ^1.2.4
+      version: 1.2.4
     '@storybook/addon-a11y':
       specifier: ^10.2.7
       version: 10.2.7
@@ -587,6 +590,9 @@ importers:
       '@digdir/designsystemet-types':
         specifier: 'catalog:'
         version: 1.11.0
+      '@radix-ui/react-slot':
+        specifier: 'catalog:'
+        version: 1.2.4(@types/react@19.2.7)(react@19.2.0)
       '@u-elements/u-details':
         specifier: 'catalog:'
         version: 0.2.2
@@ -12344,6 +12350,7 @@ snapshots:
     dependencies:
       '@digdir/designsystemet-react': 1.11.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@digdir/designsystemet-types': 1.11.0
+      '@radix-ui/react-slot': 1.2.4(@types/react@18.3.27)(react@18.3.1)
       '@u-elements/u-details': 0.2.2
       '@u-elements/u-progress': 0.0.7
       '@udir-design/css': link:@udir-design/css
@@ -12358,6 +12365,7 @@ snapshots:
     dependencies:
       '@digdir/designsystemet-react': 1.11.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@digdir/designsystemet-types': 1.11.0
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.7)(react@19.2.0)
       '@u-elements/u-details': 0.2.2
       '@u-elements/u-progress': 0.0.7
       '@udir-design/css': link:@udir-design/css

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalog:
   '@nx/azure-cache': ^5.0.0
   '@nx/eslint': 22.4.5
   '@nx/eslint-plugin': 22.4.5
+  '@radix-ui/react-slot': ^1.2.4
   '@storybook/addon-a11y': ^10.2.7
   '@storybook/addon-docs': ^10.2.7
   '@storybook/addon-vitest': ^10.2.7


### PR DESCRIPTION
## Hva er gjort?

Wrapper som man kan legge rundt inputfelt for å automatisk vise "Må fylles ut" og/eller "Valgfritt" på individuelle felt, og oppsummering ("Alle felt må fylles ut" / "Alle felt er valgfri") i toppen dersom det er tilfelle.

Dersom oppsummeringa ikkje skal ligge heilt i toppen kan man plassere `<FieldNecessity.Summary />` ein stad inne i `<FieldNecessity>`, så vil oppsummeringa bli vist der i staden.

Komponenten leser ut `required` eller `aria-required` på input og textarea inni komponenten for å finne ut kva den skal vise. All logikken er i CSS.

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er eksportert fra riktig fil
- [ ] Komponenten er testet i test-app
- [x] Komponenten er testet med skjermleser og/eller annet UU-verktøy
- [ ] Komponenten har tester i Storybook
- [x] Komponenten er i bruk i en demoside
