### PR TITLE
fix: FormNavigation support multiple lines

### DIFF
--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -108,3 +108,7 @@ Feilmeldinger håndteres ved hjelp av valgfri skjemavalidering, sammen med inlin
 - Bruk en [`ErrorSummary`](/docs/components-errorsummary--docs) på innleveringssiden for å gi en oversikt over alle feil i skjemaet. Dette hjelper brukeren med å raskt identifisere og navigere til feilene som må rettes opp.
 - Lenkene i [`ErrorSummary`](/docs/components-errorsummary--docs) skal navigere til riktig side og fokusere de respektive feltene når de klikkes.
 - Bruk `markInvalid` og `markCompleted` fra [`useFormNavigation`](/docs/utilities-useformnavigation--docs) for å oppdatere stegenes tilstand basert på valideringsresultatene.
+
+### Tekst i FormNavigation
+
+For å skille stegene fra hverandre og unngå forvirring, bør du unngå stegtitler som starter på samme måte. F.ek.s "Program for ..." i flere steg.

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
@@ -88,6 +88,36 @@ export const Grouping = meta.story({
   },
 });
 
+export const LongStepNames = meta.story({
+  args: {},
+  render(args) {
+    const { getStepProps, getGroupProps } = useFormNavigation({
+      value: 'step1',
+    });
+    return (
+      <FormNavigation {...args} style={{ width: '200px' }}>
+        <FormNavigation.Group
+          title="Utdanningsprogram"
+          {...getGroupProps(['step1', 'step2'])}
+        >
+          <FormNavigation.Step {...getStepProps('step1')}>
+            Bygg- og anleggsteknikk
+          </FormNavigation.Step>
+          <FormNavigation.Step {...getStepProps('step2')}>
+            Elektro og datateknologi
+          </FormNavigation.Step>
+          <FormNavigation.Step {...getStepProps('step3')}>
+            Håndverk, design og produktutvikling
+          </FormNavigation.Step>
+          <FormNavigation.Step {...getStepProps('step4')}>
+            Naturbruk
+          </FormNavigation.Step>
+        </FormNavigation.Group>
+      </FormNavigation>
+    );
+  },
+});
+
 export const SingleStep = meta.story({
   args: {},
   render: (args) => (

--- a/@udir-design/react/src/components/formNavigation/__snapshots__/FormNavigation.stories.tsx.snap
+++ b/@udir-design/react/src/components/formNavigation/__snapshots__/FormNavigation.stories.tsx.snap
@@ -914,6 +914,57 @@ exports[`Grouping 1`] = `
 </div>
 `;
 
+exports[`Long Step Names 1`] = `
+<div data-size="auto">
+  <div style="width: 200px;">
+    <details
+      data-state="idle"
+      open
+      data-active-step-label="Bygg- og anleggsteknikk"
+    >
+      <summary>
+        <span>
+          Utdanningsprogram
+        </span>
+      </summary>
+      <button
+        data-state="active"
+        data-variant="default"
+        aria-current="step"
+      >
+        <div>
+        </div>
+        Bygg- og anleggsteknikk
+      </button>
+      <button
+        data-state="idle"
+        data-variant="default"
+      >
+        <div>
+        </div>
+        Elektro og datateknologi
+      </button>
+      <button
+        data-state="idle"
+        data-variant="default"
+      >
+        <div>
+        </div>
+        Håndverk, design og produktutvikling
+      </button>
+      <button
+        data-state="idle"
+        data-variant="default"
+      >
+        <div>
+        </div>
+        Naturbruk
+      </button>
+    </details>
+  </div>
+</div>
+`;
+
 exports[`Preview 1`] = `
 <div data-size="auto">
   <div>

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -358,7 +358,12 @@
           );
           opacity: 1;
           height: auto;
-          transition-delay: 300ms;
+
+          @media (prefers-reduced-motion: no-preference) {
+            @supports (interpolate-size: allow-keywords) {
+              transition-delay: 300ms;
+            }
+          }
         }
       }
     }

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -353,7 +353,7 @@
             var(--uds-form-navigation-icon-size) + var(--ds-size-2)
           );
           opacity: 1;
-          max-height: 3rem;
+          max-height: 20rem;
           transition-delay: 300ms;
         }
       }
@@ -361,24 +361,42 @@
 
     /* Connector - line between steps */
     > .uds-form-navigation__step {
-      > div {
-        position: relative;
+      white-space: normal;
+      align-items: flex-start;
+
+      &:first-of-type {
+        margin-block-start: var(--uds-form-navigation-connector);
+
         &::before {
           content: '';
           position: absolute;
+          inset-inline-start: var(--ds-size-3);
           inset-block-end: calc(
             100% + (var(--uds-form-navigation-connector) / 2) - var(--ds-size-1)
           );
-          inset-inline-start: 50%;
+          height: var(--uds-form-navigation-connector);
           transform: translateX(-50%);
           width: 1px;
-          height: var(--uds-form-navigation-connector);
           background-color: var(--ds-color-border-default);
         }
       }
 
-      &:first-of-type {
-        margin-block-start: var(--uds-form-navigation-connector);
+      &::after {
+        content: '';
+        position: absolute;
+        inset-block-start: calc(var(--uds-form-navigation-icon-size) + 2px);
+        inset-block-end: calc(
+          -1 * var(--uds-form-navigation-connector) + var(--ds-size-1)
+        );
+        inset-inline-start: var(--ds-size-3);
+        transform: translateX(-50%);
+        min-height: var(--uds-form-navigation-connector);
+        width: 1px;
+        background-color: var(--ds-color-border-default);
+      }
+
+      &:last-of-type::after {
+        display: none;
       }
     }
   }

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -1,4 +1,8 @@
 .uds-form-navigation {
+  @media (prefers-reduced-motion: no-preference) {
+    interpolate-size: allow-keywords;
+  }
+
   --uds-form-navigation-active-text-stroke: 0.025em;
   --uds-form-navigation-completed-icon-url: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M3.75 12C3.75 7.44365 7.44365 3.75 12 3.75C16.5563 3.75 20.25 7.44365 20.25 12C20.25 16.5563 16.5563 20.25 12 20.25C7.44365 20.25 3.75 16.5563 3.75 12ZM12 2.25C6.61522 2.25 2.25 6.61522 2.25 12C2.25 17.3848 6.61522 21.75 12 21.75C17.3848 21.75 21.75 17.3848 21.75 12C21.75 6.61522 17.3848 2.25 12 2.25ZM16.5725 9.48444C16.8401 9.16824 16.8007 8.695 16.4845 8.42745C16.1683 8.15989 15.695 8.19932 15.4275 8.51553L10.454 14.3933L8.03033 11.9697C7.73744 11.6768 7.26256 11.6768 6.96967 11.9697C6.67678 12.2625 6.67678 12.7374 6.96967 13.0303L9.96967 16.0303C10.118 16.1786 10.3216 16.2581 10.5312 16.2493C10.7407 16.2406 10.9371 16.1446 11.0725 15.9844L16.5725 9.48444Z' fill='%23202733'/%3E%3C/svg%3E%0A");
   --uds-form-navigation-completed-active-icon-url: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 21.75C17.3848 21.75 21.75 17.3848 21.75 12C21.75 6.61522 17.3848 2.25 12 2.25C6.61522 2.25 2.25 6.61522 2.25 12C2.25 17.3848 6.61522 21.75 12 21.75ZM16.9536 9.27485C17.2434 8.93229 17.2007 8.41962 16.8582 8.12977C16.5156 7.83991 16.0029 7.88263 15.7131 8.22519L10.3251 14.5928L7.69952 11.9672C7.38222 11.6499 6.86778 11.6499 6.55048 11.9672C6.23317 12.2845 6.23317 12.7989 6.55048 13.1162L9.80048 16.3662C9.96114 16.5269 10.1817 16.6129 10.4088 16.6035C10.6358 16.594 10.8485 16.49 10.9953 16.3165L16.9536 9.27485Z' fill='%23202733'/%3E%3C/svg%3E%0A");
@@ -333,9 +337,9 @@
         display: block;
         color: var(--ds-color-text-subtle);
         opacity: 0;
-        max-height: 0;
+        height: 0;
         overflow: hidden;
-        transition: max-height 300ms ease;
+        transition: height 300ms ease;
       }
 
       &:not([open]) {
@@ -353,7 +357,7 @@
             var(--uds-form-navigation-icon-size) + var(--ds-size-2)
           );
           opacity: 1;
-          max-height: 20rem;
+          height: auto;
           transition-delay: 300ms;
         }
       }

--- a/@udir-design/react/src/components/formNavigation/formNavigation.css
+++ b/@udir-design/react/src/components/formNavigation/formNavigation.css
@@ -373,6 +373,12 @@
       white-space: normal;
       align-items: flex-start;
 
+      /* Center the icon on first line of the step label */
+      > div::after {
+        position: relative;
+        top: 2px;
+      }
+
       &:first-of-type {
         margin-block-start: var(--uds-form-navigation-connector);
 
@@ -381,7 +387,7 @@
           position: absolute;
           inset-inline-start: var(--ds-size-3);
           inset-block-end: calc(
-            100% + (var(--uds-form-navigation-connector) / 2) - var(--ds-size-1)
+            100% + (var(--uds-form-navigation-connector) / 2) - 5px
           );
           height: var(--uds-form-navigation-connector);
           transform: translateX(-50%);
@@ -393,10 +399,8 @@
       &::after {
         content: '';
         position: absolute;
-        inset-block-start: calc(var(--uds-form-navigation-icon-size) + 2px);
-        inset-block-end: calc(
-          -1 * var(--uds-form-navigation-connector) + var(--ds-size-1)
-        );
+        inset-block-start: calc(var(--uds-form-navigation-icon-size) + 4px);
+        inset-block-end: calc(-1 * var(--uds-form-navigation-connector));
         inset-inline-start: var(--ds-size-3);
         transform: translateX(-50%);
         min-height: var(--uds-form-navigation-connector);


### PR DESCRIPTION
## Hva er gjort?

Oppdatert css for `FormNavigation` til å ha dynamisk høyde på connector-line og gjort det mulig å bryte over flere linjer med white-space: normal. La også til en ny story med eksempel på dette for å unngå at det knekker i fremtiden. 

Også oppdatert dokumentasjon med info om at skjemasteg som starter på det samme burde navngis annerledes. 