### PR TITLE
docs: fix missing controls and primary story after removing autodocs tag

### DIFF
--- a/@udir-design/react/src/components/alert/Alert.mdx
+++ b/@udir-design/react/src/components/alert/Alert.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Source,
-  Controls,
-  Primary,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Source, Controls } from '@storybook/addon-docs/blocks';
 import * as AlertStories from './Alert.stories';
 
 <Meta of={AlertStories} />
@@ -28,7 +22,7 @@ Vi bruker `Alert` til å gi brukeren informasjon som det er ekstra viktig at de 
 
 ## Slik bruker du Alert
 
-<Primary />
+<Canvas of={AlertStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/alert/Alert.mdx
+++ b/@udir-design/react/src/components/alert/Alert.mdx
@@ -23,7 +23,7 @@ Vi bruker `Alert` til å gi brukeren informasjon som det er ekstra viktig at de 
 ## Slik bruker du Alert
 
 <Canvas of={AlertStories.Preview} withToolbar />
-<Controls />
+<Controls of={AlertStories.Preview} />
 
 ```tsx
 import { Alert } from '@udir-design/react';

--- a/@udir-design/react/src/components/avatar/Avatar.mdx
+++ b/@udir-design/react/src/components/avatar/Avatar.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as AvatarStories from './Avatar.stories';
 
 <Meta of={AvatarStories} />
@@ -18,7 +18,7 @@ import * as AvatarStories from './Avatar.stories';
 
 ## Slik bruker du Avatar
 
-<Primary />
+<Canvas of={AvatarStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/avatar/Avatar.mdx
+++ b/@udir-design/react/src/components/avatar/Avatar.mdx
@@ -19,7 +19,7 @@ import * as AvatarStories from './Avatar.stories';
 ## Slik bruker du Avatar
 
 <Canvas of={AvatarStories.Preview} withToolbar />
-<Controls />
+<Controls of={AvatarStories.Preview} />
 
 ```tsx
 import { Avatar } from '@udir-design/react';

--- a/@udir-design/react/src/components/badge/Badge.mdx
+++ b/@udir-design/react/src/components/badge/Badge.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as BadgeStories from './Badge.stories';
 
 <Meta of={BadgeStories} />
@@ -19,7 +19,7 @@ import * as BadgeStories from './Badge.stories';
 
 ## Slik bruker du Badge
 
-<Primary />
+<Canvas of={BadgeStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/badge/Badge.mdx
+++ b/@udir-design/react/src/components/badge/Badge.mdx
@@ -20,7 +20,7 @@ import * as BadgeStories from './Badge.stories';
 ## Slik bruker du Badge
 
 <Canvas of={BadgeStories.Preview} withToolbar />
-<Controls />
+<Controls of={BadgeStories.Preview} />
 
 ```tsx
 import { Badge } from '@udir-design/react';

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -19,7 +19,7 @@ Vi bruker `Breadcrumbs` til å hjelpe brukerne å forstå hvor de er i en hierar
 ## Slik bruker du Breadcrumbs
 
 <Canvas of={BreadcrumbsStories.Preview} withToolbar />
-<Controls />
+<Controls of={BreadcrumbsStories.Preview} />
 
 ```tsx
 <Breadcrumbs aria-label="Du er her:">

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import * as BreadcrumbsStories from './Breadcrumbs.stories';
 
 <Meta of={BreadcrumbsStories} />
@@ -18,7 +18,7 @@ Vi bruker `Breadcrumbs` til å hjelpe brukerne å forstå hvor de er i en hierar
 
 ## Slik bruker du Breadcrumbs
 
-<Primary />
+<Canvas of={BreadcrumbsStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { Do, Dont, Stack, SimpleAlert } from '.storybook/docs/components';
 import { Button } from './Button';
 import * as ButtonStories from './Button.stories';
@@ -22,7 +22,7 @@ Knapper lar brukerne utføre handlinger. Vi har variantene `primary`, `secondary
 
 ## Slik bruker du Button
 
-<Primary />
+<Canvas of={ButtonStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -23,7 +23,7 @@ Knapper lar brukerne utføre handlinger. Vi har variantene `primary`, `secondary
 ## Slik bruker du Button
 
 <Canvas of={ButtonStories.Preview} withToolbar />
-<Controls />
+<Controls of={ButtonStories.Preview} />
 
 ```tsx
 import { Button } from '@udir-design/react';

--- a/@udir-design/react/src/components/card/Card.mdx
+++ b/@udir-design/react/src/components/card/Card.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as CardStories from './Card.stories';
 
 <Meta of={CardStories} />
@@ -19,7 +19,7 @@ Vi bruker `Card` til å fremheve informasjon eller oppgaver som hører sammen. `
 
 ## Slik bruker du Card
 
-<Primary />
+<Canvas of={CardStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/card/Card.mdx
+++ b/@udir-design/react/src/components/card/Card.mdx
@@ -20,7 +20,7 @@ Vi bruker `Card` til å fremheve informasjon eller oppgaver som hører sammen. `
 ## Slik bruker du Card
 
 <Canvas of={CardStories.Preview} withToolbar />
-<Controls />
+<Controls of={CardStories.Preview} />
 
 ```tsx
 import { Card } from '@udir-design/react';

--- a/@udir-design/react/src/components/checkbox/Checkbox.mdx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.mdx
@@ -30,7 +30,7 @@ Vi bruker `Checkbox` (avmerkingsboks) for å gi brukerne valg, der de kan velge 
 ## Slik bruker du Checkbox
 
 <Canvas of={CheckboxStories.Preview} withToolbar />
-<Controls />
+<Controls of={CheckboxStories.Preview} />
 
 ```tsx
 import { Checkbox } from '@udir-design/react';

--- a/@udir-design/react/src/components/checkbox/Checkbox.mdx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Controls,
-  Primary,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import { Do, Dont, Stack } from '.storybook/docs/components';
 import * as CheckboxStories from './Checkbox.stories';
 import * as useCheckboxGroupStories from '../../utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories';
@@ -35,7 +29,7 @@ Vi bruker `Checkbox` (avmerkingsboks) for å gi brukerne valg, der de kan velge 
 
 ## Slik bruker du Checkbox
 
-<Primary />
+<Canvas of={CheckboxStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/chip/Chip.mdx
+++ b/@udir-design/react/src/components/chip/Chip.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ChipEx1 } from './docs/doAndDont';
 import * as ChipStories from './Chip.stories';
 
@@ -21,7 +21,7 @@ import * as ChipStories from './Chip.stories';
 
 ## Slik brukar du Chip
 
-<Primary />
+<Canvas of={ChipStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/chip/Chip.mdx
+++ b/@udir-design/react/src/components/chip/Chip.mdx
@@ -22,7 +22,7 @@ import * as ChipStories from './Chip.stories';
 ## Slik brukar du Chip
 
 <Canvas of={ChipStories.Preview} withToolbar />
-<Controls />
+<Controls of={ChipStories.Preview} />
 
 ```tsx
 import { Chip } from '@udir-design/react';

--- a/@udir-design/react/src/components/details/Details.mdx
+++ b/@udir-design/react/src/components/details/Details.mdx
@@ -33,7 +33,7 @@ Med `Details` kan du presentere mye innhold på liten plass i én eller flere ra
 ## Slik bruker du Details
 
 <Canvas of={DetailsStories.Preview} withToolbar />
-<Controls />
+<Controls of={DetailsStories.Preview} />
 
 ```tsx
 /* Uten ramme */

--- a/@udir-design/react/src/components/details/Details.mdx
+++ b/@udir-design/react/src/components/details/Details.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Controls,
-  Primary,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as DetailsStories from './Details.stories';
 import { Details } from './Details';
 import { DetailsEx1, DetailsEx2 } from './docs/doAndDont';
@@ -38,7 +32,7 @@ Med `Details` kan du presentere mye innhold på liten plass i én eller flere ra
 
 ## Slik bruker du Details
 
-<Primary />
+<Canvas of={DetailsStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/dialog/Dialog.mdx
+++ b/@udir-design/react/src/components/dialog/Dialog.mdx
@@ -11,7 +11,7 @@ import { Dialog } from './Dialog';
 ## Slik bruker du Dialog
 
 <Canvas of={DialogStories.Preview} withToolbar />
-<Controls />
+<Controls of={DialogStories.Preview} />
 
 Du bytter mellom modal og ikke-modal dialog ved å bruke `modal`-propen, som er satt til `true` som standard. Vi overstyrer hvordan `open` fungerer basert på verdien til `modal`.
 

--- a/@udir-design/react/src/components/dialog/Dialog.mdx
+++ b/@udir-design/react/src/components/dialog/Dialog.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Primary,
-  Controls,
-  Canvas,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as DialogStories from './Dialog.stories';
 import { Dialog } from './Dialog';
 
@@ -16,7 +10,7 @@ import { Dialog } from './Dialog';
 
 ## Slik bruker du Dialog
 
-<Primary />
+<Canvas of={DialogStories.Preview} withToolbar />
 <Controls />
 
 Du bytter mellom modal og ikke-modal dialog ved å bruke `modal`-propen, som er satt til `true` som standard. Vi overstyrer hvordan `open` fungerer basert på verdien til `modal`.

--- a/@udir-design/react/src/components/divider/Divider.mdx
+++ b/@udir-design/react/src/components/divider/Divider.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as DividerStories from './Divider.stories';
 
 <Meta of={DividerStories} />
@@ -18,7 +18,7 @@ import * as DividerStories from './Divider.stories';
 
 ## Slik bruker du Divider
 
-<Primary />
+<Canvas of={DividerStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/divider/Divider.mdx
+++ b/@udir-design/react/src/components/divider/Divider.mdx
@@ -19,7 +19,7 @@ import * as DividerStories from './Divider.stories';
 ## Slik bruker du Divider
 
 <Canvas of={DividerStories.Preview} withToolbar />
-<Controls />
+<Controls of={DividerStories.Preview} />
 
 ```tsx
 import { Divider } from '@udir-design/react';

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as DropdownStories from './Dropdown.stories';
 import { Dropdown } from './Dropdown';
 
@@ -19,7 +19,7 @@ Dropdown er en generisk nedtrekksliste. Den legger grunnmuren for å bygge menye
 
 ## Slik bruker du Dropdown
 
-<Primary />
+<Canvas of={DropdownStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -20,7 +20,7 @@ Dropdown er en generisk nedtrekksliste. Den legger grunnmuren for å bygge menye
 ## Slik bruker du Dropdown
 
 <Canvas of={DropdownStories.Preview} withToolbar />
-<Controls />
+<Controls of={DropdownStories.Preview} />
 
 ```tsx
 import { Dropdown } from '@udir-design/react';

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Controls,
-  Primary,
-  ArgTypes,
-  Canvas,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, ArgTypes, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as ErrorSummaryStories from './ErrorSummary.stories';
 
@@ -28,7 +22,7 @@ mangler som må rettes på en side eller i et steg for å komme videre.
 
 ## Slik bruker du ErrorSummary
 
-<Primary />
+<Canvas of={ErrorSummaryStories.Preview} withToolbar />
 <Controls />
 
 `ErrorSummary` består av flere delkomponenter som må brukes riktig.

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
@@ -23,7 +23,7 @@ mangler som må rettes på en side eller i et steg for å komme videre.
 ## Slik bruker du ErrorSummary
 
 <Canvas of={ErrorSummaryStories.Preview} withToolbar />
-<Controls />
+<Controls of={ErrorSummaryStories.Preview} />
 
 `ErrorSummary` består av flere delkomponenter som må brukes riktig.
 

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as FieldStories from './Field.stories';
 
@@ -18,7 +18,7 @@ import * as FieldStories from './Field.stories';
 
 ## Slik bruker du Field
 
-<Primary />
+<Canvas of={FieldStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -19,7 +19,7 @@ import * as FieldStories from './Field.stories';
 ## Slik bruker du Field
 
 <Canvas of={FieldStories.Preview} withToolbar />
-<Controls />
+<Controls of={FieldStories.Preview} />
 
 ```tsx
 <Field>

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -16,7 +16,7 @@ import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/Cs
 ## Slik bruker du FieldNecessity
 
 <Canvas of={FieldNecessityStories.Preview} withToolbar />
-<Controls />
+<Controls of={FieldNecessityStories.Preview} />
 
 ```tsx
 import { FieldNecessity } from '@udir-design/react';

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as FieldNecessityStories from './FieldNecessity.stories';
 import { Field } from '@digdir/designsystemet-react';
 import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
@@ -15,7 +15,7 @@ import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/Cs
 
 ## Slik bruker du FieldNecessity
 
-<Primary />
+<Canvas of={FieldNecessityStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/fieldset/Fieldset.mdx
+++ b/@udir-design/react/src/components/fieldset/Fieldset.mdx
@@ -19,7 +19,7 @@ import * as FieldsetStories from './Fieldset.stories';
 ## Slik bruker du Fieldset
 
 <Canvas of={FieldsetStories.Preview} withToolbar />
-<Controls />
+<Controls of={FieldsetStories.Preview} />
 
 ```tsx
 import { Fieldset } from '@udir-design/react';

--- a/@udir-design/react/src/components/fieldset/Fieldset.mdx
+++ b/@udir-design/react/src/components/fieldset/Fieldset.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import * as FieldsetStories from './Fieldset.stories';
 
 <Meta of={FieldsetStories} />
@@ -18,7 +18,7 @@ import * as FieldsetStories from './Fieldset.stories';
 
 ## Slik bruker du Fieldset
 
-<Primary />
+<Canvas of={FieldsetStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as FileUploadStories from './FileUpload.stories';
 import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
 
@@ -16,7 +16,7 @@ import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/Cs
 
 ## Slik bruker du FileUpload
 
-<Primary />
+<Canvas of={FileUploadStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -17,7 +17,7 @@ import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/Cs
 ## Slik bruker du FileUpload
 
 <Canvas of={FileUploadStories.Preview} withToolbar />
-<Controls />
+<Controls of={FileUploadStories.Preview} />
 
 ```tsx
 import { FileUpload } from '@udir-design/react';

--- a/@udir-design/react/src/components/footer/Footer.mdx
+++ b/@udir-design/react/src/components/footer/Footer.mdx
@@ -13,7 +13,7 @@ import * as FooterStories from './Footer.stories';
 ## Slik bruker du Footer
 
 <Canvas of={FooterStories.Preview} withToolbar />
-<Controls />
+<Controls of={FooterStories.Preview} />
 
 ```tsx
 import { Footer } from '@udir-design/react';

--- a/@udir-design/react/src/components/footer/Footer.mdx
+++ b/@udir-design/react/src/components/footer/Footer.mdx
@@ -1,5 +1,5 @@
 import { INITIAL_VIEWPORTS } from 'storybook/viewport';
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as FooterStories from './Footer.stories';
 
 <Meta of={FooterStories} />
@@ -12,7 +12,7 @@ import * as FooterStories from './Footer.stories';
 
 ## Slik bruker du Footer
 
-<Primary />
+<Canvas of={FooterStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/footer/Footer.stories.tsx
+++ b/@udir-design/react/src/components/footer/Footer.stories.tsx
@@ -38,6 +38,9 @@ export const Preview = meta.story({
       </Footer.List>
     </Footer>
   ),
+});
+
+export const PreviewTest = Preview.extend({
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const footer = canvas.getByTestId('footer');

--- a/@udir-design/react/src/components/footer/__snapshots__/Footer.stories.tsx.snap
+++ b/@udir-design/react/src/components/footer/__snapshots__/Footer.stories.tsx.snap
@@ -62,6 +62,68 @@ exports[`Preview 1`] = `
 </div>
 `;
 
+exports[`Preview Test 1`] = `
+<div data-size="auto">
+  <footer style="--udsc-footer-max-width: 80rem;">
+    <div>
+      <ul data-variant="simple">
+        <li>
+          <a href="#">
+            Om tjenesten
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            Kontakt oss
+          </a>
+        </li>
+      </ul>
+      <ul data-variant="simple">
+        <li>
+          <a href="#">
+            Lenke
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            Lenke
+          </a>
+        </li>
+      </ul>
+      <ul data-variant="simple">
+        <li>
+          <a href="#">
+            Personvernerklæring
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            Informasjonskapsler
+          </a>
+        </li>
+        <li>
+          <a href="#">
+            Tilgjengelighetserklæring
+          </a>
+        </li>
+      </ul>
+      <a href="https://udir.no">
+        <div style="--uds-logo-padding: 0;">
+          <img
+            alt="Utdanningsdirektoratet"
+            src="/assets/img/udir-main-logo.svg"
+          >
+          <img
+            alt="Utdanningsdirektoratet"
+            src="/assets/img/udir-main-logo-dark-mode.svg"
+          >
+        </div>
+      </a>
+    </div>
+  </footer>
+</div>
+`;
+
 exports[`Tjeneste 1`] = `
 <div data-size="auto">
   <footer style="--udsc-footer-max-width: 80rem;">

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import { INITIAL_VIEWPORTS } from 'storybook/viewport';
 import * as FormNavigationStories from './FormNavigation.stories';
 import {
@@ -28,7 +28,7 @@ import { Unstyled } from '@storybook/addon-docs/blocks';
 
 - navigere utenfor skjemaer (bruk heller [`Pagination`](/docs/components-pagination--docs))
 
-<Primary />
+<Canvas of={FormNavigationStories.Preview} withToolbar />
 <Controls />
 
 ## Eksempler

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -29,7 +29,7 @@ import { Unstyled } from '@storybook/addon-docs/blocks';
 - navigere utenfor skjemaer (bruk heller [`Pagination`](/docs/components-pagination--docs))
 
 <Canvas of={FormNavigationStories.Preview} withToolbar />
-<Controls />
+<Controls of={FormNavigationStories.Preview} />
 
 ## Eksempler
 

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -23,7 +23,7 @@ Du bygger opp `Header` ved hjelp av subkomponenter og andre komponenter fra desi
 ## Slik bruker du Header
 
 <Canvas of={HeaderStories.Preview} withToolbar />
-<Controls />
+<Controls of={HeaderStories.Preview} />
 
 ```tsx
 import { Header } from '@udir-design/react';

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as HeaderStories from './Header.stories';
 import { Table } from '@udir-design/react/beta';
@@ -22,7 +22,7 @@ Du bygger opp `Header` ved hjelp av subkomponenter og andre komponenter fra desi
 
 ## Slik bruker du Header
 
-<Primary />
+<Canvas of={HeaderStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/input/Input.mdx
+++ b/@udir-design/react/src/components/input/Input.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as InputStories from './Input.stories';
 
 <Meta of={InputStories} />
@@ -19,7 +19,7 @@ Se også [`Textfield`](/docs/components-textfield--docs) som er en gruppering av
 
 ## Slik bruker du Input
 
-<Primary />
+<Canvas of={InputStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/input/Input.mdx
+++ b/@udir-design/react/src/components/input/Input.mdx
@@ -20,7 +20,7 @@ Se også [`Textfield`](/docs/components-textfield--docs) som er en gruppering av
 ## Slik bruker du Input
 
 <Canvas of={InputStories.Preview} withToolbar />
-<Controls />
+<Controls of={InputStories.Preview} />
 
 ```tsx
 import { Input } from '@udir-design/react';

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -22,7 +22,7 @@ Komponenten er basert på [anchor HTML-taggen](https://developer.mozilla.org/en-
 ## Slik bruker du Link
 
 <Canvas of={LinkStories.Preview} withToolbar />
-<Controls />
+<Controls of={LinkStories.Preview} />
 
 ```tsx
 import { Link } from '@udir-design/react';

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as LinkStories from './Link.stories';
 
 <Meta of={LinkStories} />
@@ -21,7 +21,7 @@ Komponenten er basert på [anchor HTML-taggen](https://developer.mozilla.org/en-
 
 ## Slik bruker du Link
 
-<Primary />
+<Canvas of={LinkStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/list/List.mdx
+++ b/@udir-design/react/src/components/list/List.mdx
@@ -21,7 +21,7 @@ Listen kan være både sortert og usortert ved å bruke `List.Ordered` eller `Li
 ## Slik bruker du List
 
 <Canvas of={ListStories.Preview} withToolbar />
-<Controls />
+<Controls of={ListStories.Preview} />
 
 ```tsx
 import { List } from '@udir-design/react';

--- a/@udir-design/react/src/components/list/List.mdx
+++ b/@udir-design/react/src/components/list/List.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Primary,
-  Controls,
-  Canvas,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as ListStories from './List.stories';
 
 <Meta of={ListStories} />
@@ -26,7 +20,7 @@ Listen kan være både sortert og usortert ved å bruke `List.Ordered` eller `Li
 
 ## Slik bruker du List
 
-<Primary />
+<Canvas of={ListStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/logo/Logo.mdx
+++ b/@udir-design/react/src/components/logo/Logo.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Controls,
-  Primary,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as LogoStories from './Logo.stories';
 import * as LogoSymbolStories from './LogoSymbol.stories';
 

--- a/@udir-design/react/src/components/pagination/Pagination.mdx
+++ b/@udir-design/react/src/components/pagination/Pagination.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Controls,
-  Primary,
-  Canvas,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as usePagination from '../../utilities/hooks/usePagination/usePagination.stories';
 import * as PaginationStories from './Pagination.stories';
 
@@ -26,7 +20,7 @@ import * as PaginationStories from './Pagination.stories';
 
 ## Slik bruker du Pagination
 
-<Primary />
+<Canvas of={PaginationStories.Preview} withToolbar />
 <Controls of={PaginationStories.Preview} />
 
 Komponentens tilstand om hvilken side som er aktiv styres programmatisk ved hjelp av `usePagination`.

--- a/@udir-design/react/src/components/popover/Popover.mdx
+++ b/@udir-design/react/src/components/popover/Popover.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as PopoverStories from './Popover.stories';
 
 <Meta of={PopoverStories} />
@@ -20,7 +20,7 @@ import * as PopoverStories from './Popover.stories';
 
 ## Slik bruker du Popover
 
-<Primary />
+<Canvas of={PopoverStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/popover/Popover.mdx
+++ b/@udir-design/react/src/components/popover/Popover.mdx
@@ -21,7 +21,7 @@ import * as PopoverStories from './Popover.stories';
 ## Slik bruker du Popover
 
 <Canvas of={PopoverStories.Preview} withToolbar />
-<Controls />
+<Controls of={PopoverStories.Preview} />
 
 ```tsx
 import { Popover } from '@udir-design/react';

--- a/@udir-design/react/src/components/progressBar/ProgressBar.mdx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Primary,
-  Controls,
-  Canvas,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as ProgressBarStories from './ProgressBar.stories';
 
 <Meta of={ProgressBarStories} />
@@ -23,7 +17,7 @@ import * as ProgressBarStories from './ProgressBar.stories';
 
 ## Slik bruker du ProgressBar
 
-<Primary />
+<Canvas of={ProgressBarStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/progressBar/ProgressBar.mdx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.mdx
@@ -18,7 +18,7 @@ import * as ProgressBarStories from './ProgressBar.stories';
 ## Slik bruker du ProgressBar
 
 <Canvas of={ProgressBarStories.Preview} withToolbar />
-<Controls />
+<Controls of={ProgressBarStories.Preview} />
 
 ```tsx
 import { ProgressBar } from '@udir-design/react';

--- a/@udir-design/react/src/components/radio/Radio.mdx
+++ b/@udir-design/react/src/components/radio/Radio.mdx
@@ -29,7 +29,7 @@ Vi bruker `Radio` (radioknapp) for å gi brukerne valg, der de kan velge mellom 
 ## Slik bruker du Radio
 
 <Canvas of={RadioStories.Preview} withToolbar />
-<Controls />
+<Controls of={RadioStories.Preview} />
 
 ```tsx
 import { Radio } from '@udir-design/react';

--- a/@udir-design/react/src/components/radio/Radio.mdx
+++ b/@udir-design/react/src/components/radio/Radio.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Controls,
-  Primary,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as RadioStories from './Radio.stories';
 import * as useRadioGroupStories from '../../utilities/hooks/useRadioGroup/useRadioGroup.stories';
 import {
@@ -34,7 +28,7 @@ Vi bruker `Radio` (radioknapp) for å gi brukerne valg, der de kan velge mellom 
 
 ## Slik bruker du Radio
 
-<Primary />
+<Canvas of={RadioStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/readMore/ReadMore.mdx
+++ b/@udir-design/react/src/components/readMore/ReadMore.mdx
@@ -21,7 +21,7 @@ import * as ReadMoreStories from './ReadMore.stories';
 ## Slik bruker du ReadMore
 
 <Canvas of={ReadMoreStories.Preview} withToolbar />
-<Controls />
+<Controls of={ReadMoreStories.Preview} />
 
 ## Eksempel
 

--- a/@udir-design/react/src/components/readMore/ReadMore.mdx
+++ b/@udir-design/react/src/components/readMore/ReadMore.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as ReadMoreStories from './ReadMore.stories';
 
@@ -20,7 +20,7 @@ import * as ReadMoreStories from './ReadMore.stories';
 
 ## Slik bruker du ReadMore
 
-<Primary />
+<Canvas of={ReadMoreStories.Preview} withToolbar />
 <Controls />
 
 ## Eksempel

--- a/@udir-design/react/src/components/search/Search.mdx
+++ b/@udir-design/react/src/components/search/Search.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as SearchStories from './Search.stories';
 
 <Meta of={SearchStories} />
@@ -18,7 +18,7 @@ import * as SearchStories from './Search.stories';
 
 ## Slik bruker du Search
 
-<Primary />
+<Canvas of={SearchStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/search/Search.mdx
+++ b/@udir-design/react/src/components/search/Search.mdx
@@ -19,7 +19,7 @@ import * as SearchStories from './Search.stories';
 ## Slik bruker du Search
 
 <Canvas of={SearchStories.Preview} withToolbar />
-<Controls />
+<Controls of={SearchStories.Preview} />
 
 ```tsx
 import { Search } from '@udir-design/react';

--- a/@udir-design/react/src/components/select/Select.mdx
+++ b/@udir-design/react/src/components/select/Select.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as SelectStories from './Select.stories';
 import { DisabledEx, ReadOnlyEx } from './docs/doAndDont';
 
@@ -23,7 +23,7 @@ For eksempel er det ikke mulig å overstyre formateringen av alternativene.
 
 ## Slik bruker du Select
 
-<Primary />
+<Canvas of={SelectStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/select/Select.mdx
+++ b/@udir-design/react/src/components/select/Select.mdx
@@ -24,7 +24,7 @@ For eksempel er det ikke mulig å overstyre formateringen av alternativene.
 ## Slik bruker du Select
 
 <Canvas of={SelectStories.Preview} withToolbar />
-<Controls />
+<Controls of={SelectStories.Preview} />
 
 ```tsx
 import { Select, Field } from '@udir-design/react';

--- a/@udir-design/react/src/components/skeleton/Skeleton.mdx
+++ b/@udir-design/react/src/components/skeleton/Skeleton.mdx
@@ -1,4 +1,4 @@
-import { Meta, Primary, Controls, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import * as SkeletonStories from './Skeleton.stories';
 
 <Meta of={SkeletonStories} />
@@ -19,7 +19,7 @@ import * as SkeletonStories from './Skeleton.stories';
 
 ## Slik bruker du Skeleton
 
-<Primary />
+<Canvas of={SkeletonStories.Preview} withToolbar />
 <Controls />
 
 ## Varianter av Skeleton

--- a/@udir-design/react/src/components/skeleton/Skeleton.mdx
+++ b/@udir-design/react/src/components/skeleton/Skeleton.mdx
@@ -20,7 +20,7 @@ import * as SkeletonStories from './Skeleton.stories';
 ## Slik bruker du Skeleton
 
 <Canvas of={SkeletonStories.Preview} withToolbar />
-<Controls />
+<Controls of={SkeletonStories.Preview} />
 
 ## Varianter av Skeleton
 

--- a/@udir-design/react/src/components/skipLink/SkipLink.mdx
+++ b/@udir-design/react/src/components/skipLink/SkipLink.mdx
@@ -1,4 +1,4 @@
-import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as SkipLinkStories from './SkipLink.stories';
 
 <Meta of={SkipLinkStories} />
@@ -13,7 +13,7 @@ Vi bruker snarvei-komponenten `SkipLink` for å la folk som bruker tastaturet ti
 
 ## Slik bruker du SkipLink
 
-<Primary />
+<Canvas of={SkipLinkStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/skipLink/SkipLink.mdx
+++ b/@udir-design/react/src/components/skipLink/SkipLink.mdx
@@ -14,7 +14,7 @@ Vi bruker snarvei-komponenten `SkipLink` for å la folk som bruker tastaturet ti
 ## Slik bruker du SkipLink
 
 <Canvas of={SkipLinkStories.Preview} withToolbar />
-<Controls />
+<Controls of={SkipLinkStories.Preview} />
 
 ```tsx
 import { SkipLink } from '@udir-design/react';

--- a/@udir-design/react/src/components/spinner/Spinner.mdx
+++ b/@udir-design/react/src/components/spinner/Spinner.mdx
@@ -21,7 +21,7 @@ import * as SpinnerStories from './Spinner.stories';
 ## Slik bruker du Spinner
 
 <Canvas of={SpinnerStories.Preview} withToolbar />
-<Controls />
+<Controls of={SpinnerStories.Preview} />
 
 ## Størrelser
 

--- a/@udir-design/react/src/components/spinner/Spinner.mdx
+++ b/@udir-design/react/src/components/spinner/Spinner.mdx
@@ -1,4 +1,4 @@
-import { Meta, Primary, Controls, Canvas } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import * as SpinnerStories from './Spinner.stories';
 
 <Meta of={SpinnerStories} />
@@ -20,7 +20,7 @@ import * as SpinnerStories from './Spinner.stories';
 
 ## Slik bruker du Spinner
 
-<Primary />
+<Canvas of={SpinnerStories.Preview} withToolbar />
 <Controls />
 
 ## Størrelser

--- a/@udir-design/react/src/components/suggestion/Suggestion.mdx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Controls,
-  Primary,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as SuggestionStories from './Suggestion.stories';
 import { SuggestionList } from './Suggestion';
 import { Alert } from '@udir-design/react/alpha';
@@ -20,7 +14,7 @@ import { Alert } from '@udir-design/react/alpha';
 
 Søkbar "select" med mulighet for flervalg/multiselect. Bruk dersom `Select` ikke er tilstrekkelig.
 
-<Primary />
+<Canvas of={SuggestionStories.Preview} withToolbar />
 <Controls />
 
 ## Bruk

--- a/@udir-design/react/src/components/suggestion/Suggestion.mdx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.mdx
@@ -15,7 +15,7 @@ import { Alert } from '@udir-design/react/alpha';
 Søkbar "select" med mulighet for flervalg/multiselect. Bruk dersom `Select` ikke er tilstrekkelig.
 
 <Canvas of={SuggestionStories.Preview} withToolbar />
-<Controls />
+<Controls of={SuggestionStories.Preview} />
 
 ## Bruk
 

--- a/@udir-design/react/src/components/switch/Switch.mdx
+++ b/@udir-design/react/src/components/switch/Switch.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as SwitchStories from './Switch.stories';
 import {
   SwitchExLabel,
@@ -27,7 +27,7 @@ Vi bruker `Switch` til å gi brukerne et valg mellom to alternativer. Bryteren k
 
 ## Slik bruker du Switch
 
-<Primary />
+<Canvas of={SwitchStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/switch/Switch.mdx
+++ b/@udir-design/react/src/components/switch/Switch.mdx
@@ -28,7 +28,7 @@ Vi bruker `Switch` til å gi brukerne et valg mellom to alternativer. Bryteren k
 ## Slik bruker du Switch
 
 <Canvas of={SwitchStories.Preview} withToolbar />
-<Controls />
+<Controls of={SwitchStories.Preview} />
 
 ```tsx
 import { Switch } from '@udir-design/react';

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Primary,
-  Controls,
-  Canvas,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 
 import * as TableStories from './Table.stories';
 
@@ -30,7 +24,7 @@ Tabeller gjør det enklere for brukerne å skanne og sammenligne informasjon.
 
 ## Slik bruker du Table
 
-<Primary />
+<Canvas of={TableStories.Preview} withToolbar />
 <Controls />
 
 ```jsx

--- a/@udir-design/react/src/components/table/Table.mdx
+++ b/@udir-design/react/src/components/table/Table.mdx
@@ -25,7 +25,7 @@ Tabeller gjør det enklere for brukerne å skanne og sammenligne informasjon.
 ## Slik bruker du Table
 
 <Canvas of={TableStories.Preview} withToolbar />
-<Controls />
+<Controls of={TableStories.Preview} />
 
 ```jsx
 import { Table } from '@udir-design/react';

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
@@ -19,7 +19,7 @@ import * as TableOfContentStories from './TableOfContents.stories';
 ## Slik bruker du Table Of Contents
 
 <Canvas of={TableOfContentStories.Preview} withToolbar />
-<Controls />
+<Controls of={TableOfContentStories.Preview} />
 
 ```jsx
 import { TableOfContents, useTableOfContents } from '@udir-design/react';

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Primary,
-  Controls,
-  Canvas,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as TableOfContentStories from './TableOfContents.stories';
 
 <Meta of={TableOfContentStories} />
@@ -24,7 +18,7 @@ import * as TableOfContentStories from './TableOfContents.stories';
 
 ## Slik bruker du Table Of Contents
 
-<Primary />
+<Canvas of={TableOfContentStories.Preview} withToolbar />
 <Controls />
 
 ```jsx

--- a/@udir-design/react/src/components/tabs/Tabs.mdx
+++ b/@udir-design/react/src/components/tabs/Tabs.mdx
@@ -26,7 +26,7 @@ Vær oppmerksom på at alle `Tabs.Panel` lastes inn når komponenten vises. Du k
 ## Slik bruker du Tabs
 
 <Canvas of={TabsStories.Preview} withToolbar />
-<Controls />
+<Controls of={TabsStories.Preview} />
 
 ```tsx
 import { Tabs } from '@udir-design/react';

--- a/@udir-design/react/src/components/tabs/Tabs.mdx
+++ b/@udir-design/react/src/components/tabs/Tabs.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Canvas,
-  Controls,
-  Primary,
-  ArgTypes,
-} from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import { Tabs, TabsTab, TabsPanel } from './Tabs';
 import * as TabsStories from './Tabs.stories';
 
@@ -31,7 +25,7 @@ Vær oppmerksom på at alle `Tabs.Panel` lastes inn når komponenten vises. Du k
 
 ## Slik bruker du Tabs
 
-<Primary />
+<Canvas of={TabsStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/tag/Tag.mdx
+++ b/@udir-design/react/src/components/tag/Tag.mdx
@@ -21,7 +21,7 @@ En `Tag` er en merkelapp som kan brukes til å kategorisere elementer eller komm
 ## Slik bruker du Tag
 
 <Canvas of={TagStories.Preview} withToolbar />
-<Controls />
+<Controls of={TagStories.Preview} />
 
 ```tsx
 import { Tag } from '@udir-design/react';

--- a/@udir-design/react/src/components/tag/Tag.mdx
+++ b/@udir-design/react/src/components/tag/Tag.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as TagStories from './Tag.stories';
 
 <Meta of={TagStories} />
@@ -20,7 +20,7 @@ En `Tag` er en merkelapp som kan brukes til å kategorisere elementer eller komm
 
 ## Slik bruker du Tag
 
-<Primary />
+<Canvas of={TagStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/textarea/Textarea.mdx
+++ b/@udir-design/react/src/components/textarea/Textarea.mdx
@@ -25,7 +25,7 @@ Se også [`Textfield`](/docs/components-textfield--docs) som er en gruppering av
 ## Slik bruker du Textarea
 
 <Canvas of={TextareaStories.Preview} withToolbar />
-<Controls />
+<Controls of={TextareaStories.Preview} />
 
 `Textarea` kan også ta inn flere vanlige `<input>` attributter slik som `aria-label`.
 

--- a/@udir-design/react/src/components/textarea/Textarea.mdx
+++ b/@udir-design/react/src/components/textarea/Textarea.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 
 import * as TextareaStories from './Textarea.stories';
 
@@ -24,7 +24,7 @@ Se også [`Textfield`](/docs/components-textfield--docs) som er en gruppering av
 
 ## Slik bruker du Textarea
 
-<Primary />
+<Canvas of={TextareaStories.Preview} withToolbar />
 <Controls />
 
 `Textarea` kan også ta inn flere vanlige `<input>` attributter slik som `aria-label`.

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as TextfieldStories from './Textfield.stories';
 import { DisabledEx, ReadOnlyEx } from './docs/doAndDont';
 
@@ -19,7 +19,7 @@ Den har innebygget `label`, `description`, `validationmessage`, `affix` og `coun
 
 ## Slik bruker du Textfield
 
-<Primary />
+<Canvas of={TextfieldStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -20,7 +20,7 @@ Den har innebygget `label`, `description`, `validationmessage`, `affix` og `coun
 ## Slik bruker du Textfield
 
 <Canvas of={TextfieldStories.Preview} withToolbar />
-<Controls />
+<Controls of={TextfieldStories.Preview} />
 
 ```tsx
 import { Textfield } from '@udir-design/react';

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
@@ -21,7 +21,7 @@ Med `ToggleGroup` kan brukerne velge alternativer som påvirker innholdet på en
 ## Slik bruker du ToggleGroup
 
 <Canvas of={ToggleGroupStories.Preview} withToolbar />
-<Controls />
+<Controls of={ToggleGroupStories.Preview} />
 
 Plasser helst innholdet du skal styre rett etter `ToggleGroup` i DOM-en. Hvis ikke, bør du bruke `aria-controls` på `ToggleGroup` for å knytte komponenten til den containeren for innholdet som endrer seg.
 

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as ToggleGroupStories from './ToggleGroup.stories';
 
 <Meta of={ToggleGroupStories} />
@@ -20,7 +20,7 @@ Med `ToggleGroup` kan brukerne velge alternativer som påvirker innholdet på en
 
 ## Slik bruker du ToggleGroup
 
-<Primary />
+<Canvas of={ToggleGroupStories.Preview} withToolbar />
 <Controls />
 
 Plasser helst innholdet du skal styre rett etter `ToggleGroup` i DOM-en. Hvis ikke, bør du bruke `aria-controls` på `ToggleGroup` for å knytte komponenten til den containeren for innholdet som endrer seg.

--- a/@udir-design/react/src/components/tooltip/Tooltip.mdx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.mdx
@@ -23,7 +23,7 @@ import * as TooltipStories from './Tooltip.stories.tsx';
 ## Slik bruker du Tooltip
 
 <Canvas of={TooltipStories.Preview} withToolbar />
-<Controls />
+<Controls of={TooltipStories.Preview} />
 
 ```tsx
 import { Tooltip } from '@udir-design/react';

--- a/@udir-design/react/src/components/tooltip/Tooltip.mdx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as TooltipStories from './Tooltip.stories.tsx';
 
 <Meta of={TooltipStories} />
@@ -22,7 +22,7 @@ import * as TooltipStories from './Tooltip.stories.tsx';
 
 ## Slik bruker du Tooltip
 
-<Primary />
+<Canvas of={TooltipStories.Preview} withToolbar />
 <Controls />
 
 ```tsx

--- a/@udir-design/react/src/icons/Ikoner.mdx
+++ b/@udir-design/react/src/icons/Ikoner.mdx
@@ -2,7 +2,6 @@ import {
   Meta,
   Canvas,
   Controls,
-  Primary,
   IconGallery,
   ArgTypes,
 } from '@storybook/addon-docs/blocks';

--- a/@udir-design/react/src/icons/Retningslinjer.mdx
+++ b/@udir-design/react/src/icons/Retningslinjer.mdx
@@ -2,7 +2,6 @@ import {
   Meta,
   Canvas,
   Controls,
-  Primary,
   IconGallery,
   ArgTypes,
 } from '@storybook/addon-docs/blocks';

--- a/@udir-design/react/src/symbols/Symboler.mdx
+++ b/@udir-design/react/src/symbols/Symboler.mdx
@@ -2,7 +2,6 @@ import {
   Meta,
   Canvas,
   Controls,
-  Primary,
   IconGallery,
   ArgTypes,
 } from '@storybook/addon-docs/blocks';

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.mdx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.mdx
@@ -11,7 +11,7 @@ import { useCheckboxGroup } from './useCheckboxGroup';
 En React-hook for å koble sammen en gruppe av avmerkingsbokser.
 
 <Canvas of={Stories.Default} withToolbar />
-<Controls />
+<Controls of={Stories.Default} />
 
 I respons får du objektet:
 

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.mdx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.mdx
@@ -1,9 +1,4 @@
-import {
-  Meta,
-  Primary,
-  ArgTypes,
-  Controls,
-} from '@storybook/addon-docs/blocks';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/addon-docs/blocks';
 
 import { SimpleAlert } from '.storybook/docs/components';
 import * as Stories from './useCheckboxGroup.stories';
@@ -15,7 +10,7 @@ import { useCheckboxGroup } from './useCheckboxGroup';
 
 En React-hook for å koble sammen en gruppe av avmerkingsbokser.
 
-<Primary />
+<Canvas of={Stories.Default} withToolbar />
 <Controls />
 
 I respons får du objektet:

--- a/@udir-design/react/src/utilities/hooks/useFormNavigation/useFormNavigation.mdx
+++ b/@udir-design/react/src/utilities/hooks/useFormNavigation/useFormNavigation.mdx
@@ -1,9 +1,4 @@
-import {
-  Meta,
-  Primary,
-  ArgTypes,
-  Controls,
-} from '@storybook/addon-docs/blocks';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/addon-docs/blocks';
 
 import * as Stories from './useFormNavigation.stories';
 import { useFormNavigation } from './useFormNavigation';
@@ -14,7 +9,7 @@ import { useFormNavigation } from './useFormNavigation';
 
 En React-hook for å håndtere navigasjon i [`FormNavigation`](/docs/components-formnavigation--docs).
 
-<Primary />
+<Canvas of={Stories.Preview} withToolbar />
 <Controls of={Stories.Preview} />
 
 I respons får du objektet:

--- a/@udir-design/react/src/utilities/hooks/usePagination/usePagination.mdx
+++ b/@udir-design/react/src/utilities/hooks/usePagination/usePagination.mdx
@@ -10,7 +10,7 @@ import { usePagination } from './usePagination';
 En React-hook for å håndtere paginering.
 
 <Canvas of={Stories.Preview} withToolbar />
-<Controls />
+<Controls of={Stories.Preview} />
 
 I respons får du objektet:
 

--- a/@udir-design/react/src/utilities/hooks/usePagination/usePagination.mdx
+++ b/@udir-design/react/src/utilities/hooks/usePagination/usePagination.mdx
@@ -1,9 +1,4 @@
-import {
-  Meta,
-  Primary,
-  ArgTypes,
-  Controls,
-} from '@storybook/addon-docs/blocks';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/addon-docs/blocks';
 
 import * as Stories from './usePagination.stories';
 import { usePagination } from './usePagination';
@@ -14,7 +9,7 @@ import { usePagination } from './usePagination';
 
 En React-hook for å håndtere paginering.
 
-<Primary />
+<Canvas of={Stories.Preview} withToolbar />
 <Controls />
 
 I respons får du objektet:

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.mdx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.mdx
@@ -1,9 +1,4 @@
-import {
-  Meta,
-  Primary,
-  ArgTypes,
-  Controls,
-} from '@storybook/addon-docs/blocks';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/addon-docs/blocks';
 
 import { SimpleAlert } from '.storybook/docs/components';
 import * as Stories from './useRadioGroup.stories';
@@ -15,7 +10,7 @@ import { useRadioGroup } from './useRadioGroup';
 
 En React-hook for å koble sammen en gruppe av radioknapper.
 
-<Primary />
+<Canvas of={Stories.Preview} withToolbar />
 <Controls />
 
 ## Bruk

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.mdx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.mdx
@@ -11,7 +11,7 @@ import { useRadioGroup } from './useRadioGroup';
 En React-hook for å koble sammen en gruppe av radioknapper.
 
 <Canvas of={Stories.Preview} withToolbar />
-<Controls />
+<Controls of={Stories.Preview} />
 
 ## Bruk
 

--- a/@udir-design/react/src/utilities/hooks/useTableOfContents/useTableOfContents.mdx
+++ b/@udir-design/react/src/utilities/hooks/useTableOfContents/useTableOfContents.mdx
@@ -1,10 +1,4 @@
-import {
-  Meta,
-  Primary,
-  ArgTypes,
-  Controls,
-  Canvas,
-} from '@storybook/addon-docs/blocks';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as Stories from './useTableOfContents.stories';
 import { useTableOfContents } from './useTableOfContents';
 


### PR DESCRIPTION
## Hva er gjort?

Fiksa at `<Primary />` og `<Controls />` slutta å funke i .mdx-filer etter at vi fjerna tag `autodocs` frå preview.ts. Erstatta det med
```tsx
<Canvas of={<første story>} withToolbar />
<Controls of={<første story>} />
```

Gikk gjennom alle sidene og sjekka at det funker igjen no. Såg i den samanheng at Footer blei scrolla til bunn av sida pga test (tab-navigering i `play()`) så eg fiksa det også.


## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog