### PR TITLE
fix(usePagination): disable prev/next buttons instead of hiding them

### DIFF
--- a/@udir-design/react/src/components/pagination/Pagination.stories.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.stories.tsx
@@ -148,6 +148,9 @@ export const WithAnchor = meta.story({
       return;
     };
 
+    const prevDisabled = prevButtonProps?.['aria-disabled'];
+    const nextDisabled = nextButtonProps?.['aria-disabled'];
+
     return (
       <div
         style={{
@@ -168,7 +171,10 @@ export const WithAnchor = meta.story({
                 {...prevButtonProps}
               >
                 <a
-                  onClick={(e) => handleAnchorClick(e, page - 1)}
+                  onClick={(e) => {
+                    if (prevDisabled) return;
+                    handleAnchorClick(e, page - 1);
+                  }}
                   href={`#side-${page - 1}`}
                 >
                   Forrige
@@ -200,7 +206,10 @@ export const WithAnchor = meta.story({
                 {...nextButtonProps}
               >
                 <a
-                  onClick={(e) => handleAnchorClick(e, page + 1)}
+                  onClick={(e) => {
+                    if (nextDisabled) return;
+                    handleAnchorClick(e, page + 1);
+                  }}
                   href={`#side-${page + 1}`}
                 >
                   Neste

--- a/@udir-design/react/src/components/pagination/__snapshots__/Pagination.stories.tsx.snap
+++ b/@udir-design/react/src/components/pagination/__snapshots__/Pagination.stories.tsx.snap
@@ -58,7 +58,6 @@ exports[`Preview 1`] = `
         data-variant="tertiary"
         type="button"
         aria-label="Forrige side"
-        aria-hidden="false"
       >
         Forrige
       </button>
@@ -125,7 +124,6 @@ exports[`Preview 1`] = `
         data-variant="tertiary"
         type="button"
         aria-label="Neste side"
-        aria-hidden="false"
       >
         Neste
       </button>
@@ -151,7 +149,6 @@ exports[`With Anchor 1`] = `
           href="#side-3"
           data-variant="tertiary"
           aria-label="Forrige side"
-          aria-hidden="false"
         >
           Forrige
         </a>
@@ -218,7 +215,6 @@ exports[`With Anchor 1`] = `
           href="#side-5"
           data-variant="tertiary"
           aria-label="Neste side"
-          aria-hidden="false"
         >
           Neste
         </a>

--- a/@udir-design/react/src/demo/table-demo/__snapshots__/TableDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/table-demo/__snapshots__/TableDemo.stories.tsx.snap
@@ -765,9 +765,9 @@ exports[`Table Story 1`] = `
         <ul>
           <li>
             <button
+              aria-disabled="true"
               data-variant="tertiary"
               type="button"
-              aria-hidden="true"
             >
               <span>
                 Forrige
@@ -806,7 +806,6 @@ exports[`Table Story 1`] = `
             <button
               data-variant="tertiary"
               type="button"
-              aria-hidden="false"
             >
               <span>
                 Neste

--- a/@udir-design/react/src/utilities/hooks/usePagination/__snapshots__/usePagination.stories.tsx.snap
+++ b/@udir-design/react/src/utilities/hooks/usePagination/__snapshots__/usePagination.stories.tsx.snap
@@ -8,7 +8,6 @@ exports[`Preview 1`] = `
         data-variant="tertiary"
         type="button"
         aria-label="Forrige side"
-        aria-hidden="false"
       >
         Forrige
       </button>
@@ -75,7 +74,6 @@ exports[`Preview 1`] = `
         data-variant="tertiary"
         type="button"
         aria-label="Neste side"
-        aria-hidden="false"
       >
         Neste
       </button>

--- a/@udir-design/react/src/utilities/hooks/usePagination/usePagination.ts
+++ b/@udir-design/react/src/utilities/hooks/usePagination/usePagination.ts
@@ -1,7 +1,34 @@
 import {
   type UsePaginationProps,
-  usePagination,
+  usePagination as useDigdirPagination,
 } from '@digdir/designsystemet-react';
+import { useMemo } from 'react';
 
 export type { UsePaginationProps };
-export { usePagination };
+
+// Overriding the hook to add aria-disabled and remove aria-hidden on prev/next buttons
+// Fixes accessibility issues and communicates unavailable state instead of hiding controls: https://jira.udir.no/secure/RapidBoard.jspa?rapidView=534&projectKey=DESIGN&view=detail&selectedIssue=DESIGN-472#
+export const usePagination = (props: UsePaginationProps) => {
+  const pagination = useDigdirPagination(props);
+
+  return useMemo(() => {
+    return {
+      ...pagination,
+      prevButtonProps: pagination.prevButtonProps
+        ? {
+            ...pagination.prevButtonProps,
+            'aria-hidden': undefined,
+            'aria-disabled': !pagination.hasPrev || undefined,
+          }
+        : pagination.prevButtonProps,
+
+      nextButtonProps: pagination.nextButtonProps
+        ? {
+            ...pagination.nextButtonProps,
+            'aria-hidden': undefined,
+            'aria-disabled': !pagination.hasNext || undefined,
+          }
+        : pagination.nextButtonProps,
+    };
+  }, [pagination]);
+};

--- a/@udir-design/react/src/utilities/hooks/usePagination/usePagination.ts
+++ b/@udir-design/react/src/utilities/hooks/usePagination/usePagination.ts
@@ -10,25 +10,19 @@ export type { UsePaginationProps };
 // Fixes accessibility issues and communicates unavailable state instead of hiding controls: https://jira.udir.no/secure/RapidBoard.jspa?rapidView=534&projectKey=DESIGN&view=detail&selectedIssue=DESIGN-472#
 export const usePagination = (props: UsePaginationProps) => {
   const pagination = useDigdirPagination(props);
-
   return useMemo(() => {
     return {
       ...pagination,
-      prevButtonProps: pagination.prevButtonProps
-        ? {
-            ...pagination.prevButtonProps,
-            'aria-hidden': undefined,
-            'aria-disabled': !pagination.hasPrev || undefined,
-          }
-        : pagination.prevButtonProps,
-
-      nextButtonProps: pagination.nextButtonProps
-        ? {
-            ...pagination.nextButtonProps,
-            'aria-hidden': undefined,
-            'aria-disabled': !pagination.hasNext || undefined,
-          }
-        : pagination.nextButtonProps,
+      prevButtonProps: {
+        ...pagination.prevButtonProps,
+        'aria-hidden': undefined,
+        'aria-disabled': !pagination.hasPrev || undefined,
+      },
+      nextButtonProps: {
+        ...pagination.nextButtonProps,
+        'aria-hidden': undefined,
+        'aria-disabled': !pagination.hasNext || undefined,
+      },
     };
   }, [pagination]);
 };


### PR DESCRIPTION
## Hva er gjort?

- Disable prev/next buttons instead of hiding them
- Overriding the hook to add aria-disabled and remove aria-hidden on prev/next buttons
- Fixes accessibility issues and communicates unavailable state instead of hiding controls: [Mer info i lappen i Jira](https://jira.udir.no/secure/RapidBoard.jspa?rapidView=534&projectKey=DESIGN&view=detail&selectedIssue=DESIGN-472# )

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er testet med skjermleser og/eller annet UU-verktøy