### PR TITLE
fix: icons now scale correctly in Safari when zooming

### DIFF
--- a/@udir-design/react/.storybook/manager.tsx
+++ b/@udir-design/react/.storybook/manager.tsx
@@ -48,7 +48,7 @@ addons.setConfig({
         if (item.id === 'iconsandsymbols') {
           return (
             <>
-              <ImageIcon aria-hidden fontSize={18} />
+              <ImageIcon aria-hidden className="sidebar-subheading-icon" />
               Ikoner og symboler
             </>
           );
@@ -56,7 +56,10 @@ addons.setConfig({
         if (item.id === 'demo') {
           return (
             <>
-              <RectangleSectionsIcon aria-hidden fontSize={18} />
+              <RectangleSectionsIcon
+                aria-hidden
+                className="sidebar-subheading-icon"
+              />
               Demosider
             </>
           );
@@ -64,7 +67,7 @@ addons.setConfig({
         if (item.id === 'design-tokens') {
           return (
             <>
-              <TokenIcon aria-hidden fontSize={18} />
+              <TokenIcon aria-hidden className="sidebar-subheading-icon" />
               Design tokens
             </>
           );
@@ -72,7 +75,7 @@ addons.setConfig({
         if (item.id === 'patterns') {
           return (
             <>
-              <LayersIcon aria-hidden fontSize={18} />
+              <LayersIcon aria-hidden className="sidebar-subheading-icon" />
               Bruksmønstre
             </>
           );
@@ -80,7 +83,7 @@ addons.setConfig({
         if (item.id === 'components') {
           return (
             <>
-              <ComponentIcon aria-hidden fontSize={18} />
+              <ComponentIcon aria-hidden className="sidebar-subheading-icon" />
               Komponenter
             </>
           );
@@ -88,7 +91,7 @@ addons.setConfig({
         if (item.id === 'utilities') {
           return (
             <>
-              <WrenchIcon aria-hidden fontSize={18} />
+              <WrenchIcon aria-hidden className="sidebar-subheading-icon" />
               Hjelpeverktøy
             </>
           );

--- a/@udir-design/react/.storybook/style.css
+++ b/@udir-design/react/.storybook/style.css
@@ -19,3 +19,8 @@ body {
   margin-right: 34px;
   min-height: 18px;
 }
+
+.sidebar-subheading-icon {
+  height: 1.125rem;
+  width: auto;
+}

--- a/@udir-design/react/src/components/avatar/Avatar.tsx
+++ b/@udir-design/react/src/components/avatar/Avatar.tsx
@@ -1,3 +1,4 @@
+import './avatar.css';
 import {
   Avatar as DigdirAvatar,
   type AvatarProps as DigdirAvatarProps,

--- a/@udir-design/react/src/components/avatar/avatar.css
+++ b/@udir-design/react/src/components/avatar/avatar.css
@@ -1,0 +1,5 @@
+/* Necessary here due to setting width/height in .ds-button :where(img, svg) */
+.ds-avatar :is(img, svg) {
+  width: 100%;
+  height: 100%;
+}

--- a/@udir-design/react/src/components/badge/Badge.tsx
+++ b/@udir-design/react/src/components/badge/Badge.tsx
@@ -1,3 +1,4 @@
+import './badge.css';
 import {
   Badge as DigdirBadge,
   type BadgeProps as DigdirBadgeProps,

--- a/@udir-design/react/src/components/badge/badge.css
+++ b/@udir-design/react/src/components/badge/badge.css
@@ -1,0 +1,5 @@
+.ds-badge--position :where(img, svg) {
+  font-size: 1.83184ex;
+  height: 1.25em; /* Auto scale icon based on font-size */
+  width: auto;
+}

--- a/@udir-design/react/src/components/button/button.css
+++ b/@udir-design/react/src/components/button/button.css
@@ -3,4 +3,25 @@
   &[data-variant='secondary']:not([data-color='danger']) {
     --dsc-button-color: var(--ds-color-text-default);
   }
+
+  /* Fix scaling of icons & spinner in button in Safari */
+  &,
+  &[data-icon] {
+    :where(img, svg) {
+      /* because font-size is set to 1em upstream, scaling doesn't work in Safari */
+      /* override font-size with ch instead of em to fix scaling */
+      font-size: 1.83184ex;
+      width: auto;
+    }
+  }
+  & :where(img, svg) {
+    height: 1.3em;
+  }
+  &[data-icon] :where(img, svg) {
+    height: 1.5em;
+  }
+  .ds-spinner {
+    height: 1.4em;
+  }
+  /* END fix scaling */
 }

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -51,7 +51,8 @@
   }
 
   & > div > svg {
-    font-size: var(--ds-size-10);
+    width: auto;
+    height: var(--ds-size-10);
     margin-inline-end: var(--ds-size-3);
     align-self: center;
   }

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -204,12 +204,14 @@
 
     > svg:nth-last-child(2) {
       display: block;
-      font-size: var(--ds-size-6);
+      width: auto;
+      height: var(--ds-size-6);
     }
 
     > svg:last-child {
       display: none;
-      font-size: var(--ds-size-6);
+      width: auto;
+      height: var(--ds-size-6);
     }
 
     &:has(+ [popover]:popover-open) {

--- a/@udir-design/react/src/components/spinner/Spinner.tsx
+++ b/@udir-design/react/src/components/spinner/Spinner.tsx
@@ -1,3 +1,4 @@
+import './spinner.css';
 import { Spinner, type SpinnerProps } from '@digdir/designsystemet-react';
 
 export type { SpinnerProps };

--- a/@udir-design/react/src/components/spinner/spinner.css
+++ b/@udir-design/react/src/components/spinner/spinner.css
@@ -1,0 +1,34 @@
+.ds-spinner {
+  &,
+  &[data-size] {
+    font-size: 1.83184ex;
+  }
+
+  height: var(--ds-size-11);
+  width: auto;
+
+  /* Ensure consistent size when explicitly setting data-size */
+  &[data-size='2xs'] {
+    height: 0.75rem;
+  }
+
+  &[data-size='xs'] {
+    height: 1.25rem;
+  }
+
+  &[data-size='sm'] {
+    height: 2rem;
+  }
+
+  &[data-size='md'] {
+    height: 2.75rem;
+  }
+
+  &[data-size='lg'] {
+    height: 3.75rem;
+  }
+
+  &[data-size='xl'] {
+    height: 5.5rem;
+  }
+}

--- a/@udir-design/react/src/components/tabs/tabs.css
+++ b/@udir-design/react/src/components/tabs/tabs.css
@@ -8,4 +8,10 @@
     --dsc-tabs-tab-color: var(--ds-color-text-subtle);
     --dsc-tabs-tab-color--hover: var(--ds-color-border-default);
   }
+
+  :is([role='tablist'], u-tablist) > :is([role='tab'], u-tab) :where(img, svg) {
+    font-size: 1.83184ex;
+    height: 1.25em; /* Auto scale icon based on font-size */
+    width: auto;
+  }
 }

--- a/@udir-design/react/src/components/tag/Tag.tsx
+++ b/@udir-design/react/src/components/tag/Tag.tsx
@@ -1,3 +1,4 @@
+import './tag.css';
 import { Tag, type TagProps } from '@digdir/designsystemet-react';
 
 export type { TagProps };

--- a/@udir-design/react/src/components/tag/tag.css
+++ b/@udir-design/react/src/components/tag/tag.css
@@ -1,0 +1,5 @@
+.ds-tag :where(img, svg) {
+  font-size: 1.83184ex;
+  height: 1.25em; /* Auto scale icon based on font-size */
+  width: auto;
+}

--- a/@udir-design/react/src/docs/ResourceLinks.tsx
+++ b/@udir-design/react/src/docs/ResourceLinks.tsx
@@ -74,8 +74,9 @@ export function ComponentResourceLink() {
             Oversikten over komponentene finnes også tilgjengelig i Figma.
           </Paragraph>
           <ArrowRightIcon
-            title="a11y-title"
-            fontSize="1.5rem"
+            aria-hidden
+            height="1.5rem"
+            width="auto"
             className={styles.icon}
           />
         </Card.Block>

--- a/@udir-design/react/src/icons/Ikoner.mdx
+++ b/@udir-design/react/src/icons/Ikoner.mdx
@@ -18,7 +18,9 @@ import { HideToc } from '.storybook/docs/components';
 
 Ikoner kan brukes for å raskt identifisere interaktive elementer og skille mellom kategorier. Ikonene er tilgjengelig både som React-komponenter og som svg-filer. Vi anbefaler å bruke React-komponentene når du bruker React.
 
-Ikonene skaleres automatisk etter tekststørrelsen der de plasseres. Du kan justere størrelsen ved å sette `font-size` der de står eller direkte på ikonet: `<ArrowRightIcon fontSize="2rem" />`.
+Ikonene skaleres automatisk etter tekststørrelsen der de plasseres. Du kan justere størrelsen ved å sette `font-size` på elementet **rundt** ikonet, eller ved å sette `height` og `width` direkte på ikonet: `<ArrowRightIcon height="2rem" width="auto" />`.
+
+**Merk: ikke sett font-size direkte på ikonet, hverken inline eller via css**. Dette vil gjøre at ikonene ikke skalerer i Safari.
 
 Vi følger Digdirs anbefaling om å bruke Navs ikonbibliotek Aksel. Noen ikoner, slik som piler, finnes i ulike varianter. For disse har vi valgt ut noen som er merket "Foretrukket hos Udir" slik at vi bruker ikoner mest mulig konsistent på tvers i tjenestene våre. Vi bruker primært outline-versjon av ikonene, men i enkelttilfeller vil det fungere med filled.
 

--- a/@udir-design/react/src/icons/Ikoner.mdx
+++ b/@udir-design/react/src/icons/Ikoner.mdx
@@ -18,7 +18,7 @@ import { HideToc } from '.storybook/docs/components';
 
 Ikoner kan brukes for å raskt identifisere interaktive elementer og skille mellom kategorier. Ikonene er tilgjengelig både som React-komponenter og som svg-filer. Vi anbefaler å bruke React-komponentene når du bruker React.
 
-Ikonene skaleres automatisk etter tekststørrelsen der de plasseres. Du kan justere størrelsen ved å sette `font-size` på elementet **rundt** ikonet, eller ved å sette `height` og `width` direkte på ikonet: `<ArrowRightIcon height="2rem" width="auto" />`.
+Ikonene skaleres automatisk etter tekststørrelsen der de plasseres. Du kan justere størrelsen ved å sette `font-size` på elementet **rundt** ikonet, eller ved å sette `height` og `width` direkte på ikonet: `<ArrowRightIcon height="2rem" width="2rem" />`.
 
 **Merk: ikke sett font-size direkte på ikonet, hverken inline eller via css**. Dette vil gjøre at ikonene ikke skalerer i Safari.
 

--- a/@udir-design/react/src/icons/__snapshots__/icons.stories.tsx.snap
+++ b/@udir-design/react/src/icons/__snapshots__/icons.stories.tsx.snap
@@ -8016,13 +8016,12 @@ exports[`Outline Icons 1`] = `
 <div>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8035,13 +8034,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8054,13 +8052,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8073,13 +8070,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8092,13 +8088,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8111,13 +8106,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8130,13 +8124,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8149,13 +8142,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8168,13 +8160,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8187,13 +8178,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8206,13 +8196,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8225,13 +8214,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8244,13 +8232,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8268,13 +8255,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8285,13 +8271,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8307,13 +8292,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8324,13 +8308,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8341,13 +8324,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8360,13 +8342,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8377,13 +8358,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8394,13 +8374,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8411,13 +8390,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8428,13 +8406,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8445,13 +8422,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8462,13 +8438,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8489,13 +8464,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8506,13 +8480,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8523,13 +8496,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8542,13 +8514,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8561,13 +8532,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8580,13 +8550,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8599,13 +8568,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8618,13 +8586,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8637,13 +8604,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8656,13 +8622,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8675,13 +8640,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8694,13 +8658,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8713,13 +8676,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8732,13 +8694,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8751,13 +8712,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8770,13 +8730,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8787,13 +8746,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8806,13 +8764,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8825,13 +8782,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8844,13 +8800,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8863,13 +8818,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8889,13 +8843,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8908,13 +8861,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8927,13 +8879,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8953,13 +8904,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8972,13 +8922,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -8991,13 +8940,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9010,13 +8958,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9029,13 +8976,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9048,13 +8994,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9067,13 +9012,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9086,13 +9030,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9105,13 +9048,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9124,13 +9066,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9143,13 +9084,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9162,13 +9102,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9181,13 +9120,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9200,13 +9138,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9219,13 +9156,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9238,13 +9174,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9257,13 +9192,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9276,13 +9210,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9295,13 +9228,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9314,13 +9246,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9333,13 +9264,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9352,13 +9282,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9371,13 +9300,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9390,13 +9318,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9409,13 +9336,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9428,13 +9354,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9447,13 +9372,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9466,13 +9390,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9485,13 +9408,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9504,13 +9426,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9523,13 +9444,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9542,13 +9462,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9561,13 +9480,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9580,13 +9498,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9599,13 +9516,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9616,13 +9532,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9635,13 +9550,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9654,13 +9568,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9676,13 +9589,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9695,13 +9607,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9714,13 +9625,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9733,13 +9643,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9752,13 +9661,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9771,13 +9679,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9788,13 +9695,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9807,13 +9713,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9826,13 +9731,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9845,13 +9749,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9864,13 +9767,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9883,13 +9785,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9902,13 +9803,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9921,13 +9821,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9940,13 +9839,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9959,13 +9857,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9978,13 +9875,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -9997,13 +9893,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10016,13 +9911,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10035,13 +9929,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10054,13 +9947,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10073,13 +9965,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10092,13 +9983,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10111,13 +10001,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10130,13 +10019,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10149,13 +10037,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10168,13 +10055,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10187,13 +10073,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10206,13 +10091,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10225,13 +10109,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10244,13 +10127,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10263,13 +10145,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10282,13 +10163,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10301,13 +10181,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10320,13 +10199,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10339,13 +10217,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10358,13 +10235,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10377,13 +10253,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10396,13 +10271,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10415,13 +10289,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10434,13 +10307,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10453,13 +10325,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10472,13 +10343,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10491,13 +10361,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10510,13 +10379,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10529,13 +10397,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10548,13 +10415,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10567,13 +10433,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10586,13 +10451,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10605,13 +10469,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10624,13 +10487,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10643,13 +10505,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10662,13 +10523,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10681,13 +10541,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10700,13 +10559,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10719,13 +10577,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10738,13 +10595,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10757,13 +10613,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10776,13 +10631,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10795,13 +10649,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10814,13 +10667,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10833,13 +10685,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10852,13 +10703,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10871,13 +10721,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10890,13 +10739,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10909,13 +10757,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10928,13 +10775,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10947,13 +10793,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10966,13 +10811,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -10985,13 +10829,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11004,13 +10847,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11023,13 +10865,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11042,13 +10883,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11061,13 +10901,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11080,13 +10919,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11099,13 +10937,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11118,13 +10955,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11137,13 +10973,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11156,13 +10991,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11175,13 +11009,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11194,13 +11027,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11213,13 +11045,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11232,13 +11063,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11251,13 +11081,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11270,13 +11099,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11289,13 +11117,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11308,13 +11135,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11327,13 +11153,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11346,13 +11171,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11365,13 +11189,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11384,13 +11207,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11403,13 +11225,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11422,13 +11243,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11439,13 +11259,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11458,13 +11277,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11477,13 +11295,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11496,13 +11313,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11515,13 +11331,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11534,13 +11349,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11553,13 +11367,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11572,13 +11385,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11591,13 +11403,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11610,13 +11421,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11629,13 +11439,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11648,13 +11457,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11667,13 +11475,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11686,13 +11493,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11705,13 +11511,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11724,13 +11529,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11743,13 +11547,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11762,13 +11565,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11781,13 +11583,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11800,13 +11601,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11819,13 +11619,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11838,13 +11637,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11857,13 +11655,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11876,13 +11673,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11900,13 +11696,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11924,13 +11719,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11943,13 +11737,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11962,13 +11755,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -11986,13 +11778,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12005,13 +11796,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12029,13 +11819,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12048,13 +11837,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12067,13 +11855,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12086,13 +11873,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12105,13 +11891,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12129,13 +11914,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12148,13 +11932,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12167,13 +11950,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12186,13 +11968,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12205,13 +11986,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12224,13 +12004,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12243,13 +12022,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12262,13 +12040,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12281,13 +12058,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12300,13 +12076,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12319,13 +12094,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12338,13 +12112,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12357,13 +12130,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12376,13 +12148,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12395,13 +12166,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12414,13 +12184,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12433,13 +12202,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12452,13 +12220,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12469,13 +12236,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12488,13 +12254,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12507,13 +12272,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12526,13 +12290,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12545,13 +12308,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12564,13 +12326,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12583,13 +12344,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12602,13 +12362,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12621,13 +12380,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12640,13 +12398,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12659,13 +12416,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12678,13 +12434,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12697,13 +12452,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12716,13 +12470,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12735,13 +12488,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12754,13 +12506,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12773,13 +12524,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12792,13 +12542,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12811,13 +12560,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12830,13 +12578,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12849,13 +12596,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12868,13 +12614,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12887,13 +12632,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12906,13 +12650,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12925,13 +12668,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12944,13 +12686,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12963,13 +12704,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -12982,13 +12722,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13001,13 +12740,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13020,13 +12758,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13039,13 +12776,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13058,13 +12794,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13077,13 +12812,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13096,13 +12830,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13115,13 +12848,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13134,13 +12866,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13153,13 +12884,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13172,13 +12902,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13191,13 +12920,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13210,13 +12938,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13229,13 +12956,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13248,13 +12974,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13267,13 +12992,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13286,13 +13010,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13305,13 +13028,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13324,13 +13046,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13343,13 +13064,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13362,13 +13082,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13381,13 +13100,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13400,13 +13118,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13419,13 +13136,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13438,13 +13154,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13457,13 +13172,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13476,13 +13190,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13493,13 +13206,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13512,13 +13224,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13531,13 +13242,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13548,13 +13258,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13567,13 +13276,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13586,13 +13294,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13605,13 +13312,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13624,13 +13330,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13643,13 +13348,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13662,13 +13366,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13679,13 +13382,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13698,13 +13400,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13717,13 +13418,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13736,13 +13436,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13755,13 +13454,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13774,13 +13472,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13793,13 +13490,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13812,13 +13508,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13831,13 +13526,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13850,13 +13544,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13869,13 +13562,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13888,13 +13580,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13907,13 +13598,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13926,13 +13616,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13945,13 +13634,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13964,13 +13652,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -13983,13 +13670,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14002,13 +13688,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14021,13 +13706,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14040,13 +13724,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14059,13 +13742,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14078,13 +13760,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14097,13 +13778,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14116,13 +13796,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14135,13 +13814,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14154,13 +13832,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14173,13 +13850,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14192,13 +13868,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14211,13 +13886,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14230,13 +13904,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14249,13 +13922,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14268,13 +13940,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14285,13 +13956,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14304,13 +13974,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14323,13 +13992,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14342,13 +14010,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14361,13 +14028,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14380,13 +14046,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14399,13 +14064,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14416,13 +14080,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14433,13 +14096,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14452,13 +14114,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14471,13 +14132,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14490,13 +14150,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14509,13 +14168,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14528,13 +14186,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14547,13 +14204,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14566,13 +14222,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14585,13 +14240,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14604,13 +14258,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14623,13 +14276,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14642,13 +14294,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14661,13 +14312,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14680,13 +14330,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14699,13 +14348,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14718,13 +14366,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14737,13 +14384,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14756,13 +14402,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14775,13 +14420,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14794,13 +14438,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14813,13 +14456,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14832,13 +14474,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14851,13 +14492,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14870,13 +14510,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14889,13 +14528,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14908,13 +14546,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14927,13 +14564,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14946,13 +14582,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14965,13 +14600,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -14984,13 +14618,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15003,13 +14636,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15022,13 +14654,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15041,13 +14672,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15060,13 +14690,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15079,13 +14708,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15098,13 +14726,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15117,13 +14744,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15136,13 +14762,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15155,13 +14780,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15172,13 +14796,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15191,13 +14814,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15210,13 +14832,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15229,13 +14850,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15248,13 +14868,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15267,13 +14886,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15286,13 +14904,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15305,13 +14922,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15324,13 +14940,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15343,13 +14958,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15362,13 +14976,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15379,13 +14992,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15398,13 +15010,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15417,13 +15028,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15436,13 +15046,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15455,13 +15064,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15474,13 +15082,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15493,13 +15100,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15512,13 +15118,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15531,13 +15136,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15550,13 +15154,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15569,13 +15172,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15588,13 +15190,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15607,13 +15208,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15626,13 +15226,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15645,13 +15244,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15664,13 +15262,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15683,13 +15280,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15702,13 +15298,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15721,13 +15316,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15740,13 +15334,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15759,13 +15352,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15778,13 +15370,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15797,13 +15388,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15830,13 +15420,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15854,13 +15443,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15878,13 +15466,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15902,13 +15489,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15921,13 +15507,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15940,13 +15525,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15959,13 +15543,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15978,13 +15561,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -15997,13 +15579,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16016,13 +15597,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16035,13 +15615,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16054,13 +15633,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16073,13 +15651,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16092,13 +15669,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16111,13 +15687,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16130,13 +15705,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16149,13 +15723,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16168,13 +15741,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16187,13 +15759,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16206,13 +15777,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16225,13 +15795,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16244,13 +15813,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16263,13 +15831,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16282,13 +15849,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16301,13 +15867,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16320,13 +15885,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16339,13 +15903,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16358,13 +15921,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16377,13 +15939,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16396,13 +15957,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16413,13 +15973,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16432,13 +15991,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16451,13 +16009,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16470,13 +16027,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16487,13 +16043,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16504,13 +16059,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16523,13 +16077,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16542,13 +16095,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16561,13 +16113,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16580,13 +16131,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16599,13 +16149,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16618,13 +16167,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16637,13 +16185,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16656,13 +16203,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16675,13 +16221,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16694,13 +16239,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16713,13 +16257,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16732,13 +16275,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16751,13 +16293,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16770,13 +16311,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16789,13 +16329,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16806,13 +16345,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16825,13 +16363,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16844,13 +16381,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16863,13 +16399,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16882,13 +16417,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16901,13 +16435,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16920,13 +16453,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16939,13 +16471,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16958,13 +16489,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16977,13 +16507,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -16996,13 +16525,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17015,13 +16543,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17034,13 +16561,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17053,13 +16579,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17072,13 +16597,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17091,13 +16615,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17110,13 +16633,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17129,13 +16651,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17148,13 +16669,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17167,13 +16687,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17186,13 +16705,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17205,13 +16723,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17224,13 +16741,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17243,13 +16759,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17262,13 +16777,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17281,13 +16795,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17298,13 +16811,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17317,13 +16829,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17334,13 +16845,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17353,13 +16863,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17372,13 +16881,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17391,13 +16899,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17410,13 +16917,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17429,13 +16935,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17448,13 +16953,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17467,13 +16971,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17486,13 +16989,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17505,13 +17007,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17524,13 +17025,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17543,13 +17043,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17560,13 +17059,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17577,13 +17075,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17594,13 +17091,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17613,13 +17109,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17632,13 +17127,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17651,13 +17145,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17670,13 +17163,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17689,13 +17181,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17708,13 +17199,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17727,13 +17217,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17746,13 +17235,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17765,13 +17253,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17784,13 +17271,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17803,13 +17289,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17822,13 +17307,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17841,13 +17325,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17860,13 +17343,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17879,13 +17361,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17898,13 +17379,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17917,13 +17397,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17936,13 +17415,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17953,13 +17431,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17972,13 +17449,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path
@@ -17991,13 +17467,12 @@ exports[`Outline Icons 1`] = `
   </svg>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="3rem"
+    height="3rem"
     fill="none"
     viewbox="0 0 24 24"
     focusable="false"
     role="img"
-    font-size="3rem"
     aria-hidden="true"
   >
     <path

--- a/@udir-design/react/src/icons/icons.stories.tsx
+++ b/@udir-design/react/src/icons/icons.stories.tsx
@@ -25,7 +25,12 @@ export const OutlineIcons = meta.story({
           return (
             !key.includes('Fill') && (
               <React.Fragment key={key}>
-                <Component fontSize="3rem" aria-hidden className="icon-color" />
+                <Component
+                  height="3rem"
+                  width="3rem"
+                  aria-hidden
+                  className="icon-color"
+                />
               </React.Fragment>
             )
           );


### PR DESCRIPTION
## Hva er gjort?

Endra alle stader vi setter font-size på svg, sidan dette ikkje skalerer med zoom i Safari.

### Skalering av ikon i komponentar

Setter `font-size` på svg inni ulike komponentar til `1.83184ex`, som for Inter-fonten gir samme pikselverdi som `1em` men får skalering til å funke i Safari.

Deretter, setter størrelsen på ikon med `height` istadenfor `font-size`, og `width: 'auto'`.  Dermed har vi samme størrelse på ikona som før, men med skalering i Safari.

Alle endringane i css-filer i `@udir-design/react` kan reverteres dersom [denne PRen hos Digdir](https://github.com/digdir/designsystemet/pull/4484) blir akseptert og blir med i ein upstream release.

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog

