### PR TITLE
fix(ProgressBar): issues with aria-label

### DIFF
--- a/@udir-design/react/src/components/progressBar/ProgressBar.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.tsx
@@ -50,6 +50,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
           value={value}
           max={max}
           aria-hidden="true"
+          aria-label="..." // only because ARC Toolkit reports empty label as an error, but this will never be read
           // Ensure shadow dom is server rendered
           // see https://u-elements.github.io/u-elements/elements/u-progress#server-side-rendering
           dangerouslySetInnerHTML={{ __html: UHTMLProgressShadowRoot }}

--- a/@udir-design/react/src/components/progressBar/ProgressBar.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.tsx
@@ -4,7 +4,7 @@ import { type Size } from '@digdir/designsystemet-react';
 import type { Color } from '@digdir/designsystemet-types';
 import { UHTMLProgressShadowRoot } from '@u-elements/u-progress';
 import cl from 'clsx/lite';
-import type { HTMLAttributes } from 'react';
+import type { AriaRole, HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
 export type ProgressBarProps = Omit<
@@ -38,13 +38,50 @@ export type ProgressBarProps = Omit<
   }) => string;
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label#associated_roles
+const nonNameableAriaRoles: AriaRole[] = [
+  'caption',
+  'code',
+  'definition',
+  'deletion',
+  'emphasis',
+  'generic',
+  'insertion',
+  'mark',
+  'paragraph',
+  'presentation',
+  'none',
+  'strong',
+  'subscript',
+  'suggestion',
+  'superscript',
+  'term',
+  'time',
+];
+
 export const ProgressBar = forwardRef<HTMLDivElement, ProgressBarProps>(
-  function ProgressBar({ className, max, value, progressText, ...rest }, ref) {
+  function ProgressBar(
+    { className, max, value, progressText, 'aria-label': ariaLabel, ...rest },
+    ref,
+  ) {
+    let screenreaderText: string | undefined;
+    // aria-label is not permitted on div without a role, and only certain roles can use it.
+    if (!rest.role || (nonNameableAriaRoles.includes(rest.role) && ariaLabel)) {
+      screenreaderText = ariaLabel;
+    }
     const percentage = max > 0 ? Math.round((value / max) * 100) : 0;
     const text =
       progressText?.({ value, max, percentage }) ?? `${value} av ${max}`;
     return (
-      <div className={cl(`uds-progressBar`, className)} ref={ref} {...rest}>
+      <div
+        className={cl(`uds-progressBar`, className)}
+        ref={ref}
+        aria-label={screenreaderText ? undefined : ariaLabel}
+        {...rest}
+      >
+        {screenreaderText && (
+          <span className="ds-sr-only">{screenreaderText}</span>
+        )}
         <span>{text}</span>
         <u-progress
           value={value}

--- a/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
+++ b/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
@@ -12,9 +12,11 @@ exports[`Form Example 1`] = `
       <div
         data-color="accent"
         tabindex="-1"
-        aria-label="Skjemafremgang"
         style="width: 30%;"
       >
+        <span>
+          Skjemafremgang
+        </span>
         <span>
           Side 1 av 7
         </span>
@@ -22,7 +24,7 @@ exports[`Form Example 1`] = `
           value="1"
           id=":u-progress3"
           aria-busy="false"
-          aria-label
+          aria-label="..."
           aria-valuemax="100"
           aria-valuemin="0"
           aria-valuenow="14"
@@ -216,7 +218,7 @@ exports[`Percentage 1`] = `
     value="2"
     id=":u-progress2"
     aria-busy="false"
-    aria-label
+    aria-label="..."
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="20"
@@ -249,7 +251,7 @@ exports[`Preview 1`] = `
     value="3"
     id=":u-progress1"
     aria-busy="false"
-    aria-label
+    aria-label="..."
     aria-valuemax="100"
     aria-valuemin="0"
     aria-valuenow="30"


### PR DESCRIPTION
## Hva er gjort?

- Sørger for at ARC Toolkit ikkje rapporterer feil på `<u-progress>` pga tom `aria-label`. Vil seie dette eigentleg er ein bug i ARC, for det er ingen grunn til å scanne element som har `aria-hidden` då dei ikkje er ein del av accessibility-APIet.
- Vi har anbefalt aria-label på ProgressBar for å lese opp informasjon kun til skjermleserbrukarar, men dette er eigentleg ikkje lov på `<div>`-element med mindre man også setter ein `role` som har lov til å bruke `aria-label` . Har laga ein workaround som sjekker om man har ein role som gjer dette lov, og om man ikkje har det setter vi inn teksten som ein `<span>` som er visuelt skjult med `ds-sr-only`-klassen.

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er testet med skjermleser og/eller annet UU-verktøy
