### PR TITLE
docs: update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] Dokumentasjonen er oppdatert om nødvendig
 - [ ] Commitmeldingene gir mening i kontekst av changelog
 - [ ] Komponenten er eksportert fra riktig fil
+- [ ] Komponenten fungerer godt med `dir="rtl"`
 - [ ] Komponenten er testet i test-app
 - [ ] Komponenten er testet med skjermleser og/eller annet UU-verktøy
 - [ ] Komponenten har tester i Storybook


### PR DESCRIPTION
## Hva er gjort?

Oppdaterer PR-templaten for å sørge for at vi husker på å bruke f.eks. `inset-inline-start` i stedet for `left` osv også i fremtidige PRer:) 