### PR TITLE
build: pnpm settings cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,39 +47,5 @@
     "tsx": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:"
-  },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "@bundled-es-modules/glob",
-      "@parcel/watcher",
-      "@swc/core",
-      "esbuild",
-      "lmdb",
-      "msgpackr-extract",
-      "msw",
-      "nx",
-      "oxc-resolver",
-      "sharp",
-      "style-dictionary",
-      "unrs-resolver"
-    ],
-    "overrides": {
-      "@eslint/plugin-kit@<0.3.4": ">=0.3.4",
-      "tmp@<=0.2.3": ">=0.2.4",
-      "glob@>=10.2.0 <10.5.0": "^10.5.0",
-      "semver@<7": "^7",
-      "chokidar@>=4.0.0 <5": "^5.0.0",
-      "jws@=4.0.0": ">=4.0.1",
-      "jws@<3.2.3": ">=3.2.3",
-      "qs@<6.14.1": ">=6.14.1",
-      "unist-util-visit@<5": "^5.0.0",
-      "minimatch@>=9.0.0 <9.0.6": ">=9.0.6",
-      "minimatch@>=10.0.0 <10.2.1": ">=10.2.1",
-      "minimatch@>=9.0.0 <9.0.7": ">=9.0.7",
-      "minimatch@>=10.0.0 <10.2.3": ">=10.2.3"
-    },
-    "patchedDependencies": {
-      "remark-heading-id@1.0.1": "patches/remark-heading-id@1.0.1.patch"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
       "@eslint/plugin-kit@<0.3.4": ">=0.3.4",
       "tmp@<=0.2.3": ">=0.2.4",
       "glob@>=10.2.0 <10.5.0": "^10.5.0",
-      "semver@<7": "^6.3.1",
+      "semver@<7": "^7",
       "chokidar@>=4.0.0 <5": "^5.0.0",
       "jws@=4.0.0": ">=4.0.1",
       "jws@<3.2.3": ">=3.2.3",
@@ -80,11 +80,6 @@
     },
     "patchedDependencies": {
       "remark-heading-id@1.0.1": "patches/remark-heading-id@1.0.1.patch"
-    },
-    "auditConfig": {
-      "ignoreCves": [
-        "CVE-2025-56648"
-      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,7 +386,7 @@ overrides:
   '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
   tmp@<=0.2.3: '>=0.2.4'
   glob@>=10.2.0 <10.5.0: ^10.5.0
-  semver@<7: ^6.3.1
+  semver@<7: ^7
   chokidar@>=4.0.0 <5: ^5.0.0
   jws@=4.0.0: '>=4.0.1'
   jws@<3.2.3: '>=3.2.3'
@@ -7785,10 +7785,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -8935,7 +8931,7 @@ snapshots:
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -8957,7 +8953,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.1
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 7.7.4
 
   '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -8968,7 +8964,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -8977,7 +8973,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
-      semver: 6.3.1
+      semver: 7.7.4
 
   '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.29.0)':
     dependencies:
@@ -9438,7 +9434,7 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9576,7 +9572,7 @@ snapshots:
       babel-plugin-polyfill-corejs3: 0.14.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
       core-js-compat: 3.48.0
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12825,7 +12821,7 @@ snapshots:
       '@babel/compat-data': 7.29.0
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.6(@babel/core@7.29.0)
-      semver: 6.3.1
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -13181,7 +13177,7 @@ snapshots:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 6.3.1
+      semver: 7.7.4
       shebang-command: 1.2.0
       which: 1.3.1
 
@@ -13813,7 +13809,7 @@ snapshots:
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
@@ -13871,7 +13867,7 @@ snapshots:
       object.values: 1.2.1
       prop-types: 15.8.1
       resolve: 2.0.0-next.6
-      semver: 6.3.1
+      semver: 7.7.4
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
@@ -15029,12 +15025,12 @@ snapshots:
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
-      semver: 6.3.1
+      semver: 7.7.4
     optional: true
 
   make-dir@3.1.0:
     dependencies:
-      semver: 6.3.1
+      semver: 7.7.4
 
   make-dir@4.0.0:
     dependencies:
@@ -15559,7 +15555,7 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       es-errors: 1.3.0
       object.entries: 1.1.9
-      semver: 6.3.1
+      semver: 7.7.4
 
   node-gyp-build-optional-packages@5.1.1:
     dependencies:
@@ -16584,8 +16580,6 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
-
-  semver@6.3.1: {}
 
   semver@7.5.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,18 +384,18 @@ catalogs:
 
 overrides:
   '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
-  tmp@<=0.2.3: '>=0.2.4'
-  glob@>=10.2.0 <10.5.0: ^10.5.0
-  semver@<7: ^7
   chokidar@>=4.0.0 <5: ^5.0.0
-  jws@=4.0.0: '>=4.0.1'
+  glob@>=10.2.0 <10.5.0: ^10.5.0
   jws@<3.2.3: '>=3.2.3'
-  qs@<6.14.1: '>=6.14.1'
-  unist-util-visit@<5: ^5.0.0
-  minimatch@>=9.0.0 <9.0.6: '>=9.0.6'
+  jws@=4.0.0: '>=4.0.1'
   minimatch@>=10.0.0 <10.2.1: '>=10.2.1'
-  minimatch@>=9.0.0 <9.0.7: '>=9.0.7'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
+  minimatch@>=9.0.0 <9.0.6: '>=9.0.6'
+  minimatch@>=9.0.0 <9.0.7: '>=9.0.7'
+  qs@<6.14.1: '>=6.14.1'
+  semver@<7: ^7
+  tmp@<=0.2.3: '>=0.2.4'
+  unist-util-visit@<5: ^5.0.0
 
 packageExtensionsChecksum: sha256-LMeXZzq7zvEM75wWqXhoH5AKiX4vxXAjdihGHRrb69w=
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -161,11 +161,6 @@ packageExtensions:
 
 trustPolicy: no-downgrade
 
-trustPolicyExclude:
-  - semver@6.3.1
-  - eslint-import-resolver-typescript@3.10.1
-  - detect-port@1.6.1
-
 useNodeVersion: 24.10.0
 
 verifyDepsBeforeRun: prompt

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -142,11 +142,40 @@ catalogs:
 
 cleanupUnusedCatalogs: true
 
+ignoredBuiltDependencies:
+  - '@bundled-es-modules/glob'
+  - '@parcel/watcher'
+  - '@swc/core'
+  - esbuild
+  - lmdb
+  - msgpackr-extract
+  - msw
+  - nx
+  - oxc-resolver
+  - sharp
+  - style-dictionary
+  - unrs-resolver
+
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
   - '@digdir/*'
   - '@u-elements/*'
+
+overrides:
+  '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
+  chokidar@>=4.0.0 <5: ^5.0.0
+  glob@>=10.2.0 <10.5.0: ^10.5.0
+  jws@<3.2.3: '>=3.2.3'
+  jws@=4.0.0: '>=4.0.1'
+  minimatch@>=10.0.0 <10.2.1: '>=10.2.1'
+  minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
+  minimatch@>=9.0.0 <9.0.6: '>=9.0.6'
+  minimatch@>=9.0.0 <9.0.7: '>=9.0.7'
+  qs@<6.14.1: '>=6.14.1'
+  semver@<7: ^7
+  tmp@<=0.2.3: '>=0.2.4'
+  unist-util-visit@<5: ^5.0.0
 
 packageExtensions:
   '@navikt/aksel-icons':
@@ -158,6 +187,9 @@ packageExtensions:
         optional: true
       react:
         optional: true
+
+patchedDependencies:
+  remark-heading-id@1.0.1: patches/remark-heading-id@1.0.1.patch
 
 trustPolicy: no-downgrade
 


### PR DESCRIPTION
## Hva er gjort?

- Fjerner behov for trustPolicyExclude
- Fjerner ignoreCves siden feilen det gjeld har blitt fiksa i Parcel
- Flytter alt som har med pnpm å gjere til pnpm-workspace.yml, sidan pnpm sine cli commands no ser ut til å faktisk ikkje flytte dei tilbake til package.json som var problemet før

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog

