### PR TITLE
Fix/header long names

### DIFF
--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -45,17 +45,6 @@ Subkomponenter:
 - `Header.Menu` med `Header.Menu.Link`
 - `Header.ThemeMenuButton`
 
-### Lange tjenestenavn
-
-Hvis tjenesten har et langt navn, bruker du `&shy;` (soft hyphen) for å indikere hvor navnet kan deles opp i flere linjer. Det gjør at navnet kan brytes på en pen måte på mindre skjermer, samtidig som det vises i sin helhet på større skjermer.
-
-I eksempelet under setter vi `applicationName="Foreldre&shy;undersøkelsen i barnehage"`. Da brytes navnet etter "Foreldre" og "undersøkelsen" dersom det ikke er nok plass til å vise hele navnet på én linje. For å sørge for at det er nok plass i headeren, setter vi `--udsc-header-height` til en høyere verdi når navnet brekker på tre linjer. Se kodesnutten for å se hvordan dette gjøres.
-
-<Canvas
-  story={{ inline: false, height: '90px' }}
-  of={HeaderStories.LongApplicationName}
-/>
-
 ### Brukerprofil
 
 Subkomponenten `Header.UserButton` viser brukerinformasjon og kan knyttes til en meny med brukerrelaterte handlinger. Den har props for navn, beskrivelse og avatar og finnes i fargene `neutral` og `accent`. I eksempelet brukes [`Dropdown`](/docs/components-dropdown--docs) som brukermeny.
@@ -129,11 +118,24 @@ Navigasjonslenker og meny er de eneste navigasjonselementene som kan kombineres 
   of={HeaderStories.WithNavigationLinksAndMenu}
 />
 
+### Lange tjenestenavn
+
+Hvis tjenesten har et langt navn, bruker du `&shy;` (soft hyphen) for å indikere hvor navnet kan deles opp i flere linjer. Det gjør at navnet kan brytes på en pen måte på mindre skjermer, samtidig som det vises i sin helhet på større skjermer.
+
+I eksempelet under setter vi `applicationName="Foreldre&shy;undersøkelsen i barnehage"`. Da brytes navnet etter "Foreldre" og "undersøkelsen" dersom det ikke er nok plass til å vise hele navnet på én linje. Vi setter også ned font-size på tjenestenavnet og fjerner "Meny"-teksten på menyknappen når skjermen blir smalere. Ta en titt på kodesnutten for å se hvordan dette kan gjøres.
+
+Er navnet så langt at det må brekke på tre linjer, kan det være nødvendig å justere høyden på `Header` ved å sette `--udsc-header-height` til en høyere verdi.
+
+<Canvas
+  story={{ inline: false, height: '90px' }}
+  of={HeaderStories.LongApplicationName}
+/>
+
 ### Utviklingsmiljø
 
 Bruk `Tag` til å indikere at en tjeneste vises i et annet kjøretidsmiljø enn produksjon, f.eks. dev, test eller qa. Den skal alltid ligge som første element og vil da automatisk legges til venstre, inntil logo.
 
-<Canvas story={{ inline: false, height: '150px' }} of={HeaderStories.WithTag} />
+<Canvas story={{ inline: false, height: '90px' }} of={HeaderStories.WithTag} />
 
 ### Språkvelger
 

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -45,6 +45,17 @@ Subkomponenter:
 - `Header.Menu` med `Header.Menu.Link`
 - `Header.ThemeMenuButton`
 
+### Lange tjenestenavn
+
+Hvis tjenesten har et langt navn, bruker du `&shy;` (soft hyphen) for å indikere hvor navnet kan deles opp i flere linjer. Det gjør at navnet kan brytes på en pen måte på mindre skjermer, samtidig som det vises i sin helhet på større skjermer.
+
+I eksempelet under setter vi `applicationName="Foreldre&shy;undersøkelsen i barnehage"`. Da brytes navnet etter "Foreldre" og "undersøkelsen" dersom det ikke er nok plass til å vise hele navnet på én linje.
+
+<Canvas
+  story={{ inline: false, height: '90px' }}
+  of={HeaderStories.LongApplicationName}
+/>
+
 ### Brukerprofil
 
 Subkomponenten `Header.UserButton` viser brukerinformasjon og kan knyttes til en meny med brukerrelaterte handlinger. Den har props for navn, beskrivelse og avatar og finnes i fargene `neutral` og `accent`. I eksempelet brukes [`Dropdown`](/docs/components-dropdown--docs) som brukermeny.

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -49,7 +49,7 @@ Subkomponenter:
 
 Hvis tjenesten har et langt navn, bruker du `&shy;` (soft hyphen) for å indikere hvor navnet kan deles opp i flere linjer. Det gjør at navnet kan brytes på en pen måte på mindre skjermer, samtidig som det vises i sin helhet på større skjermer.
 
