### PR TITLE
feat: add nynorsk support to FileUpload and document existing nynorsk support in FieldNecessity

### DIFF
--- a/@udir-design/react/.storybook/docs/components/CssVariables/CssLanguageVariables.tsx
+++ b/@udir-design/react/.storybook/docs/components/CssVariables/CssLanguageVariables.tsx
@@ -1,34 +1,77 @@
 import { Unstyled } from '@storybook/addon-docs/blocks';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Table } from 'src/components/table';
 import styles from './CssLanguageVariables.module.css';
 
 export const CssLanguageVariables = ({
   variables,
 }: {
-  variables: Record<string, { nb: string; en: string }>;
+  variables: string[];
 }) => {
+  const langs = useMemo(() => ['nb', 'nn', 'en'] as const, []);
+  type Lang = (typeof langs)[number];
+  const enRef = useRef<HTMLDivElement>(null);
+  const nbRef = useRef<HTMLDivElement>(null);
+  const nnRef = useRef<HTMLDivElement>(null);
+  const refs = useMemo(
+    () => ({
+      en: enRef,
+      nb: nbRef,
+      nn: nnRef,
+    }),
+    [],
+  );
+  const [computedStyle, setComputedStyle] = useState<
+    Record<Lang, CSSStyleDeclaration | undefined>
+  >({
+    en: undefined,
+    nb: undefined,
+    nn: undefined,
+  });
+
+  useEffect(() => {
+    const setForLang = (lang: Lang) =>
+      setComputedStyle((prev) =>
+        !prev[lang] && refs[lang].current
+          ? { ...prev, [lang]: getComputedStyle(refs[lang].current) }
+          : prev,
+      );
+
+    langs.forEach(setForLang);
+  }, [langs, refs]);
+
+  const getTranslation = (lang: Lang, variable: string) => {
+    const langStyle = computedStyle[lang];
+    if (!langStyle) return;
+    return langStyle.getPropertyValue(variable);
+  };
+
   return (
     <Unstyled>
+      {langs.map((lang) => (
+        <div style={{ display: 'none' }} lang={lang} ref={refs[lang]} />
+      ))}
+
       <Table className={styles.languageVariables} border zebra>
         <Table.Head>
           <Table.Row>
             <Table.HeaderCell>Navn</Table.HeaderCell>
-            <Table.HeaderCell>
-              <code>lang="nb"</code>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
-              <code>lang="en"</code>
-            </Table.HeaderCell>
+            {langs.map((lang) => (
+              <Table.HeaderCell>
+                <code>lang="{lang}"</code>
+              </Table.HeaderCell>
+            ))}
           </Table.Row>
         </Table.Head>
         <Table.Body>
-          {Object.entries(variables).map(([name, value]) => (
-            <Table.Row key={name}>
+          {variables.map((variable) => (
+            <Table.Row key={variable}>
               <Table.Cell>
-                <code>{name}</code>
+                <code>{variable}</code>
               </Table.Cell>
-              <Table.Cell>"{value.nb}"</Table.Cell>
-              <Table.Cell>"{value.en}"</Table.Cell>
+              {langs.map((lang) => (
+                <Table.Cell>{getTranslation(lang, variable) ?? ''}</Table.Cell>
+              ))}
             </Table.Row>
           ))}
         </Table.Body>

--- a/@udir-design/react/src/components/Språkstøtte.mdx
+++ b/@udir-design/react/src/components/Språkstøtte.mdx
@@ -17,7 +17,7 @@ Det vil fungere å sette `lang` på hvilken som helst forelder, men gjerne sett 
 </div>
 ```
 
-Komponentene med forhåndsdefinert tekst støtter språkene `"nb"` (norsk bokmål) eller `"en"` (engelsk). Ønsker du å støtte andre språk i disse komponentene, kan du sette standardtekstene gjennom CSS-variabler. Det gjør du ved å overstyre variablene i `lang`-attributtet for ønsket språk:
+Komponentene med forhåndsdefinert tekst støtter språkene `"nb"` (bokmål), `"nn"` (nynorsk) eller `"en"` (engelsk). Ønsker du å støtte andre språk i disse komponentene, kan du sette standardtekstene gjennom CSS-variabler. Det gjør du ved å overstyre variablene i `lang`-attributtet for ønsket språk:
 
 ```css
 /* Oversettelser for nordsamisk */

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -91,27 +91,15 @@ Oppsummeringen vil alltid leses av skjermlesere dersom den er synlig.
 
 ## Språkstøtte
 
-Komponenten har innebygget støtte for bokmål og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
 
 Følgende tekstvariabler er tilgjengelige for overstyring:
 
 <CssLanguageVariables
-  variables={{
-    '--udsc-fieldNecessity-required-text': {
-      nb: 'Må fylles ut',
-      en: 'Required',
-    },
-    '--udsc-fieldNecessity-optional-text': {
-      nb: 'Valgfritt',
-      en: 'Optional',
-    },
-    '--udsc-fieldNecessity-all-required-text': {
-      nb: 'Alle felt må fylles ut',
-      en: 'All fields are required',
-    },
-    '--udsc-fieldNecessity-all-optional-text': {
-      nb: 'Alle felt er valgfri',
-      en: 'All fields are optional',
-    },
-  }}
+  variables={[
+    '--udsc-fieldNecessity-required-text',
+    '--udsc-fieldNecessity-optional-text',
+    '--udsc-fieldNecessity-all-required-text',
+    '--udsc-fieldNecessity-all-optional-text',
+  ]}
 />

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -77,43 +77,19 @@ Ved bruk av `ErrorSummary` bør feil med flere filer oppsummeres i ett punkt, me
 
 ## Språkstøtte
 
-Komponenten har innebygget støtte for bokmål og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
 
 Følgende tekstvariabler er tilgjengelige for overstyring:
 
 <CssLanguageVariables
-  variables={{
-    '--udsc-fileUpload-addFile-text': {
-      nb: 'Legg til fil',
-      en: 'Add file',
-    },
-    '--udsc-fileUpload-addFiles-text': {
-      nb: 'Legg til filer',
-      en: 'Add files',
-    },
-    '--udsc-fileUpload-chooseFile-text': {
-      nb: 'Velg fil',
-      en: 'Choose file',
-    },
-    '--udsc-fileUpload-chooseFiles-text': {
-      nb: 'Velg filer',
-      en: 'Choose files',
-    },
-    '--udsc-fileUpload-dropFile-text': {
-      nb: 'Dra og slipp fil her',
-      en: 'Drag and drop file here',
-    },
-    '--udsc-fileUpload-dropFiles-text': {
-      nb: 'Dra og slipp filer her',
-      en: 'Drag and drop files here',
-    },
-    '--udsc-fileUpload-or-text': {
-      nb: 'eller',
-      en: 'or',
-    },
-    '--udsc-fileUpload-uploading-text': {
-      nb: 'Laster opp...',
-      en: 'Uploading...',
-    },
-  }}
+  variables={[
+    '--udsc-fileUpload-addFile-text',
+    '--udsc-fileUpload-addFiles-text',
+    '--udsc-fileUpload-chooseFile-text',
+    '--udsc-fileUpload-chooseFiles-text',
+    '--udsc-fileUpload-dropFile-text',
+    '--udsc-fileUpload-dropFiles-text',
+    '--udsc-fileUpload-or-text',
+    '--udsc-fileUpload-uploading-text',
+  ]}
 />

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -11,6 +11,18 @@
   --udsc-fileUpload-removeFile-text: 'Fjern filen';
 }
 
+[lang='nn'] {
+  --udsc-fileUpload-addFile-text: 'Legg til fil';
+  --udsc-fileUpload-addFiles-text: 'Legg til filer';
+  --udsc-fileUpload-chooseFile-text: 'Vel fil';
+  --udsc-fileUpload-chooseFiles-text: 'Vel filer';
+  --udsc-fileUpload-dropFile-text: 'Dra og slepp fila her';
+  --udsc-fileUpload-dropFiles-text: 'Dra og slepp filer her';
+  --udsc-fileUpload-or-text: 'eller';
+  --udsc-fileUpload-uploading-text: 'Lastar opp...';
+  --udsc-fileUpload-removeFile-text: 'Fjern fila';
+}
+
 [lang='en'] {
   --udsc-fileUpload-addFile-text: 'Add file';
   --udsc-fileUpload-addFiles-text: 'Add files';


### PR DESCRIPTION
## Hva er gjort?

- Legger til nynorsk oversettelse av FileUpload, med dokumentasjon
- Dokumenterer nynorsk-støtte som allerede fantes i FieldNecessity
- Endrer doc-utilityen `CssLanguageVariables` slik at vi kun treng å sende inn ei liste med variablar, så henter den ut verdian av variablane sjølv. Så slepp vi å huske å holde verdiane i synk dersom vi endrar på dei.

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
