### PR TITLE
fix: fileUpload forwardRef and readonly variant

### DIFF
--- a/@udir-design/css/src/icons.css
+++ b/@udir-design/css/src/icons.css
@@ -1,5 +1,6 @@
 @import '../node_modules/@udir-design/icons/dist/css/circle.css';
 @import '../node_modules/@udir-design/icons/dist/css/circleFill.css';
+@import '../node_modules/@udir-design/icons/dist/css/circleSlash.css';
 @import '../node_modules/@udir-design/icons/dist/css/chevronDown.css';
 @import '../node_modules/@udir-design/icons/dist/css/chevronUp.css';
 @import '../node_modules/@udir-design/icons/dist/css/clipboard.css';

--- a/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
@@ -60,9 +60,11 @@ export const DocumentationPage = ({
         description="Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB."
         {...getRootProps()}
         error={errors.documentation?.message}
-        inputProps={getInputProps({ required: true })}
+        inputProps={getInputProps({
+          required: true,
+          readOnly: isSubmitSuccessful,
+        })}
         aria-invalid={!!errors.documentation}
-        readOnly={isSubmitSuccessful}
       />
       {uploadedFiles.length > 0 && (
         <>

--- a/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
@@ -55,15 +55,17 @@ export const DocumentationPage = ({
       </Heading>
       <FieldNecessity.Summary />
       <FileUpload.Dropzone
-        id="dokumentasjon-dropzone"
         label={<span>Last opp dokumentasjon</span>}
         description="Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB."
         {...getRootProps()}
         error={errors.documentation?.message}
-        inputProps={getInputProps({
-          required: true,
-          readOnly: isSubmitSuccessful,
-        })}
+        inputProps={{
+          ...getInputProps({
+            required: true,
+            readOnly: isSubmitSuccessful,
+          }),
+          id: 'dokumentasjon-dropzone',
+        }}
         aria-invalid={!!errors.documentation}
       />
       {uploadedFiles.length > 0 && (

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -43,6 +43,14 @@ Varianten `FileUpload.Trigger` er en knapp som åpner nettleserens filvelger. Du
 
 <Canvas of={FileUploadStories.ExampleTrigger} />
 
+### Begrenset antall filer
+
+Dersom du ønsker å begrense antall filer implementeres dette selv. Du kan bruke propertien `disabled` for å hindre brukeren i å laste opp flere filer når grensen er nådd.
+
+Dersom brukeren allerede har lastet opp mer enn det maksimalt tillatte antallet, f.eks. ved å droppe flere filer omgangen i dropzonen, bør du vise en feilmelding for input-feltet, ikke for hver enkelt fil. Se eksempelet under.
+
+<Canvas of={FileUploadStories.TooManyFiles} />
+
 ### Vedlegg
 
 Delkomponenten `FileUpload.Item` brukes til å vise status for filer som er lastet opp. Du kan bruke `error` til å vise feilmeldinger, for eksempel dersom filformatet ikke er riktig.

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -45,9 +45,7 @@ Varianten `FileUpload.Trigger` er en knapp som åpner nettleserens filvelger. Du
 
 ### Begrenset antall filer
 
-Dersom du ønsker å begrense antall filer implementeres dette selv. Du kan bruke propertien `disabled` for å hindre brukeren i å laste opp flere filer når grensen er nådd.
-
-Dersom brukeren allerede har lastet opp mer enn det maksimalt tillatte antallet, f.eks. ved å droppe flere filer omgangen i dropzonen, bør du vise en feilmelding for input-feltet, ikke for hver enkelt fil. Se eksempelet under.
+Dersom du ønsker å begrense antall filer implementeres dette selv. Om brukeren har lastet opp mer enn det maksimalt tillatte antallet bør du vise en feilmelding for input-feltet, ikke for hver enkelt fil. Se eksempelet under.
 
 <Canvas of={FileUploadStories.TooManyFiles} />
 

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -32,16 +32,13 @@ export const Preview = meta.story({
         justifyContent: 'center',
       }}
     >
-      <FileUpload.Trigger {...args} id="trigger" />
-      <FileUpload.Dropzone {...args} id="dropzone" />
+      <FileUpload.Trigger {...args} inputProps={{ id: 'trigger' }} />
+      <FileUpload.Dropzone {...args} inputProps={{ id: 'dropzone' }} />
     </div>
   ),
 });
 
 export const ExampleDropZone = meta.story({
-  args: {
-    id: 'dokumentasjon-dropzone',
-  },
   render: (args) => {
     const [files, setFiles] = useState<File[]>([]);
     const [rejected, setRejected] = useState<FileRejection[]>([]);
@@ -155,7 +152,6 @@ export const ExampleTrigger = meta.story({
   args: {
     label: 'Last opp profilbilde',
     description: 'Du kan laste opp filer i PNG- og JPEG-format.',
-    id: 'profilbilde',
   },
   render: (args) => {
     const [file, setFile] = useState<File | null>(null);
@@ -313,8 +309,8 @@ export const Upload = meta.story({
         <FileUpload.Trigger
           label="Last opp rapport"
           description="Du kan legge ved 1 fil."
-          id="rapport"
           onChange={handleOnChange}
+          inputProps={{ id: 'rapport' }}
         />
         {file && (
           <>

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -76,13 +76,13 @@ export const Readonly = meta.story({
       >
         <FileUpload.Trigger
           {...args}
-          inputProps={{ readOnly: true }}
+          inputProps={{ readOnly: true, id: 'readonly-trigger' }}
           label="Lesemodus"
           description="Beskrivelse for Trigger"
         />
         <FileUpload.Dropzone
           {...args}
-          inputProps={{ readOnly: true, max: 2 }}
+          inputProps={{ readOnly: true, max: 2, id: 'readonly-dropzone' }}
           label="Lesemodus"
           description="Beskrivelse for Dropzone"
         />
@@ -133,7 +133,7 @@ export const ExampleDropZone = meta.story({
           label="Last opp dokumentasjon"
           description="Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB."
           multiple
-          inputProps={getInputProps()}
+          inputProps={{ ...getInputProps(), id: 'dokumentasjon' }}
           data-testid="dropzone"
           error={files.length > 2 && 'Du har lastet opp for mange filer.'}
           {...getRootProps()}
@@ -232,7 +232,7 @@ export const TooManyFiles = meta.story({
             files.length > 2 &&
             'Du har lastet opp for mange filer. Fjern noen for å kunne sende inn skjemaet.'
           }
-          inputProps={getInputProps()}
+          inputProps={{ ...getInputProps(), id: 'dokumentasjon-for-mange' }}
           {...getRootProps()}
           style={{ maxWidth: '450px', width: '100%' }}
           {...args}
@@ -286,7 +286,7 @@ export const ExampleTrigger = meta.story({
         }}
       >
         <FileUpload.Trigger
-          inputProps={{ accept: 'image/png, image/jpeg' }}
+          inputProps={{ accept: 'image/png, image/jpeg', id: 'profilbilde' }}
           onChange={(e) => handleOnChange(e)}
           data-testid="trigger"
           {...args}

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -115,7 +115,7 @@ export const ExampleDropZone = meta.story({
       onDropRejected: (rej) => {
         setRejected((prev) => [...prev, ...rej]);
       },
-      maxSize: 524288,
+      maxSize: 5242880,
       accept: {
         'application/pdf': [],
       },
@@ -135,6 +135,7 @@ export const ExampleDropZone = meta.story({
           multiple
           inputProps={getInputProps()}
           data-testid="dropzone"
+          error={files.length > 2 && 'Du har lastet opp for mange filer.'}
           {...getRootProps()}
           {...args}
         />
@@ -194,11 +195,71 @@ export const ExampleDropZone = meta.story({
   },
 });
 
+export const TooManyFiles = meta.story({
+  render: (args) => {
+    const [files, setFiles] = useState<File[]>([
+      new File(['abc'.repeat(100000)], 'eksempel1.pdf'),
+      new File(['abc'.repeat(10000)], 'eksempel2.docx'),
+      new File(['abc'.repeat(1000000)], 'eksempel3.png'),
+    ]);
+
+    const removeFile = (fileToRemove: File) => {
+      setFiles((prevItems) =>
+        prevItems.filter((file) => file !== fileToRemove),
+      );
+    };
+
+    const { getRootProps, getInputProps } = useDropzone({
+      onDropAccepted: (file) => {
+        setFiles((prev) => [...prev, ...file]);
+      },
+      multiple: true,
+    });
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 'var(--ds-size-3)',
+        }}
+      >
+        <FileUpload.Dropzone
+          label="Last opp dokumentasjon"
+          description="Du kan kun laste opp 2 filer."
+          data-testid="dropzone"
+          error={
+            files.length > 2 &&
+            'Du har lastet opp for mange filer. Fjern noen for å kunne sende inn skjemaet.'
+          }
+          inputProps={getInputProps()}
+          {...getRootProps()}
+          style={{ maxWidth: '450px', width: '100%' }}
+          {...args}
+        />
+        {files.length > 0 && (
+          <>
+            <Heading level={3} data-size="2xs">
+              Vedlegg ({files.length}):
+            </Heading>
+            {files.map((file, index) => (
+              <FileUpload.Item
+                key={index}
+                file={file}
+                onRemove={() => removeFile(file)}
+              />
+            ))}
+          </>
+        )}
+      </div>
+    );
+  },
+});
+
 const ErrorMessages = new Map<string, string>([
   ['file-invalid-type', 'Filformatet støttes ikke'],
   ['file-too-large', 'Filen er for stor'],
   ['file-too-small', 'Filen er for liten'],
-  ['too-many-files', 'Du har lastet opp for mange filer'],
 ]);
 
 export const ExampleTrigger = meta.story({

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -132,8 +132,10 @@ export const ExampleDropZone = meta.story({
         <FileUpload.Dropzone
           label="Last opp dokumentasjon"
           description="Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB."
-          multiple
-          inputProps={{ ...getInputProps(), id: 'dokumentasjon' }}
+          inputProps={{
+            ...getInputProps(),
+            id: 'dokumentasjon',
+          }}
           data-testid="dropzone"
           error={files.length > 2 && 'Du har lastet opp for mange filer.'}
           {...getRootProps()}
@@ -270,10 +272,11 @@ export const ExampleTrigger = meta.story({
   render: (args) => {
     const [file, setFile] = useState<File | null>(null);
 
-    const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
-      if (e.target.files) {
-        setFile(e.target.files[0]);
-        e.target.value = '';
+    const handleOnChange = (e: ChangeEvent<HTMLDivElement>) => {
+      const input = e.target as unknown as HTMLInputElement;
+      if (input.files) {
+        setFile(input.files[0]);
+        input.value = '';
       }
     };
 
@@ -286,7 +289,10 @@ export const ExampleTrigger = meta.story({
         }}
       >
         <FileUpload.Trigger
-          inputProps={{ accept: 'image/png, image/jpeg', id: 'profilbilde' }}
+          inputProps={{
+            accept: 'image/png, image/jpeg',
+            id: 'profilbilde',
+          }}
           onChange={(e) => handleOnChange(e)}
           data-testid="trigger"
           {...args}

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -24,18 +24,71 @@ export const Preview = meta.story({
     label: 'Label',
     description: 'Beskrivelse',
   },
-  render: (args) => (
-    <div
-      style={{
-        display: 'flex',
-        gap: 'var(--ds-size-18)',
-        justifyContent: 'center',
-      }}
-    >
-      <FileUpload.Trigger {...args} inputProps={{ id: 'trigger' }} />
-      <FileUpload.Dropzone {...args} inputProps={{ id: 'dropzone' }} />
-    </div>
-  ),
+  render: (args) => {
+    const { getRootProps, getInputProps } = useDropzone({
+      onDropAccepted: (files) => {
+        window.alert(
+          `Accepted dropped file(s):\n  - ${files.map((x) => x.name).join(',\n  - ')}`,
+        );
+      },
+      onDropRejected: (rej) => {
+        window.alert(
+          `Rejected dropped file(s):\n  - ${rej.map((x) => `${x.file.name} (reason: ${x.errors.map((err) => err.message).join(', ')})`).join(',\n  - ')}`,
+        );
+      },
+      accept: {
+        'application/pdf': [],
+      },
+    });
+    return (
+      <div
+        style={{
+          display: 'flex',
+          gap: 'var(--ds-size-18)',
+          justifyContent: 'center',
+        }}
+      >
+        <FileUpload.Trigger
+          {...args}
+          inputProps={{ ...args.inputProps, id: 'trigger' }}
+        />
+        <FileUpload.Dropzone
+          {...getRootProps(args)}
+          inputProps={getInputProps({ ...args.inputProps, id: 'dropzone' })}
+        />
+      </div>
+    );
+  },
+});
+
+export const Readonly = meta.story({
+  render: (args) => {
+    return (
+      <div
+        style={{
+          background: 'var(--ds-color-neutral-surface-tinted)',
+          display: 'flex',
+          gap: 'var(--ds-size-12)',
+          justifyContent: 'center',
+          padding: 'var(--ds-size-8)',
+          borderRadius: 'var(--ds-border-radius-md)',
+        }}
+      >
+        <FileUpload.Trigger
+          {...args}
+          inputProps={{ readOnly: true }}
+          label="Lesemodus"
+          description="Beskrivelse for Trigger"
+        />
+        <FileUpload.Dropzone
+          {...args}
+          inputProps={{ readOnly: true, max: 2 }}
+          label="Lesemodus"
+          description="Beskrivelse for Dropzone"
+        />
+      </div>
+    );
+  },
 });
 
 export const ExampleDropZone = meta.story({
@@ -214,9 +267,10 @@ export const ExampleItems = meta.story({
       new File(['abc'.repeat(100000)], 'eksempel1.pdf'),
       new File(['abc'.repeat(10000)], 'eksempel2.docx'),
       new File(['abc'.repeat(1000000)], 'eksempel3.png'),
+      new File(['abc'.repeat(123000)], 'eksempel4.pdf'),
     ];
     const dummyRejected: File[] = [
-      new File(['abc'.repeat(288000)], 'eksempel4.tsx'),
+      new File(['abc'.repeat(288000)], 'eksempel5.tsx'),
     ];
 
     const [files, setFiles] = useState<File[]>(dummyFiles);
@@ -251,7 +305,8 @@ export const ExampleItems = meta.story({
               <FileUpload.Item
                 key={index}
                 file={file}
-                loading={index === 2 && true}
+                readonly={index === 2 && true}
+                loading={index === 3 && true}
                 onRemove={() => removeFile(file)}
               />
             ))}

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -12,25 +12,23 @@ import type { FileUploadProps } from './FileUploadTrigger';
 export type FileUploadDropzoneProps = FileUploadProps;
 
 export const FileUploadDropzone = forwardRef<
-  HTMLInputElement,
+  HTMLDivElement,
   FileUploadDropzoneProps
 >(function FileUploadDropzone(
   {
     className,
-    multiple,
     'data-size': size,
     label,
     error,
     description,
     inputProps,
-    id,
     ...rest
   },
   ref,
 ) {
-  const mult = multiple === true || inputProps?.multiple === true;
+  const disabled = inputProps?.readOnly ?? inputProps?.max === 0;
   const buttonRef = useRef<HTMLButtonElement>(null);
-  const cssVar = mult
+  const cssVar = inputProps?.multiple
     ? '--udsc-fileUpload-chooseFiles-text'
     : '--udsc-fileUpload-chooseFile-text';
   // This is to make sure accessibility tests pass. Not actually necessary to make screenreaders announce the button.
@@ -59,7 +57,18 @@ export const FileUploadDropzone = forwardRef<
           {/* Text in css */}
         </Button>
       </Card>
-      <input type="file" id={id} multiple={mult} {...inputProps} />
+      <input
+        type="file"
+        {...inputProps}
+        readOnly={inputProps?.readOnly}
+        disabled={disabled}
+        onClick={(e) => {
+          if (inputProps?.readOnly) {
+            e.preventDefault();
+          }
+          inputProps?.onClick?.(e);
+        }}
+      />
       {!!error && <ValidationMessage>{error}</ValidationMessage>}
     </Field>
   );

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -54,7 +54,7 @@ export const FileUploadDropzone = forwardRef<
         {inputProps?.readOnly ? (
           <>
             <div>{/* Text in css */}</div>
-            <CircleSlashIcon />
+            <CircleSlashIcon aria-hidden />
           </>
         ) : (
           <>

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -68,8 +68,6 @@ export const FileUploadDropzone = forwardRef<
       </Card>
       <input
         type="file"
-        readOnly={inputProps?.readOnly}
-        id={inputProps?.id}
         {...inputProps}
         onClick={(e) => {
           if (inputProps?.readOnly) {

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -1,6 +1,6 @@
 import cl from 'clsx/lite';
 import { forwardRef, useEffect, useRef } from 'react';
-import { CircleSlashIcon, UploadIcon } from '@udir-design/icons';
+import { UploadIcon } from '@udir-design/icons';
 import { Button } from '../button/Button';
 import { Card } from '../card/Card';
 import './fileUpload.css';
@@ -44,6 +44,13 @@ export const FileUploadDropzone = forwardRef<
     <Field
       className={cl(`uds-file-upload`, className)}
       data-size={size}
+      onDrop={(e) => {
+        if (inputProps?.readOnly) {
+          e.preventDefault();
+          return;
+        }
+        rest.onDrop?.(e);
+      }}
       ref={ref}
       {...rest}
     >
@@ -51,27 +58,25 @@ export const FileUploadDropzone = forwardRef<
       {!!description && <Field.Description>{description}</Field.Description>}
       <Card>
         {/* Text in css */}
-        {inputProps?.readOnly ? (
-          <>
-            <div>{/* Text in css */}</div>
-            <CircleSlashIcon aria-hidden />
-          </>
-        ) : (
-          <>
-            <div>{/* Text in css */}</div>
-            <Button variant="secondary" ref={buttonRef}>
-              <UploadIcon aria-hidden />
-              {/* Text in css */}
-            </Button>
-          </>
+        <div>{/* Text in css */}</div>
+        {!inputProps?.readOnly && (
+          <Button variant="secondary" ref={buttonRef}>
+            <UploadIcon aria-hidden />
+            {/* Text in css */}
+          </Button>
         )}
       </Card>
       <input
         type="file"
         readOnly={inputProps?.readOnly}
-        onClick={inputProps?.readOnly ? (e) => e.preventDefault() : undefined}
         id={inputProps?.id}
         {...inputProps}
+        onClick={(e) => {
+          if (inputProps?.readOnly) {
+            e.preventDefault();
+          }
+          inputProps?.onClick?.(e);
+        }}
       />
       {!!error && <ValidationMessage>{error}</ValidationMessage>}
     </Field>

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -1,6 +1,6 @@
 import cl from 'clsx/lite';
 import { forwardRef, useEffect, useRef } from 'react';
-import { UploadIcon } from '@udir-design/icons';
+import { CircleSlashIcon, UploadIcon } from '@udir-design/icons';
 import { Button } from '../button/Button';
 import { Card } from '../card/Card';
 import './fileUpload.css';
@@ -26,7 +26,6 @@ export const FileUploadDropzone = forwardRef<
   },
   ref,
 ) {
-  const disabled = inputProps?.readOnly ?? inputProps?.max === 0;
   const buttonRef = useRef<HTMLButtonElement>(null);
   const cssVar = inputProps?.multiple
     ? '--udsc-fileUpload-chooseFiles-text'
@@ -40,6 +39,7 @@ export const FileUploadDropzone = forwardRef<
       .trim();
     buttonRef.current.setAttribute('aria-label', buttonAriaLabel);
   }, [cssVar]);
+
   return (
     <Field
       className={cl(`uds-file-upload`, className)}
@@ -51,23 +51,27 @@ export const FileUploadDropzone = forwardRef<
       {!!description && <Field.Description>{description}</Field.Description>}
       <Card>
         {/* Text in css */}
-        <div>{/* Text in css */}</div>
-        <Button variant="secondary" ref={buttonRef}>
-          <UploadIcon aria-hidden />
-          {/* Text in css */}
-        </Button>
+        {inputProps?.readOnly ? (
+          <>
+            <div>{/* Text in css */}</div>
+            <CircleSlashIcon />
+          </>
+        ) : (
+          <>
+            <div>{/* Text in css */}</div>
+            <Button variant="secondary" ref={buttonRef}>
+              <UploadIcon aria-hidden />
+              {/* Text in css */}
+            </Button>
+          </>
+        )}
       </Card>
       <input
         type="file"
-        {...inputProps}
         readOnly={inputProps?.readOnly}
-        disabled={disabled}
-        onClick={(e) => {
-          if (inputProps?.readOnly) {
-            e.preventDefault();
-          }
-          inputProps?.onClick?.(e);
-        }}
+        onClick={inputProps?.readOnly ? (e) => e.preventDefault() : undefined}
+        id={inputProps?.id}
+        {...inputProps}
       />
       {!!error && <ValidationMessage>{error}</ValidationMessage>}
     </Field>

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -48,6 +48,10 @@ export interface FileUploadItemProps extends Omit<
    * @default false
    */
   loading?: boolean;
+  /**
+   * @default false
+   */
+  readonly?: boolean;
 }
 
 export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
@@ -56,6 +60,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
       file,
       error,
       loading,
+      readonly = false,
       className,
       'data-size': size,
       onRemove,
@@ -74,6 +79,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
         .trim();
       setTooltipContent(content);
     }, []);
+
     return (
       <Card
         className={cl('uds-file-upload__item', className)}
@@ -84,10 +90,11 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
         {...rest}
       >
         <div>
-          <Icon file={file} showError={Boolean(error)} loading={loading} />
+          <div>
+            <Icon file={file} showError={Boolean(error)} loading={loading} />
+          </div>
           <div>
             <Link
-              href="#"
               download={file.name}
               onClick={(event) => {
                 event.preventDefault();
@@ -101,7 +108,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
               {!loading && formatFileSize(file)}
             </Paragraph>
           </div>
-          {!loading && (
+          {!loading && !readonly && (
             <Tooltip content={tooltipContent} ref={tooltipRef}>
               <Button
                 icon

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -52,6 +52,10 @@ export interface FileUploadItemProps extends Omit<
    * @default false
    */
   readonly?: boolean;
+  /**
+   * href to file location
+   */
+  href?: string;
 }
 
 export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
@@ -60,6 +64,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
       file,
       error,
       loading,
+      href,
       readonly = false,
       className,
       'data-size': size,
@@ -94,15 +99,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
             <Icon file={file} showError={Boolean(error)} loading={loading} />
           </div>
           <div>
-            <Link
-              download={file.name}
-              onClick={(event) => {
-                event.preventDefault();
-                downloadFile(file);
-              }}
-            >
-              {file.name}
-            </Link>
+            <FileName file={file} href={href} />
             <Paragraph data-size="sm">
               {/* Loading text in css */}
               {!loading && formatFileSize(file)}
@@ -197,4 +194,27 @@ const downloadFile = (file: File): void => {
   a.click();
 
   URL.revokeObjectURL(url);
+};
+
+interface FileNameProps {
+  file: File;
+  href?: string;
+}
+
+const FileName = ({ file, href }: FileNameProps) => {
+  if (href) {
+    return <Link href={href}>{file.name}</Link>;
+  }
+
+  return (
+    <Link
+      download={file.name}
+      onClick={(event) => {
+        event.preventDefault();
+        downloadFile(file);
+      }}
+    >
+      {file.name}
+    </Link>
+  );
 };

--- a/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
@@ -1,6 +1,6 @@
 import type { Size } from '@digdir/designsystemet-react';
 import cl from 'clsx/lite';
-import type { InputHTMLAttributes, ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef, useEffect, useRef } from 'react';
 import { UploadIcon } from '@udir-design/icons';
 import { Button } from '../button/Button';
@@ -15,7 +15,7 @@ type InputProps_ = Omit<
   'prefix' | 'className' | 'style' | 'data-color' | 'type' | 'data-size'
 >;
 
-export type FileUploadProps = InputHTMLAttributes<HTMLInputElement> & {
+export type FileUploadProps = HTMLAttributes<HTMLDivElement> & {
   /**
    * Changes size for descendant Designsystemet components.
    * Select from predefined sizes.
@@ -39,7 +39,7 @@ export type FileUploadProps = InputHTMLAttributes<HTMLInputElement> & {
   inputProps?: InputProps_;
 };
 
-export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
+export const FileUploadTrigger = forwardRef<HTMLDivElement, FileUploadProps>(
   function FileUploadTrigger(
     {
       className,
@@ -77,7 +77,7 @@ export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
         {!!label && <Label>{label}</Label>}
         {!!description && <Field.Description>{description}</Field.Description>}
         <Button
-          disabled={inputProps?.readOnly}
+          disabled={inputProps?.readOnly ?? inputProps?.disabled}
           variant="secondary"
           onClick={() => {
             fileInputRef.current?.click();
@@ -91,10 +91,15 @@ export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
           type="file"
           ref={fileInputRef}
           readOnly={inputProps?.readOnly}
-          onClick={inputProps?.readOnly ? (e) => e.preventDefault() : undefined}
           multiple={Boolean(inputProps?.multiple) || undefined}
           id={inputProps?.id}
           {...inputProps}
+          onClick={(e) => {
+            if (inputProps?.readOnly) {
+              e.preventDefault();
+            }
+            inputProps?.onClick?.(e);
+          }}
         />
         {!!error && <ValidationMessage>{error}</ValidationMessage>}
       </Field>

--- a/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
@@ -77,6 +77,7 @@ export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
         {!!label && <Label>{label}</Label>}
         {!!description && <Field.Description>{description}</Field.Description>}
         <Button
+          disabled={inputProps?.readOnly}
           variant="secondary"
           onClick={() => {
             fileInputRef.current?.click();
@@ -90,6 +91,7 @@ export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
           type="file"
           ref={fileInputRef}
           readOnly={inputProps?.readOnly}
+          onClick={inputProps?.readOnly ? (e) => e.preventDefault() : undefined}
           multiple={Boolean(inputProps?.multiple) || undefined}
           id={inputProps?.id}
           {...inputProps}

--- a/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
@@ -37,30 +37,24 @@ export type FileUploadProps = InputHTMLAttributes<HTMLInputElement> & {
    * Props for the input field
    */
   inputProps?: InputProps_;
-  /**
-   * Id for the input field
-   */
-  id?: string;
 };
 
 export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
   function FileUploadTrigger(
     {
       className,
-      multiple,
       'data-size': size,
       label,
       error,
       description,
       inputProps,
-      id,
       ...rest
     },
     ref,
   ) {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const cssVar = multiple
+    const cssVar = inputProps?.multiple
       ? '--udsc-fileUpload-addFiles-text'
       : '--udsc-fileUpload-addFile-text';
     // This is to make sure accessibility tests pass. Not actually necessary to make screenreaders announce the button.
@@ -95,8 +89,9 @@ export const FileUploadTrigger = forwardRef<HTMLInputElement, FileUploadProps>(
         <input
           type="file"
           ref={fileInputRef}
-          multiple={Boolean(multiple) || undefined}
-          id={id}
+          readOnly={inputProps?.readOnly}
+          multiple={Boolean(inputProps?.multiple) || undefined}
+          id={inputProps?.id}
           {...inputProps}
         />
         {!!error && <ValidationMessage>{error}</ValidationMessage>}

--- a/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
@@ -90,9 +90,6 @@ export const FileUploadTrigger = forwardRef<HTMLDivElement, FileUploadProps>(
         <input
           type="file"
           ref={fileInputRef}
-          readOnly={inputProps?.readOnly}
-          multiple={Boolean(inputProps?.multiple) || undefined}
-          id={inputProps?.id}
           {...inputProps}
           onClick={(e) => {
             if (inputProps?.readOnly) {

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -8,13 +8,13 @@ exports[`Example Drop Zone 1`] = `
   >
     <label
       data-weight="medium"
-      for=":mm3l4h4xq7t"
+      for=":mm4l1uxykj4"
     >
       Last opp dokumentasjon
     </label>
     <div
       data-field="description"
-      id=":mm3l4h4xq7t:description:1"
+      id=":mm4l1uxykj4:description:1"
     >
       Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
     </div>
@@ -51,8 +51,8 @@ exports[`Example Drop Zone 1`] = `
       multiple
       tabindex="-1"
       type="file"
-      id=":mm3l4h4xq7t"
-      aria-describedby=":mm3l4h4xq7t:description:1"
+      id=":mm4l1uxykj4"
+      aria-describedby=":mm4l1uxykj4:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
   </div>
@@ -519,13 +519,13 @@ exports[`Example Trigger 1`] = `
   <div>
     <label
       data-weight="medium"
-      for=":mm3l4habfmv"
+      for=":mm4l1v41cw2"
     >
       Last opp profilbilde
     </label>
     <div
       data-field="description"
-      id=":mm3l4habfmv:description:1"
+      id=":mm4l1v41cw2:description:1"
     >
       Du kan laste opp filer i PNG- og JPEG-format.
     </div>
@@ -556,8 +556,8 @@ exports[`Example Trigger 1`] = `
     <input
       accept="image/png, image/jpeg"
       type="file"
-      id=":mm3l4habfmv"
-      aria-describedby=":mm3l4habfmv:description:1"
+      id=":mm4l1v41cw2"
+      aria-describedby=":mm4l1v41cw2:description:1"
     >
   </div>
   <h3 data-size="2xs">

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -8,13 +8,13 @@ exports[`Example Drop Zone 1`] = `
   >
     <label
       data-weight="medium"
-      for="dokumentasjon-dropzone"
+      for=":mm3l4h4xq7t"
     >
       Last opp dokumentasjon
     </label>
     <div
       data-field="description"
-      id="dokumentasjon-dropzone:description:1"
+      id=":mm3l4h4xq7t:description:1"
     >
       Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
     </div>
@@ -47,12 +47,12 @@ exports[`Example Drop Zone 1`] = `
       </button>
     </div>
     <input
-      id="dokumentasjon-dropzone"
-      multiple
       accept="application/pdf"
+      multiple
       tabindex="-1"
       type="file"
-      aria-describedby="dokumentasjon-dropzone:description:1"
+      id=":mm3l4h4xq7t"
+      aria-describedby=":mm3l4h4xq7t:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
   </div>
@@ -64,34 +64,33 @@ exports[`Example Drop Zone 1`] = `
     aria-invalid="false"
   >
     <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
-        >
-        </path>
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
       <div>
-        <a
-          href="#"
-          download="eksempel1.pdf"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
         >
+          <path
+            fill="currentColor"
+            d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+          >
+          </path>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel1.pdf">
           eksempel1.pdf
         </a>
         <p
@@ -105,9 +104,9 @@ exports[`Example Drop Zone 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_4_"
+        popovertarget="_r_6_"
         popovertargetaction="show"
-        aria-labelledby="_r_4_"
+        aria-labelledby="_r_6_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -130,7 +129,7 @@ exports[`Example Drop Zone 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_4_"
+        id="_r_6_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -149,41 +148,40 @@ exports[`Example Drop Zone 1`] = `
 exports[`Example Items 1`] = `
 <div style="display: flex; flex-direction: column; gap: var(--ds-size-3);">
   <h3 data-size="2xs">
-    Vedlegg (3):
+    Vedlegg (4):
   </h3>
   <div
     data-variant="default"
     aria-invalid="false"
   >
     <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
-        >
-        </path>
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
       <div>
-        <a
-          href="#"
-          download="eksempel1.pdf"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
         >
+          <path
+            fill="currentColor"
+            d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+          >
+          </path>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel1.pdf">
           eksempel1.pdf
         </a>
         <p
@@ -197,9 +195,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_b_"
+        popovertarget="_r_d_"
         popovertargetaction="show"
-        aria-labelledby="_r_b_"
+        aria-labelledby="_r_d_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -222,7 +220,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_b_"
+        id="_r_d_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -240,34 +238,33 @@ exports[`Example Items 1`] = `
     aria-invalid="false"
   >
     <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
-        >
-        </path>
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
       <div>
-        <a
-          href="#"
-          download="eksempel2.docx"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
         >
+          <path
+            fill="currentColor"
+            d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
+          >
+          </path>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel2.docx">
           eksempel2.docx
         </a>
         <p
@@ -281,9 +278,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_e_"
+        popovertarget="_r_g_"
         popovertargetaction="show"
-        aria-labelledby="_r_e_"
+        aria-labelledby="_r_g_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -306,7 +303,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_e_"
+        id="_r_g_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -322,37 +319,79 @@ exports[`Example Items 1`] = `
   <div
     data-variant="default"
     aria-invalid="false"
+  >
+    <div>
+      <div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel3.png">
+          eksempel3.png
+        </a>
+        <p
+          data-variant="default"
+          data-size="sm"
+        >
+          2.86 MB
+        </p>
+      </div>
+    </div>
+    <div
+      aria-relevant="additions removals"
+      aria-live="polite"
+    >
+    </div>
+  </div>
+  <div
+    data-variant="default"
+    aria-invalid="false"
     aria-busy="true"
   >
     <div>
-      <svg
-        aria-label="spinner"
-        role="img"
-        viewbox="0 0 50 50"
-      >
-        <circle
-          cx="25"
-          cy="25"
-          r="20"
-          fill="none"
-          stroke-width="5"
-        >
-        </circle>
-        <circle
-          cx="25"
-          cy="25"
-          r="20"
-          fill="none"
-          stroke-width="5"
-        >
-        </circle>
-      </svg>
       <div>
-        <a
-          href="#"
-          download="eksempel3.png"
+        <svg
+          aria-label="spinner"
+          role="img"
+          viewbox="0 0 50 50"
         >
-          eksempel3.png
+          <circle
+            cx="25"
+            cy="25"
+            r="20"
+            fill="none"
+            stroke-width="5"
+          >
+          </circle>
+          <circle
+            cx="25"
+            cy="25"
+            r="20"
+            fill="none"
+            stroke-width="5"
+          >
+          </circle>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel4.pdf">
+          eksempel4.pdf
         </a>
         <p
           data-variant="default"
@@ -378,30 +417,29 @@ exports[`Example Items 1`] = `
     aria-invalid="true"
   >
     <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v11.5c0 .69-.56 1.25-1.25 1.25h-11c-.69 0-1.25-.56-1.25-1.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h10.5V8.75zm.25-2.94 1.44 1.44h-1.44zm-.72 6.16a.75.75 0 0 1 0 1.06l-.97.97.97.97a.75.75 0 1 1-1.06 1.06l-.97-.97-.97.97a.75.75 0 1 1-1.06-1.06l.97-.97-.97-.97a.75.75 0 1 1 1.06-1.06l.97.97.97-.97a.75.75 0 0 1 1.06 0"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
       <div>
-        <a
-          href="#"
-          download="eksempel4.tsx"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
         >
-          eksempel4.tsx
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v11.5c0 .69-.56 1.25-1.25 1.25h-11c-.69 0-1.25-.56-1.25-1.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h10.5V8.75zm.25-2.94 1.44 1.44h-1.44zm-.72 6.16a.75.75 0 0 1 0 1.06l-.97.97.97.97a.75.75 0 1 1-1.06 1.06l-.97-.97-.97.97a.75.75 0 1 1-1.06-1.06l.97-.97-.97-.97a.75.75 0 1 1 1.06-1.06l.97.97.97-.97a.75.75 0 0 1 1.06 0"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel5.tsx">
+          eksempel5.tsx
         </a>
         <p
           data-variant="default"
@@ -414,9 +452,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_h_"
+        popovertarget="_r_k_"
         popovertargetaction="show"
-        aria-labelledby="_r_h_"
+        aria-labelledby="_r_k_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -439,7 +477,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_h_"
+        id="_r_k_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -481,13 +519,13 @@ exports[`Example Trigger 1`] = `
   <div>
     <label
       data-weight="medium"
-      for="profilbilde"
+      for=":mm3l4habfmv"
     >
       Last opp profilbilde
     </label>
     <div
       data-field="description"
-      id="profilbilde:description:1"
+      id=":mm3l4habfmv:description:1"
     >
       Du kan laste opp filer i PNG- og JPEG-format.
     </div>
@@ -516,10 +554,10 @@ exports[`Example Trigger 1`] = `
       </svg>
     </button>
     <input
-      id="profilbilde"
       accept="image/png, image/jpeg"
       type="file"
-      aria-describedby="profilbilde:description:1"
+      id=":mm3l4habfmv"
+      aria-describedby=":mm3l4habfmv:description:1"
     >
   </div>
   <h3 data-size="2xs">
@@ -530,29 +568,28 @@ exports[`Example Trigger 1`] = `
     aria-invalid="false"
   >
     <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
       <div>
-        <a
-          href="#"
-          download="eksempel1.png"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
         >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel1.png">
           eksempel1.png
         </a>
         <p
@@ -566,9 +603,9 @@ exports[`Example Trigger 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_8_"
+        popovertarget="_r_a_"
         popovertargetaction="show"
-        aria-labelledby="_r_8_"
+        aria-labelledby="_r_a_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -591,7 +628,7 @@ exports[`Example Trigger 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_8_"
+        id="_r_a_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -652,7 +689,11 @@ exports[`Preview 1`] = `
       aria-describedby="trigger:description:1"
     >
   </div>
-  <div data-size="md">
+  <div
+    data-size="md"
+    role="presentation"
+    tabindex="0"
+  >
     <label
       data-weight="medium"
       for="dropzone"
@@ -671,7 +712,7 @@ exports[`Preview 1`] = `
       <button
         data-variant="secondary"
         type="button"
-        aria-label="Velg fil"
+        aria-label="Velg filer"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -694,9 +735,119 @@ exports[`Preview 1`] = `
       </button>
     </div>
     <input
+      accept="application/pdf"
+      multiple
+      tabindex="-1"
       id="dropzone"
       type="file"
       aria-describedby="dropzone:description:1"
+      style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+    >
+  </div>
+</div>
+`;
+
+exports[`Readonly 1`] = `
+<div style="display: flex; gap: var(--ds-size-18); justify-content: center;">
+  <div data-size="md">
+    <label
+      data-weight="medium"
+      for="trigger"
+    >
+      Label
+    </label>
+    <div
+      data-field="description"
+      id="trigger:description:1"
+    >
+      Beskrivelse
+    </div>
+    <button
+      data-variant="secondary"
+      type="button"
+      disabled
+      aria-label="Legg til fil"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M6.97 9.03a.75.75 0 0 0 1.06 0l3.22-3.22v8.69a.75.75 0 0 0 1.5 0V5.81l3.22 3.22a.75.75 0 1 0 1.06-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0l-4.5 4.5a.75.75 0 0 0 0 1.06M4.75 15.5a.75.75 0 0 0-1.5 0V19c0 .966.784 1.75 1.75 1.75h14A1.75 1.75 0 0 0 20.75 19v-3.5a.75.75 0 0 0-1.5 0V19a.25.25 0 0 1-.25.25H5a.25.25 0 0 1-.25-.25z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </button>
+    <input
+      id="trigger"
+      readonly
+      type="file"
+      aria-describedby="trigger:description:1"
+    >
+  </div>
+  <div
+    data-size="md"
+    role="presentation"
+    tabindex="0"
+  >
+    <label
+      data-weight="medium"
+      for="dropzone"
+    >
+      Label
+    </label>
+    <div
+      data-field="description"
+      id="dropzone:description:1"
+    >
+      Beskrivelse
+    </div>
+    <div data-variant="default">
+      <div>
+      </div>
+      <button
+        data-variant="secondary"
+        type="button"
+        aria-label="Velg filer"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.098 5.114A9.72 9.72 0 0 0 2.25 12c0 5.385 4.365 9.75 9.75 9.75s9.75-4.365 9.75-9.75S17.385 2.25 12 2.25a9.72 9.72 0 0 0-6.886 2.848l-.008.008zm1.623.546a8.25 8.25 0 0 1 11.62 11.62zM5.66 6.72l11.62 11.62A8.25 8.25 0 0 1 5.66 6.72"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </button>
+    </div>
+    <input
+      accept="application/pdf"
+      multiple
+      tabindex="-1"
+      readonly
+      id="dropzone"
+      disabled
+      type="file"
+      aria-describedby="dropzone:description:1"
+      style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
   </div>
 </div>

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -8,13 +8,13 @@ exports[`Example Drop Zone 1`] = `
   >
     <label
       data-weight="medium"
-      for=":mmam98wfj31"
+      for="dokumentasjon"
     >
       Last opp dokumentasjon
     </label>
     <div
       data-field="description"
-      id=":mmam98wfj31:description:1"
+      id="dokumentasjon:description:1"
     >
       Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
     </div>
@@ -47,12 +47,12 @@ exports[`Example Drop Zone 1`] = `
       </button>
     </div>
     <input
+      id="dokumentasjon"
       accept="application/pdf"
       multiple
       tabindex="-1"
       type="file"
-      id=":mmam98wfj31"
-      aria-describedby=":mmam98wfj31:description:1"
+      aria-describedby="dokumentasjon:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
   </div>
@@ -519,13 +519,13 @@ exports[`Example Trigger 1`] = `
   <div>
     <label
       data-weight="medium"
-      for=":mmam993m59v"
+      for="profilbilde"
     >
       Last opp profilbilde
     </label>
     <div
       data-field="description"
-      id=":mmam993m59v:description:1"
+      id="profilbilde:description:1"
     >
       Du kan laste opp filer i PNG- og JPEG-format.
     </div>
@@ -554,10 +554,10 @@ exports[`Example Trigger 1`] = `
       </svg>
     </button>
     <input
+      id="profilbilde"
       accept="image/png, image/jpeg"
       type="file"
-      id=":mmam993m59v"
-      aria-describedby=":mmam993m59v:description:1"
+      aria-describedby="profilbilde:description:1"
     >
   </div>
   <h3 data-size="2xs">
@@ -752,13 +752,13 @@ exports[`Readonly 1`] = `
   <div>
     <label
       data-weight="medium"
-      for=":mmam98rtw1k"
+      for="readonly-trigger"
     >
       Lesemodus
     </label>
     <div
       data-field="description"
-      id=":mmam98rtw1k:description:1"
+      id="readonly-trigger:description:1"
     >
       Beskrivelse for Trigger
     </div>
@@ -789,21 +789,21 @@ exports[`Readonly 1`] = `
     </button>
     <input
       readonly
+      id="readonly-trigger"
       type="file"
-      id=":mmam98rtw1k"
-      aria-describedby=":mmam98rtw1k:description:1"
+      aria-describedby="readonly-trigger:description:1"
     >
   </div>
   <div>
     <label
       data-weight="medium"
-      for=":mmam98ru0iw"
+      for="readonly-dropzone"
     >
       Lesemodus
     </label>
     <div
       data-field="description"
-      id=":mmam98ru0iw:description:1"
+      id="readonly-dropzone:description:1"
     >
       Beskrivelse for Dropzone
     </div>
@@ -818,6 +818,7 @@ exports[`Readonly 1`] = `
         viewbox="0 0 24 24"
         focusable="false"
         role="img"
+        aria-hidden="true"
       >
         <path
           fill="currentColor"
@@ -830,10 +831,10 @@ exports[`Readonly 1`] = `
     </div>
     <input
       readonly
+      id="readonly-dropzone"
       max="2"
       type="file"
-      id=":mmam98ru0iw"
-      aria-describedby=":mmam98ru0iw:description:1"
+      aria-describedby="readonly-dropzone:description:1"
     >
   </div>
 </div>
@@ -848,13 +849,13 @@ exports[`Too Many Files 1`] = `
   >
     <label
       data-weight="medium"
-      for=":mmam9928i30"
+      for="dokumentasjon-for-mange"
     >
       Last opp dokumentasjon
     </label>
     <div
       data-field="description"
-      id=":mmam9928i30:description:1"
+      id="dokumentasjon-for-mange:description:1"
     >
       Du kan kun laste opp 2 filer.
     </div>
@@ -887,16 +888,16 @@ exports[`Too Many Files 1`] = `
       </button>
     </div>
     <input
+      id="dokumentasjon-for-mange"
       multiple
       tabindex="-1"
       type="file"
-      id=":mmam9928i30"
-      aria-describedby=":mmam9928i30:validation:1 :mmam9928i30:description:1"
+      aria-describedby="dokumentasjon-for-mange:validation:1 dokumentasjon-for-mange:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
     <p
       data-field="validation"
-      id=":mmam9928i30:validation:1"
+      id="dokumentasjon-for-mange:validation:1"
     >
       Du har lastet opp for mange filer. Fjern noen for å kunne sende inn skjemaet.
     </p>

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -8,13 +8,13 @@ exports[`Example Drop Zone 1`] = `
   >
     <label
       data-weight="medium"
-      for=":mm4l1uxykj4"
+      for=":mmam98wfj31"
     >
       Last opp dokumentasjon
     </label>
     <div
       data-field="description"
-      id=":mm4l1uxykj4:description:1"
+      id=":mmam98wfj31:description:1"
     >
       Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
     </div>
@@ -51,8 +51,8 @@ exports[`Example Drop Zone 1`] = `
       multiple
       tabindex="-1"
       type="file"
-      id=":mm4l1uxykj4"
-      aria-describedby=":mm4l1uxykj4:description:1"
+      id=":mmam98wfj31"
+      aria-describedby=":mmam98wfj31:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
   </div>
@@ -195,9 +195,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_d_"
+        popovertarget="_r_n_"
         popovertargetaction="show"
-        aria-labelledby="_r_d_"
+        aria-labelledby="_r_n_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -220,7 +220,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_d_"
+        id="_r_n_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -278,9 +278,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_g_"
+        popovertarget="_r_q_"
         popovertargetaction="show"
-        aria-labelledby="_r_g_"
+        aria-labelledby="_r_q_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -303,7 +303,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_g_"
+        id="_r_q_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -452,9 +452,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_k_"
+        popovertarget="_r_u_"
         popovertargetaction="show"
-        aria-labelledby="_r_k_"
+        aria-labelledby="_r_u_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -477,7 +477,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_k_"
+        id="_r_u_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -519,13 +519,13 @@ exports[`Example Trigger 1`] = `
   <div>
     <label
       data-weight="medium"
-      for=":mm4l1v41cw2"
+      for=":mmam993m59v"
     >
       Last opp profilbilde
     </label>
     <div
       data-field="description"
-      id=":mm4l1v41cw2:description:1"
+      id=":mmam993m59v:description:1"
     >
       Du kan laste opp filer i PNG- og JPEG-format.
     </div>
@@ -556,8 +556,8 @@ exports[`Example Trigger 1`] = `
     <input
       accept="image/png, image/jpeg"
       type="file"
-      id=":mm4l1v41cw2"
-      aria-describedby=":mm4l1v41cw2:description:1"
+      id=":mmam993m59v"
+      aria-describedby=":mmam993m59v:description:1"
     >
   </div>
   <h3 data-size="2xs">
@@ -603,9 +603,9 @@ exports[`Example Trigger 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_a_"
+        popovertarget="_r_k_"
         popovertargetaction="show"
-        aria-labelledby="_r_a_"
+        aria-labelledby="_r_k_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -628,7 +628,7 @@ exports[`Example Trigger 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_a_"
+        id="_r_k_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -735,10 +735,10 @@ exports[`Preview 1`] = `
       </button>
     </div>
     <input
+      id="dropzone"
       accept="application/pdf"
       multiple
       tabindex="-1"
-      id="dropzone"
       type="file"
       aria-describedby="dropzone:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
@@ -748,19 +748,19 @@ exports[`Preview 1`] = `
 `;
 
 exports[`Readonly 1`] = `
-<div style="display: flex; gap: var(--ds-size-18); justify-content: center;">
-  <div data-size="md">
+<div style="background: var(--ds-color-neutral-surface-tinted); display: flex; gap: var(--ds-size-12); justify-content: center; padding: var(--ds-size-8); border-radius: var(--ds-border-radius-md);">
+  <div>
     <label
       data-weight="medium"
-      for="trigger"
+      for=":mmam98rtw1k"
     >
-      Label
+      Lesemodus
     </label>
     <div
       data-field="description"
-      id="trigger:description:1"
+      id=":mmam98rtw1k:description:1"
     >
-      Beskrivelse
+      Beskrivelse for Trigger
     </div>
     <button
       data-variant="secondary"
@@ -788,28 +788,75 @@ exports[`Readonly 1`] = `
       </svg>
     </button>
     <input
-      id="trigger"
       readonly
       type="file"
-      aria-describedby="trigger:description:1"
+      id=":mmam98rtw1k"
+      aria-describedby=":mmam98rtw1k:description:1"
     >
   </div>
-  <div
-    data-size="md"
-    role="presentation"
-    tabindex="0"
-  >
+  <div>
     <label
       data-weight="medium"
-      for="dropzone"
+      for=":mmam98ru0iw"
     >
-      Label
+      Lesemodus
     </label>
     <div
       data-field="description"
-      id="dropzone:description:1"
+      id=":mmam98ru0iw:description:1"
     >
-      Beskrivelse
+      Beskrivelse for Dropzone
+    </div>
+    <div data-variant="default">
+      <div>
+      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M5.098 5.114A9.72 9.72 0 0 0 2.25 12c0 5.385 4.365 9.75 9.75 9.75s9.75-4.365 9.75-9.75S17.385 2.25 12 2.25a9.72 9.72 0 0 0-6.886 2.848l-.008.008zm1.623.546a8.25 8.25 0 0 1 11.62 11.62zM5.66 6.72l11.62 11.62A8.25 8.25 0 0 1 5.66 6.72"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </div>
+    <input
+      readonly
+      max="2"
+      type="file"
+      id=":mmam98ru0iw"
+      aria-describedby=":mmam98ru0iw:description:1"
+    >
+  </div>
+</div>
+`;
+
+exports[`Too Many Files 1`] = `
+<div style="display: flex; flex-direction: column; gap: var(--ds-size-3);">
+  <div
+    role="presentation"
+    tabindex="0"
+    style="max-width: 450px; width: 100%;"
+  >
+    <label
+      data-weight="medium"
+      for=":mmam9928i30"
+    >
+      Last opp dokumentasjon
+    </label>
+    <div
+      data-field="description"
+      id=":mmam9928i30:description:1"
+    >
+      Du kan kun laste opp 2 filer.
     </div>
     <div data-variant="default">
       <div>
@@ -827,11 +874,12 @@ exports[`Readonly 1`] = `
           viewbox="0 0 24 24"
           focusable="false"
           role="img"
+          aria-hidden="true"
         >
           <path
             fill="currentColor"
             fill-rule="evenodd"
-            d="M5.098 5.114A9.72 9.72 0 0 0 2.25 12c0 5.385 4.365 9.75 9.75 9.75s9.75-4.365 9.75-9.75S17.385 2.25 12 2.25a9.72 9.72 0 0 0-6.886 2.848l-.008.008zm1.623.546a8.25 8.25 0 0 1 11.62 11.62zM5.66 6.72l11.62 11.62A8.25 8.25 0 0 1 5.66 6.72"
+            d="M6.97 9.03a.75.75 0 0 0 1.06 0l3.22-3.22v8.69a.75.75 0 0 0 1.5 0V5.81l3.22 3.22a.75.75 0 1 0 1.06-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0l-4.5 4.5a.75.75 0 0 0 0 1.06M4.75 15.5a.75.75 0 0 0-1.5 0V19c0 .966.784 1.75 1.75 1.75h14A1.75 1.75 0 0 0 20.75 19v-3.5a.75.75 0 0 0-1.5 0V19a.25.25 0 0 1-.25.25H5a.25.25 0 0 1-.25-.25z"
             clip-rule="evenodd"
           >
           </path>
@@ -839,16 +887,266 @@ exports[`Readonly 1`] = `
       </button>
     </div>
     <input
-      accept="application/pdf"
       multiple
       tabindex="-1"
-      readonly
-      id="dropzone"
-      disabled
       type="file"
-      aria-describedby="dropzone:description:1"
+      id=":mmam9928i30"
+      aria-describedby=":mmam9928i30:validation:1 :mmam9928i30:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
     >
+    <p
+      data-field="validation"
+      id=":mmam9928i30:validation:1"
+    >
+      Du har lastet opp for mange filer. Fjern noen for å kunne sende inn skjemaet.
+    </p>
+  </div>
+  <h3 data-size="2xs">
+    Vedlegg (3):
+  </h3>
+  <div
+    data-variant="default"
+    aria-invalid="false"
+  >
+    <div>
+      <div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+          >
+          </path>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel1.pdf">
+          eksempel1.pdf
+        </a>
+        <p
+          data-variant="default"
+          data-size="sm"
+        >
+          0.29 MB
+        </p>
+      </div>
+      <button
+        data-icon="true"
+        data-variant="tertiary"
+        type="button"
+        popovertarget="_r_a_"
+        popovertargetaction="show"
+        aria-labelledby="_r_a_"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </button>
+      <span
+        role="tooltip"
+        id="_r_a_"
+        popover="manual"
+        style="opacity: 0;"
+      >
+        Fjern filen
+      </span>
+    </div>
+    <div
+      aria-relevant="additions removals"
+      aria-live="polite"
+    >
+    </div>
+  </div>
+  <div
+    data-variant="default"
+    aria-invalid="false"
+  >
+    <div>
+      <div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
+          >
+          </path>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel2.docx">
+          eksempel2.docx
+        </a>
+        <p
+          data-variant="default"
+          data-size="sm"
+        >
+          0.03 MB
+        </p>
+      </div>
+      <button
+        data-icon="true"
+        data-variant="tertiary"
+        type="button"
+        popovertarget="_r_d_"
+        popovertargetaction="show"
+        aria-labelledby="_r_d_"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </button>
+      <span
+        role="tooltip"
+        id="_r_d_"
+        popover="manual"
+        style="opacity: 0;"
+      >
+        Fjern filen
+      </span>
+    </div>
+    <div
+      aria-relevant="additions removals"
+      aria-live="polite"
+    >
+    </div>
+  </div>
+  <div
+    data-variant="default"
+    aria-invalid="false"
+  >
+    <div>
+      <div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel3.png">
+          eksempel3.png
+        </a>
+        <p
+          data-variant="default"
+          data-size="sm"
+        >
+          2.86 MB
+        </p>
+      </div>
+      <button
+        data-icon="true"
+        data-variant="tertiary"
+        type="button"
+        popovertarget="_r_g_"
+        popovertargetaction="show"
+        aria-labelledby="_r_g_"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </button>
+      <span
+        role="tooltip"
+        id="_r_g_"
+        popover="manual"
+        style="opacity: 0;"
+      >
+        Fjern filen
+      </span>
+    </div>
+    <div
+      aria-relevant="additions removals"
+      aria-live="polite"
+    >
+    </div>
   </div>
 </div>
 `;

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -47,10 +47,10 @@ exports[`Example Drop Zone 1`] = `
       </button>
     </div>
     <input
-      id="dokumentasjon"
       accept="application/pdf"
       multiple
       tabindex="-1"
+      id="dokumentasjon"
       type="file"
       aria-describedby="dokumentasjon:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
@@ -554,8 +554,8 @@ exports[`Example Trigger 1`] = `
       </svg>
     </button>
     <input
-      id="profilbilde"
       accept="image/png, image/jpeg"
+      id="profilbilde"
       type="file"
       aria-describedby="profilbilde:description:1"
     >
@@ -735,10 +735,10 @@ exports[`Preview 1`] = `
       </button>
     </div>
     <input
-      id="dropzone"
       accept="application/pdf"
       multiple
       tabindex="-1"
+      id="dropzone"
       type="file"
       aria-describedby="dropzone:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
@@ -813,8 +813,8 @@ exports[`Readonly 1`] = `
     </div>
     <input
       readonly
-      id="readonly-dropzone"
       max="2"
+      id="readonly-dropzone"
       type="file"
       aria-describedby="readonly-dropzone:description:1"
     >
@@ -870,9 +870,9 @@ exports[`Too Many Files 1`] = `
       </button>
     </div>
     <input
-      id="dokumentasjon-for-mange"
       multiple
       tabindex="-1"
+      id="dokumentasjon-for-mange"
       type="file"
       aria-describedby="dokumentasjon-for-mange:validation:1 dokumentasjon-for-mange:description:1"
       style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -104,9 +104,9 @@ exports[`Example Drop Zone 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_6_"
+        popovertarget="_r_5_"
         popovertargetaction="show"
-        aria-labelledby="_r_6_"
+        aria-labelledby="_r_5_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -129,7 +129,7 @@ exports[`Example Drop Zone 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_6_"
+        id="_r_5_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -195,9 +195,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_n_"
+        popovertarget="_r_m_"
         popovertargetaction="show"
-        aria-labelledby="_r_n_"
+        aria-labelledby="_r_m_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -220,7 +220,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_n_"
+        id="_r_m_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -278,9 +278,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_q_"
+        popovertarget="_r_p_"
         popovertargetaction="show"
-        aria-labelledby="_r_q_"
+        aria-labelledby="_r_p_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -303,7 +303,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_q_"
+        id="_r_p_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -452,9 +452,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_u_"
+        popovertarget="_r_t_"
         popovertargetaction="show"
-        aria-labelledby="_r_u_"
+        aria-labelledby="_r_t_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -477,7 +477,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_u_"
+        id="_r_t_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -603,9 +603,9 @@ exports[`Example Trigger 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_k_"
+        popovertarget="_r_j_"
         popovertargetaction="show"
-        aria-labelledby="_r_k_"
+        aria-labelledby="_r_j_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -628,7 +628,7 @@ exports[`Example Trigger 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_k_"
+        id="_r_j_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -810,24 +810,6 @@ exports[`Readonly 1`] = `
     <div data-variant="default">
       <div>
       </div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.098 5.114A9.72 9.72 0 0 0 2.25 12c0 5.385 4.365 9.75 9.75 9.75s9.75-4.365 9.75-9.75S17.385 2.25 12 2.25a9.72 9.72 0 0 0-6.886 2.848l-.008.008zm1.623.546a8.25 8.25 0 0 1 11.62 11.62zM5.66 6.72l11.62 11.62A8.25 8.25 0 0 1 5.66 6.72"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
     </div>
     <input
       readonly
@@ -950,9 +932,9 @@ exports[`Too Many Files 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_a_"
+        popovertarget="_r_9_"
         popovertargetaction="show"
-        aria-labelledby="_r_a_"
+        aria-labelledby="_r_9_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -975,7 +957,7 @@ exports[`Too Many Files 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_a_"
+        id="_r_9_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -1033,9 +1015,9 @@ exports[`Too Many Files 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_d_"
+        popovertarget="_r_c_"
         popovertargetaction="show"
-        aria-labelledby="_r_d_"
+        aria-labelledby="_r_c_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -1058,7 +1040,7 @@ exports[`Too Many Files 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_d_"
+        id="_r_c_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -1111,9 +1093,9 @@ exports[`Too Many Files 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_g_"
+        popovertarget="_r_f_"
         popovertargetaction="show"
-        aria-labelledby="_r_g_"
+        aria-labelledby="_r_f_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -1136,7 +1118,7 @@ exports[`Too Many Files 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_g_"
+        id="_r_f_"
         popover="manual"
         style="opacity: 0;"
       >

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -144,6 +144,7 @@
   flex-direction: column;
   align-items: flex-start;
   max-width: 30rem;
+  word-break: break-all;
 
   /* Uploading text in the paragraph after link */
   &[aria-busy='true'] .ds-link + .ds-paragraph::before {
@@ -156,7 +157,7 @@
     width: 100%;
   }
 
-  & > div > svg {
+  & > div > div > svg {
     width: auto;
     height: var(--ds-size-10);
     margin-inline-end: var(--ds-size-3);

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -51,7 +51,7 @@
   width: fit-content;
   height: fit-content;
 
-  & > input {
+  > input {
     display: none;
   }
 
@@ -135,6 +135,33 @@
       content: var(--udsc-fileUpload-dropzone-button-text);
     }
   }
+
+  /* Text and icon for readOnly */
+  &:has(input[readOnly]) {
+    > .ds-card {
+      &::before {
+        content: '';
+        display: block;
+        width: 1.3rem;
+        height: 1.3rem;
+        background: currentColor;
+        mask-image: var(--uds-icon-circleSlash);
+        mask-size: contain;
+        mask-repeat: no-repeat;
+        mask-position: center;
+      }
+
+      > div {
+        text-align: center;
+
+        &::before {
+          content: var(--udsc-fileUpload-disabled-text-line-one) '\a'
+            var(--udsc-fileUpload-disabled-text-line-two);
+          white-space: pre;
+        }
+      }
+    }
+  }
 }
 
 /* FileUpload.Item */
@@ -157,7 +184,7 @@
     width: 100%;
   }
 
-  & > div > div > svg {
+  > div > div > svg {
     width: auto;
     height: var(--ds-size-10);
     margin-inline-end: var(--ds-size-3);

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -9,6 +9,8 @@
   --udsc-fileUpload-or-text: 'eller';
   --udsc-fileUpload-uploading-text: 'Laster opp...';
   --udsc-fileUpload-removeFile-text: 'Fjern filen';
+  --udsc-fileUpload-disabled-text-line-one: 'Du kan ikke lenger';
+  --udsc-fileUpload-disabled-text-line-two: 'laste opp filer';
 }
 
 [lang='nn'] {
@@ -21,6 +23,8 @@
   --udsc-fileUpload-or-text: 'eller';
   --udsc-fileUpload-uploading-text: 'Lastar opp...';
   --udsc-fileUpload-removeFile-text: 'Fjern fila';
+  --udsc-fileUpload-disabled-text-line-one: 'Du kan ikkje lenger';
+  --udsc-fileUpload-disabled-text-line-two: 'laste opp filer';
 }
 
 [lang='en'] {
@@ -33,6 +37,8 @@
   --udsc-fileUpload-or-text: 'or';
   --udsc-fileUpload-uploading-text: 'Uploading...';
   --udsc-fileUpload-removeFile-text: 'Remove file';
+  --udsc-fileUpload-disabled-text-line-one: 'You can no longer';
+  --udsc-fileUpload-disabled-text-line-two: 'upload files';
 }
 
 /* FileUpload.Dropzone and FileUpload.Trigger */
@@ -43,23 +49,59 @@
   );
   --udsc-fileUpload-dropzone-text: var(--udsc-fileUpload-dropFile-text);
   width: fit-content;
+  height: fit-content;
 
   & > input {
     display: none;
   }
 
+  /* Loading state */
   &[aria-busy='true'] {
-    & > .ds-card {
+    > .ds-card {
       cursor: progress;
     }
   }
 
-  &:not([aria-busy='true']) {
+  /* Design of dropzone */
+  > .ds-card {
+    margin-block-start: var(--ds-size-2);
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--ds-size-2);
+    --dsc-card-border-style: dashed;
+    --dsc-card-border-color: var(--ds-color-border-strong);
+  }
+
+  &:has(input[readOnly]) {
+    cursor: not-allowed;
+
+    > label {
+      cursor: not-allowed;
+    }
+
+    > .ds-card {
+      background: transparent;
+      opacity: var(--ds-opacity-disabled);
+    }
+  }
+
+  /* 
+  * Override opacity for label and description when disabled, 
+  * to ensure they are still readable since disabled button is used for readOnly.
+  */
+  > label,
+  [data-field='description'] {
+    opacity: 1;
+  }
+
+  &:not([aria-busy='true']):not(:has(input[readOnly])) {
     &:hover {
-      & > .ds-card {
+      > .ds-card {
         cursor: pointer;
 
-        & > .ds-button {
+        > .ds-button {
           background: var(--dsc-button-background--hover);
           color: var(--dsc-button-color--hover);
         }
@@ -77,31 +119,21 @@
   }
 
   /* Trigger texts */
-  & > .ds-button::after {
+  > .ds-button::after {
     content: var(--udsc-fileUpload-button-text);
   }
 
   /* Dropzone texts */
-  & > .ds-card {
+  > .ds-card {
     &::before {
       content: var(--udsc-fileUpload-dropzone-text);
     }
-    & > div::before {
+    > div::before {
       content: var(--udsc-fileUpload-or-text);
     }
-    & > .ds-button::after {
+    > .ds-button::after {
       content: var(--udsc-fileUpload-dropzone-button-text);
     }
-  }
-
-  & > .ds-card {
-    margin-block-start: var(--ds-size-2);
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--ds-size-2);
-    --dsc-card-border-style: dashed;
   }
 }
 
@@ -118,7 +150,7 @@
     content: var(--udsc-fileUpload-uploading-text);
   }
 
-  & > div {
+  > div {
     display: flex;
     align-items: center;
     width: 100%;
@@ -134,7 +166,7 @@
   &[aria-invalid='true'] {
     --dsc-card-border-color: var(--ds-color-danger-border-strong);
 
-    & > div:last-of-type > p {
+    > div:last-of-type > p {
       padding-inline-start: var(--ds-size-12);
       color: var(--ds-color-danger-text-subtle);
       display: flex;
@@ -144,7 +176,7 @@
     }
   }
 
-  & > div > .ds-button {
+  > div > .ds-button {
     margin-inline-start: auto;
   }
 

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -817,13 +817,14 @@ exports[`Form Page 3 1`] = `
       <div>
       </div>
       <div
+        id="dokumentasjon-dropzone"
         role="presentation"
         tabindex="0"
         aria-invalid="false"
       >
         <label
           data-weight="medium"
-          for="dokumentasjon-dropzone"
+          for=":mm3l4j03eri"
         >
           <span>
             Last opp dokumentasjon
@@ -831,7 +832,7 @@ exports[`Form Page 3 1`] = `
         </label>
         <div
           data-field="description"
-          id="dokumentasjon-dropzone:description:1"
+          id=":mm3l4j03eri:description:1"
         >
           Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB.
         </div>
@@ -864,13 +865,13 @@ exports[`Form Page 3 1`] = `
           </button>
         </div>
         <input
-          id="dokumentasjon-dropzone"
-          multiple
           accept="application/pdf"
+          multiple
           tabindex="-1"
           required
           type="file"
-          aria-describedby="dokumentasjon-dropzone:description:1"
+          id=":mm3l4j03eri"
+          aria-describedby=":mm3l4j03eri:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
         >
       </div>

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -824,7 +824,7 @@ exports[`Form Page 3 1`] = `
       >
         <label
           data-weight="medium"
-          for=":mm3l4j03eri"
+          for=":mm4l1w6vxhp"
         >
           <span>
             Last opp dokumentasjon
@@ -832,7 +832,7 @@ exports[`Form Page 3 1`] = `
         </label>
         <div
           data-field="description"
-          id=":mm3l4j03eri:description:1"
+          id=":mm4l1w6vxhp:description:1"
         >
           Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB.
         </div>
@@ -870,8 +870,8 @@ exports[`Form Page 3 1`] = `
           tabindex="-1"
           required
           type="file"
-          id=":mm3l4j03eri"
-          aria-describedby=":mm3l4j03eri:description:1"
+          id=":mm4l1w6vxhp"
+          aria-describedby=":mm4l1w6vxhp:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
         >
       </div>

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -824,7 +824,7 @@ exports[`Form Page 3 1`] = `
       >
         <label
           data-weight="medium"
-          for=":mm4l1w6vxhp"
+          for=":mmam9aryndy"
         >
           <span>
             Last opp dokumentasjon
@@ -832,7 +832,7 @@ exports[`Form Page 3 1`] = `
         </label>
         <div
           data-field="description"
-          id=":mm4l1w6vxhp:description:1"
+          id=":mmam9aryndy:description:1"
         >
           Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB.
         </div>
@@ -870,8 +870,8 @@ exports[`Form Page 3 1`] = `
           tabindex="-1"
           required
           type="file"
-          id=":mm4l1w6vxhp"
-          aria-describedby=":mm4l1w6vxhp:description:1"
+          id=":mmam9aryndy"
+          aria-describedby=":mmam9aryndy:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
         >
       </div>

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -817,14 +817,13 @@ exports[`Form Page 3 1`] = `
       <div>
       </div>
       <div
-        id="dokumentasjon-dropzone"
         role="presentation"
         tabindex="0"
         aria-invalid="false"
       >
         <label
           data-weight="medium"
-          for=":mmbpn7o76qo"
+          for="dokumentasjon-dropzone"
         >
           <span>
             Last opp dokumentasjon
@@ -832,7 +831,7 @@ exports[`Form Page 3 1`] = `
         </label>
         <div
           data-field="description"
-          id=":mmbpn7o76qo:description:1"
+          id="dokumentasjon-dropzone:description:1"
         >
           Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB.
         </div>
@@ -865,13 +864,13 @@ exports[`Form Page 3 1`] = `
           </button>
         </div>
         <input
+          id="dokumentasjon-dropzone"
           accept="application/pdf"
           multiple
           tabindex="-1"
           required
           type="file"
-          id=":mmbpn7o76qo"
-          aria-describedby=":mmbpn7o76qo:description:1"
+          aria-describedby="dokumentasjon-dropzone:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
         >
       </div>

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -864,11 +864,11 @@ exports[`Form Page 3 1`] = `
           </button>
         </div>
         <input
-          id="dokumentasjon-dropzone"
           accept="application/pdf"
           multiple
           tabindex="-1"
           required
+          id="dokumentasjon-dropzone"
           type="file"
           aria-describedby="dokumentasjon-dropzone:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -824,7 +824,7 @@ exports[`Form Page 3 1`] = `
       >
         <label
           data-weight="medium"
-          for=":mmam9aryndy"
+          for=":mmbpn7o76qo"
         >
           <span>
             Last opp dokumentasjon
@@ -832,7 +832,7 @@ exports[`Form Page 3 1`] = `
         </label>
         <div
           data-field="description"
-          id=":mmam9aryndy:description:1"
+          id=":mmbpn7o76qo:description:1"
         >
           Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB.
         </div>
@@ -870,8 +870,8 @@ exports[`Form Page 3 1`] = `
           tabindex="-1"
           required
           type="file"
-          id=":mmam9aryndy"
-          aria-describedby=":mmam9aryndy:description:1"
+          id=":mmbpn7o76qo"
+          aria-describedby=":mmbpn7o76qo:description:1"
           style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
         >
       </div>

--- a/test-apps/nextjs/project.json
+++ b/test-apps/nextjs/project.json
@@ -8,6 +8,9 @@
   "targets": {
     "start": {
       "dependsOn": ["build"]
+    },
+    "dev": {
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
## Hva er gjort?

- Refaktorert slik at alle input-relaterte props, f.eks. `multiple` og `readOnly` må sendes inn via `inputProps` objektet. 
- Lagt til readonly versjon av komponentene som utgjør `FileUpload`
- Man kan nå lenke til href og ikke bare fil-instans i `FileUpload.Item`

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er testet i test-app