### PR TITLE
fix: alignment readonly for FieldNecessity

### DIFF
--- a/@udir-design/react/src/components/field/Field.tsx
+++ b/@udir-design/react/src/components/field/Field.tsx
@@ -1,3 +1,4 @@
+import './field.css';
 import {
   Field as DigdirField,
   FieldAffix,

--- a/@udir-design/react/src/components/field/field.css
+++ b/@udir-design/react/src/components/field/field.css
@@ -1,0 +1,9 @@
+.ds-field:has([aria-readonly='true'], [readonly]) label::before {
+  /* position lock icon correctly even if the label contains a Tag */
+  vertical-align: middle;
+  position: relative;
+  top: calc(-0.5 * var(--ds-size-1));
+  /* prevent increasing the height of the label (when there is no Tag) due to vertical-align: middle */
+  height: calc(1lh - 0.5ch);
+  mask-size: cover;
+}

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
@@ -82,6 +82,37 @@ export const Outline = meta.story({
   ),
 });
 
+export const Readonly = meta.story({
+  render: (args, context) => (
+    <FieldNecessity
+      {...args}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        rowGap: 'var(--ds-size-4)',
+      }}
+    >
+      <Textfield
+        id={id(context, 'first')}
+        label={<span>Fornavn</span>}
+        required
+        readOnly
+      />
+      <Textfield
+        id={id(context, 'middle')}
+        label={<span>Mellomnavn</span>}
+        readOnly
+      />
+      <Textfield
+        id={id(context, 'last')}
+        label={<span>Etternavn</span>}
+        required
+        readOnly
+      />
+    </FieldNecessity>
+  ),
+});
+
 export const AllRequired = meta.story({
   render: (args, context) => (
     <FieldNecessity

--- a/@udir-design/react/src/components/fieldNecessity/__snapshots__/FieldNecessity.stories.tsx.snap
+++ b/@udir-design/react/src/components/fieldNecessity/__snapshots__/FieldNecessity.stories.tsx.snap
@@ -455,6 +455,69 @@ exports[`Preview 1`] = `
 </div>
 `;
 
+exports[`Readonly 1`] = `
+<div
+  data-show-required="true"
+  data-show-optional="false"
+  data-show-summary="true"
+  style="display: flex; flex-direction: column; row-gap: var(--ds-size-4);"
+>
+  <div>
+    <label
+      data-weight="medium"
+      for="readonly-first"
+    >
+      <span>
+        Fornavn
+      </span>
+    </label>
+    <div>
+      <input
+        id="readonly-first"
+        required
+        readonly
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="readonly-middle"
+    >
+      <span>
+        Mellomnavn
+      </span>
+    </label>
+    <div>
+      <input
+        id="readonly-middle"
+        readonly
+        type="text"
+      >
+    </div>
+  </div>
+  <div>
+    <label
+      data-weight="medium"
+      for="readonly-last"
+    >
+      <span>
+        Etternavn
+      </span>
+    </label>
+    <div>
+      <input
+        id="readonly-last"
+        required
+        readonly
+        type="text"
+      >
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Single Optional Field 1`] = `
 <div
   data-show-required="true"

--- a/@udir-design/react/src/components/textarea/Textarea.tsx
+++ b/@udir-design/react/src/components/textarea/Textarea.tsx
@@ -1,3 +1,5 @@
+/* Import Field's css here, otherwise it will not always be loaded in Storybook due to Textarea using Digdir's field directly */
+import '../field/field.css';
 import { Textarea, type TextareaProps } from '@digdir/designsystemet-react';
 
 export type { TextareaProps };

--- a/@udir-design/react/src/components/textfield/Textfield.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.tsx
@@ -1,3 +1,5 @@
+/* Import Field's css here, otherwise it will not always be loaded in Storybook due to Textfield using Digdir's field directly */
+import '../field/field.css';
 import { Textfield, type TextfieldProps } from '@digdir/designsystemet-react';
 
 export type { TextfieldProps };


### PR DESCRIPTION
## Hva er gjort?

Endrer posisjonering av hengelås-ikonet så det ikke lenger er offset når det vises sammen med en FieldNecessity-tag
