### PR TITLE
docs(FileUpload): uploads were misbehaving in ExampleDropZone if interaction tests had run

### DIFF
--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -141,6 +141,10 @@ export const ExampleDropZone = meta.story({
         await within(canvasElement).findByText(dummyFile.name),
       ).toBeInTheDocument();
     });
+
+    // Reset file input so uploads work. Without this, every subsequent
+    // uploaded file will be replaced by the dummyFile used in the test
+    dropzone.value = '';
   },
 });
 


### PR DESCRIPTION
## Hva er gjort?

I testen (play-funksjon) til ExampleDropZone: resetter det interne inputfletet sin `value` til tom streng etter testen er ferdig. Dette fikser problemet der ein person som leser gjennom dokumentasjonen og klikker seg inn i den isolerte storyen vil få veldig merkelig oppførsel der alle opplastinger får filnamnet `eksempel1.pdf`. Problemet eksisterte ikkje på dokumentasjonssida, for der blir ikkje interaksjonstestane kjørt.

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