-I eksempelet under setter vi `applicationName="Foreldre&shy;undersøkelsen i barnehage"`. Da brytes navnet etter "Foreldre" og "undersøkelsen" dersom det ikke er nok plass til å vise hele navnet på én linje.
+I eksempelet under setter vi `applicationName="Foreldre&shy;undersøkelsen i barnehage"`. Da brytes navnet etter "Foreldre" og "undersøkelsen" dersom det ikke er nok plass til å vise hele navnet på én linje. For å sørge for at det er nok plass i headeren, setter vi `--udsc-header-height` til en høyere verdi når navnet brekker på tre linjer. Se kodesnutten for å se hvordan dette gjøres.
 
 <Canvas
   story={{ inline: false, height: '90px' }}

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -120,16 +120,36 @@ Navigasjonslenker og meny er de eneste navigasjonselementene som kan kombineres 
 
 ### Lange tjenestenavn
 
-Hvis tjenesten har et langt navn, bruker du `&shy;` (soft hyphen) for å indikere hvor navnet kan deles opp i flere linjer. Det gjør at navnet kan brytes på en pen måte på mindre skjermer, samtidig som det vises i sin helhet på større skjermer.
+Hvis tjenesten har et langt navn, bruker du "soft hyphen" for å indikere hvor navnet kan deles opp i flere linjer. Det gjør at navnet kan brytes på en pen måte på mindre skjermer, samtidig som det vises i sin helhet på større skjermer.
+
+Soft hyphen settes inn med HTML entity `&shy;` eller unicode-sekvens `\u00AD` avhengig av kontekst.
+
+```tsx
+// Når verdien settes direkte som komponent-property
+<Header applicationName="Foreldre&shy;undersøkelsen i barnehage" />
+
+// Når verdien først settes som en variabel
+const appName = "Foreldre\u00ADundersøkelsen i barnehage"
+// ...
+<Header applicationName={appName} />
+```
 
 I eksempelet under setter vi `applicationName="Foreldre&shy;undersøkelsen i barnehage"`. Da brytes navnet etter "Foreldre" og "undersøkelsen" dersom det ikke er nok plass til å vise hele navnet på én linje. Vi setter også ned font-size på tjenestenavnet og fjerner "Meny"-teksten på menyknappen når skjermen blir smalere. Ta en titt på kodesnutten for å se hvordan dette kan gjøres.
-
-Er navnet så langt at det må brekke på tre linjer, kan det være nødvendig å justere høyden på `Header` ved å sette `--udsc-header-height` til en høyere verdi.
 
 <Canvas
   story={{ inline: false, height: '90px' }}
   of={HeaderStories.LongApplicationName}
 />
+
+Er navnet så langt at det må brekke på tre linjer, kan det være nødvendig å justere høyden på `Header` ved å sette `--udsc-header-height` til en høyere verdi:
+
+```css
+@media (max-width: <største bredde der navn går over tre linjer>) {
+  .uds-header {
+    --udsc-header-height: var(--ds-size-26);
+  }
+}
+```
 
 ### Utviklingsmiljø
 

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -51,26 +51,6 @@ export const Preview = meta.story({
   },
 });
 
-export const LongApplicationName = meta.story({
-  args: {
-    applicationName: 'Foreldre\u00ADundersøkelsen i barnehage',
-  },
-  render: (args) => (
-    <>
-      <style>
-        {`
-        /* Styles defined in application-specific css */
-        @media (max-width: 22.74rem) {
-        .uds-header {
-          --udsc-header-height: var(--ds-size-25);
-        }
-      }`}
-      </style>
-      <Header {...args} />
-    </>
-  ),
-});
-
 const profileImage =
   'https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
 
@@ -613,18 +593,44 @@ export const WithNavigationLinksAndMenu = meta.story({
   ),
 });
 
-const responsiveLinks = ['Navlinker', 'Overskrift 1', 'Overskrift 2'].map(
-  (heading, index) => ({
-    heading,
-    links: Array.from(
-      { length: index === 1 ? 5 : index === 2 ? 4 : 3 },
-      (_, i) => ({
-        title: heading === 'Navlinker' ? `Navlink ${i + 1}` : `Link ${i + 1}`,
-        href: '',
-      }),
-    ),
-  }),
-);
+export const LongApplicationName = meta.story({
+  args: {
+    applicationName: 'Foreldre\u00ADundersøkelsen i barnehage',
+  },
+  render: (args) => {
+    const menuButtonRef = useRef<HTMLButtonElement>(null);
+    return (
+      <>
+        <style>
+          {`
+        /* Styles defined in application-specific css */
+        @media (max-width: 30rem) {
+        .uds-header__logo > :last-child {
+          font-size: var(--ds-font-size-4);
+        }
+        @media (max-width: 23rem) {
+          .myMenuText {
+            // Visually hidden but accessible for screen readers
+            border: 0;
+            clip: rect(0 0 0 0);
+            height: 1px;
+            overflow: hidden;
+            padding: 0;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }`}
+        </style>
+        <Header {...args}>
+          <Header.MenuButton ref={menuButtonRef}>
+            <span className="myMenuText">Meny</span>
+          </Header.MenuButton>
+          <Header.Menu>{/* Menyinnhold her*/}</Header.Menu>
+        </Header>
+      </>
+    );
+  },
+});
 
 export const WithTag = meta.story({
   render(args) {
@@ -713,6 +719,19 @@ export const WithTwoLanguages = meta.story({
     );
   },
 });
+
+const responsiveLinks = ['Navlinker', 'Overskrift 1', 'Overskrift 2'].map(
+  (heading, index) => ({
+    heading,
+    links: Array.from(
+      { length: index === 1 ? 5 : index === 2 ? 4 : 3 },
+      (_, i) => ({
+        title: heading === 'Navlinker' ? `Navlink ${i + 1}` : `Link ${i + 1}`,
+        href: '',
+      }),
+    ),
+  }),
+);
 
 export const Responsive = meta.story({
   render(args) {

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -55,7 +55,20 @@ export const LongApplicationName = meta.story({
   args: {
     applicationName: 'Foreldre\u00ADundersøkelsen i barnehage',
   },
-  render: Preview.input.render,
+  render: (args) => (
+    <>
+      <style>
+        {`
+        /* Styles defined in application-specific css */
+        @media (max-width: 22.74rem) {
+        .uds-header {
+          --udsc-header-height: var(--ds-size-25);
+        }
+      }`}
+      </style>
+      <Header {...args} />
+    </>
+  ),
 });
 
 const profileImage =

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -51,6 +51,13 @@ export const Preview = meta.story({
   },
 });
 
+export const LongApplicationName = meta.story({
+  args: {
+    applicationName: 'Foreldre\u00ADundersøkelsen i barnehage',
+  },
+  render: Preview.input.render,
+});
+
 const profileImage =
   'https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&w=1480&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D';
 

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -594,11 +594,8 @@ export const WithNavigationLinksAndMenu = meta.story({
 });
 
 export const LongApplicationName = meta.story({
-  args: {
-    applicationName: 'Foreldre\u00ADundersøkelsen i barnehage',
-  },
-  render: (args) => {
-    const menuButtonRef = useRef<HTMLButtonElement>(null);
+  parameters: { docs: advancedCodeDocs },
+  render: () => {
     return (
       <>
         <style>
@@ -621,8 +618,8 @@ export const LongApplicationName = meta.story({
             width: 1px;
           }`}
         </style>
-        <Header {...args}>
-          <Header.MenuButton ref={menuButtonRef}>
+        <Header applicationName="Foreldre&shy;undersøkelsen i barnehage">
+          <Header.MenuButton>
             <span className="myMenuText">Meny</span>
           </Header.MenuButton>
           <Header.Menu>{/* Menyinnhold her*/}</Header.Menu>

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -944,6 +944,34 @@ exports[`Auto Hide Sticky Test 1`] = `
 </div>
 `;
 
+exports[`Long Application Name 1`] = `
+<div data-size="auto">
+  <header
+    data-scroll-direction="up"
+    data-top="true"
+    style="--udsc-header-max-width: 80rem;"
+  >
+    <div>
+      <a href="/">
+        <div style="--uds-logo-padding: 0;">
+          <img
+            alt="Utdanningsdirektoratet"
+            src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-3&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-2&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+          >
+          <img
+            alt="Utdanningsdirektoratet"
+            src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-2&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-3&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+          >
+        </div>
+        <span data-size="xs">
+          Foreldre­undersøkelsen i barnehage
+        </span>
+      </a>
+    </div>
+  </header>
+</div>
+`;
+
 exports[`Preview 1`] = `
 <div data-size="auto">
   <header style="--udsc-header-max-width: 80rem;">

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -946,6 +946,14 @@ exports[`Auto Hide Sticky Test 1`] = `
 
 exports[`Long Application Name 1`] = `
 <div data-size="auto">
+  <style>
+    /* Styles defined in application-specific css */
+        @media (max-width: 22.74rem) {
+        .uds-header {
+          --udsc-header-height: var(--ds-size-25);
+        }
+      }
+  </style>
   <header
     data-scroll-direction="up"
     data-top="true"

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -948,11 +948,22 @@ exports[`Long Application Name 1`] = `
 <div data-size="auto">
   <style>
     /* Styles defined in application-specific css */
-        @media (max-width: 22.74rem) {
-        .uds-header {
-          --udsc-header-height: var(--ds-size-25);
+        @media (max-width: 30rem) {
+        .uds-header__logo > :last-child {
+          font-size: var(--ds-font-size-4);
         }
-      }
+        @media (max-width: 23rem) {
+          .myMenuText {
+            // Visually hidden but accessible for screen readers
+            border: 0;
+            clip: rect(0 0 0 0);
+            height: 1px;
+            overflow: hidden;
+            padding: 0;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+          }
   </style>
   <header
     data-scroll-direction="up"
@@ -975,6 +986,57 @@ exports[`Long Application Name 1`] = `
           Foreldre­undersøkelsen i barnehage
         </span>
       </a>
+      <div>
+        <button
+          data-variant="tertiary"
+          type="button"
+          popovertarget="uds-header-menu"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
+            >
+            </path>
+          </svg>
+          <span>
+            Meny
+          </span>
+        </button>
+        <div
+          id="uds-header-menu"
+          popover="auto"
+          data-variant="default"
+        >
+        </div>
+      </div>
     </div>
   </header>
 </div>

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -110,7 +110,13 @@
     position: fixed;
     width: 100%;
     border: none;
-    inset-block-start: calc(var(--udsc-header-padding) - var(--ds-size-3));
+    /* Position menu at the bottom edge of the header content.
+    paddingY = (headerHeight - headerContentHeight) / 2
+    Round down to whole px to avoid subpixel jitter, then offset by trigger size. */
+    inset-block-start: calc(
+      round(down, (var(--udsc-header-height) - var(--ds-size-12)) / 2, 1px) -
+        var(--ds-size-3)
+    );
     max-height: 0;
     overflow: hidden;
     background-color: var(--ds-color-background-default);

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -1,10 +1,12 @@
 .uds-header {
-  --udsc-header-height: var(--ds-size-12);
+  --udsc-header-height: var(--ds-size-22);
   --udsc-header-padding: var(--ds-size-5);
   @media (max-width: 30rem) {
+    --udsc-header-height: calc(var(--ds-size-22) - var(--ds-size-2));
     --udsc-header-padding: var(--ds-size-4);
   }
 
+  box-sizing: border-box;
   height: var(--udsc-header-height);
   padding: var(--udsc-header-padding);
   background-color: var(--ds-color-background-default);

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -16,7 +16,7 @@
   > div {
     display: flex;
     height: 100%;
-    gap: var(--ds-size-8);
+    gap: var(--ds-size-4);
     align-content: center;
     justify-content: space-between;
     max-width: var(--udsc-header-max-width, 80rem);
@@ -33,6 +33,8 @@
     gap: var(--ds-size-3);
     text-decoration: none;
     color: var(--dsc-link-color);
+    text-wrap: pretty;
+    overflow-wrap: break-word;
 
     @composes ds-focus from '@digdir/designsystemet-css/base.css';
   }
@@ -41,7 +43,7 @@
     display: flex;
     gap: var(--ds-size-8);
     align-items: center;
-    width: 100%;
+    flex-grow: 1;
     justify-content: flex-end;
 
     > .ds-tag {

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -146,9 +146,7 @@
     animation: 1.3s delay-overflow;
 
     &:popover-open {
-      max-height: calc(
-        95% - (var(--udsc-header-height) + (var(--udsc-header-padding) * 2))
-      );
+      max-height: calc(95% - (var(--udsc-header-height)));
       overflow: auto;
       display: block;
       @starting-style {
@@ -278,9 +276,7 @@
       box-shadow 200ms ease;
   }
   &[data-scroll-direction='down']:not(:has([popover]:popover-open)) {
-    transform: translateY(
-      calc(-1 * var(--udsc-header-height) - (var(--udsc-header-padding) * 2))
-    );
+    transform: translateY(calc(-1 * var(--udsc-header-height)));
     box-shadow: none;
   }
   &[data-scroll-direction='up'] {


### PR DESCRIPTION
## Hva er gjort?

- Restore vertical spacing when using border-box
- Improve wrapping for long application names

Usikker på om vi skal sette høyden på header som vi gjør nå, eller sette den til auto. Problemet med auto er at headerMenu bruker `--udsc-header-height`. Hvis header ikke følger den variabelen, så har det ikke noe for seg lengre... 

> I den gjeldende løsningen har header samme høyde hele tiden. Da får vi ikke margin til lange titler. Er det et problem?

Edit: Har fikset dette, men systemteamene må endre høyden med media queries
 