### PR TITLE
docs: new info about input counter

### DIFF
--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -48,6 +48,10 @@ Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i fe
 
 <Canvas of={FieldStories.Counter} />
 
+I noen tilfeller vil man ha data med et visst antall tegn, men unngå å telle med f.eks. mellomrom. Dette gjelder for eksempel telefonnummer eller personnummer. Du burde la brukeren plassere mellomrom der det er naturlig for dem, og heller fjerne disse programmatisk før innsending. Det kan i disse tilfellene være nødvendig å skrive sin egen logikk for å validere antall tegn fremfor å bruke `counter`. Se eksempelet under for hvordan det kan løses for telefonnummer.
+
+<Canvas of={FieldStories.Format} />
+
 ### Plassering
 
 Bruk `position="end"` når du ønsker å plassere [`Input`](/docs/components-input--docs) til høyre for `Label`. Dette kan være nyttig i innstillingsgrensesnitt, slik at brukeren først kan lese etiketten til venstre – som forklarer hva innstillingen gjelder – og deretter handlingselementet (bryteren) til høyre.

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -44,7 +44,7 @@ Det er viktig at samme informasjon som vises i prefixet eller suffixet, også in
 
 ### Antall tegn
 
-Bruk `Field.Counter` til å informere om antall tegn brukerne kan skrive i feltet.
+Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data f.eks. ved å komme borti samme tall to ganger. Det er bedre å la brukeren skrive inn det de ønsker, og heller vise en feilmelding dersom de har skrevet for mye.
 
 <Canvas of={FieldStories.Counter} />
 

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -44,7 +44,7 @@ Det er viktig at samme informasjon som vises i prefixet eller suffixet, også in
 
 ### Antall tegn
 
-Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data. Det er bedre å la brukeren skrive inn det de ønsker, og vise en feilmelding dersom de har skrevet for mye.
+Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Ved behov kan du bruke `over` eller `under` til å skrive en tilpasset melding, f.eks. dersom man ønsker å vise antall tegn brukt av en total. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data. Det er bedre å la brukeren skrive inn det de ønsker, og vise en feilmelding dersom de har skrevet for mye.
 
 <Canvas of={FieldStories.Counter} />
 

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -48,7 +48,7 @@ Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i fe
 
 <Canvas of={FieldStories.Counter} />
 
-I noen tilfeller vil man ha data med et visst antall tegn, men unngå å telle med f.eks. mellomrom. Dette gjelder for eksempel telefonnummer eller personnummer. Du burde la brukeren plassere mellomrom der det er naturlig for dem, og heller fjerne disse programmatisk før innsending. Det kan i disse tilfellene være nødvendig å skrive sin egen logikk for å validere antall tegn fremfor å bruke `counter`. Se eksempelet under for hvordan det kan løses for telefonnummer.
+I noen tilfeller vil man ha data med et visst antall tegn, men unngå å telle med f.eks. mellomrom. Dette gjelder for eksempel telefonnummer eller personnummer. Du burde la brukeren plassere mellomrom der det er naturlig for dem, og heller fjerne disse programmatisk før innsending. Det kan i disse tilfellene være nødvendig å skrive sin egen logikk for å validere antall tegn fremfor å bruke `counter`. Se eksempelet under for hvordan det kan løses.
 
 <Canvas of={FieldStories.Format} />
 

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -44,7 +44,7 @@ Det er viktig at samme informasjon som vises i prefixet eller suffixet, også in
 
 ### Antall tegn
 
-Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data f.eks. ved å komme borti samme tall to ganger. Det er bedre å la brukeren skrive inn det de ønsker, og heller vise en feilmelding dersom de har skrevet for mye.
+Bruk `Field.Counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data. Det er bedre å la brukeren skrive inn det de ønsker, og vise en feilmelding dersom de har skrevet for mye.
 
 <Canvas of={FieldStories.Counter} />
 

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -1,3 +1,5 @@
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
 import { expect, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Input } from '../input/Input';
@@ -97,6 +99,41 @@ export const Counter = meta.story({
       expect(label).toBeInTheDocument();
       await waitFor(() => expect(label).toHaveAttribute('for', textarea.id));
     });
+  },
+});
+
+export const Format = meta.story({
+  render: () => {
+    const [nationalIdentityNumber, setNationalIdentityNumber] =
+      useState<string>('');
+    const tooLong = nationalIdentityNumber.length > 11;
+    const hasNonDigits = /\D/.test(nationalIdentityNumber);
+
+    const updateNumber = (e: ChangeEvent<HTMLInputElement>) => {
+      // removing spaces from stored value so users can space how they like withour error message
+      setNationalIdentityNumber(e.target.value.replace(/\s+/g, ''));
+    };
+
+    return (
+      <Field>
+        <Label>Fødselsnummer</Label>
+        <Input
+          id="format"
+          inputMode="numeric"
+          onChange={(e) => updateNumber(e)}
+        />
+        {tooLong && (
+          <ValidationMessage>
+            Fødselsnummer skal kun være 11 tegn
+          </ValidationMessage>
+        )}
+        {hasNonDigits && (
+          <ValidationMessage>
+            Fødselsnummer skal kun inneholde siffere
+          </ValidationMessage>
+        )}
+      </Field>
+    );
   },
 });
 

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -82,8 +82,8 @@ export const Counter = meta.story({
   render: () => (
     <Field>
       <Label>Legg til en beskrivelse</Label>
-      <Textarea rows={2} id="counter" />
-      <Field.Counter limit={10} />
+      <Textarea rows={4} id="counter" />
+      <Field.Counter limit={75} />
     </Field>
   ),
   play: async ({ canvasElement, step }) => {

--- a/@udir-design/react/src/components/field/__snapshots__/Field.stories.tsx.snap
+++ b/@udir-design/react/src/components/field/__snapshots__/Field.stories.tsx.snap
@@ -33,7 +33,7 @@ exports[`Counter 1`] = `
     Legg til en beskrivelse
   </label>
   <textarea
-    rows="2"
+    rows="4"
     id="counter"
     aria-describedby="counter:description:1"
   >
@@ -44,15 +44,31 @@ exports[`Counter 1`] = `
     data-variant="default"
     aria-hidden="true"
   >
-    10 tegn igjen
+    75 tegn igjen
   </p>
   <div
     aria-hidden="true"
     data-field="description"
     id="counter:description:1"
   >
-    Maks 10 tegn tillatt.
+    Maks 75 tegn tillatt.
   </div>
+</div>
+`;
+
+exports[`Format 1`] = `
+<div>
+  <label
+    data-weight="medium"
+    for="format"
+  >
+    Fødselsnummer
+  </label>
+  <input
+    id="format"
+    inputmode="numeric"
+    type="text"
+  >
 </div>
 `;
 

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -44,7 +44,7 @@ Prefixer og suffixer er nyttige for å vise enheter, valuta eller annen informas
 
 ### Antall tegn
 
-Bruk `counter` til å begrense antall tegn brukerne kan skrive i feltet.
+Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data f.eks. ved å komme borti samme tall to ganger. Det er bedre å la brukeren skrive inn det de ønsker, og heller vise en feilmelding dersom de har skrevet for mye.
 
 <Canvas of={TextfieldStories.Counter} />
 

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -44,7 +44,7 @@ Prefixer og suffixer er nyttige for å vise enheter, valuta eller annen informas
 
 ### Antall tegn
 
-Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data. Det er bedre å la brukeren skrive inn det de ønsker, og vise en feilmelding dersom de har skrevet for mye.
+Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Ved behov kan du lage et objekt for `counter` og skreddersy teksten med blant annet `over` eller `under`, f.eks. dersom man ønsker å vise antall tegn brukt av en total. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data. Det er bedre å la brukeren skrive inn det de ønsker, og vise en feilmelding dersom de har skrevet for mye.
 
 <Canvas of={TextfieldStories.Counter} />
 

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -48,6 +48,10 @@ Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. 
 
 <Canvas of={TextfieldStories.Counter} />
 
+I noen tilfeller vil man ha data med et visst antall tegn, men unngå å telle med f.eks. mellomrom. Dette gjelder for eksempel telefonnummer eller personnummer. Du burde la brukeren plassere mellomrom der det er naturlig for dem, og heller fjerne disse programmatisk før innsending. Det kan i disse tilfellene være nødvendig å skrive sin egen logikk for å validere antall tegn fremfor å bruke `counter`. Se eksempelet under for hvordan det kan løses for telefonnummer.
+
+<Canvas of={TextfieldStories.Format} />
+
 ### Kontrollert tilstand
 
 Tilstanden til `Textfield` kan kontrolleres ved å bruke `value` og `onChange`. Dette er nyttig når du vil at `Textfield` skal oppdatere seg selv basert på endringer i andre komponenter eller tilstander.

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -48,7 +48,7 @@ Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. 
 
 <Canvas of={TextfieldStories.Counter} />
 
-I noen tilfeller vil man ha data med et visst antall tegn, men unngå å telle med f.eks. mellomrom. Dette gjelder for eksempel telefonnummer eller personnummer. Du burde la brukeren plassere mellomrom der det er naturlig for dem, og heller fjerne disse programmatisk før innsending. Det kan i disse tilfellene være nødvendig å skrive sin egen logikk for å validere antall tegn fremfor å bruke `counter`. Se eksempelet under for hvordan det kan løses for telefonnummer.
+I noen tilfeller vil man ha data med et visst antall tegn, men unngå å telle med f.eks. mellomrom. Dette gjelder for eksempel telefonnummer eller personnummer. Du burde la brukeren plassere mellomrom der det er naturlig for dem, og heller fjerne disse programmatisk før innsending. Det kan i disse tilfellene være nødvendig å skrive sin egen logikk for å validere antall tegn fremfor å bruke `counter`. Se eksempelet under for hvordan det kan løses.
 
 <Canvas of={TextfieldStories.Format} />
 

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -44,7 +44,7 @@ Prefixer og suffixer er nyttige for å vise enheter, valuta eller annen informas
 
 ### Antall tegn
 
-Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data f.eks. ved å komme borti samme tall to ganger. Det er bedre å la brukeren skrive inn det de ønsker, og heller vise en feilmelding dersom de har skrevet for mye.
+Bruk `counter` til å vise brukeren hvor mange tegn de kan skrive inn i feltet. Man bør ikke hindre folk i å skrive mer enn maks antall tegn, da dette kan føre til at man sender inn feil data. Det er bedre å la brukeren skrive inn det de ønsker, og vise en feilmelding dersom de har skrevet for mye.
 
 <Canvas of={TextfieldStories.Counter} />
 

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -129,15 +129,15 @@ export const Affix = meta.story({
 });
 
 export const Counter = meta.story({
-  args: {
-    counter: {
-      limit: 11,
-      over: 'Fødselsnummer må være 11 siffer',
-    },
-    label: 'Fødselsnummer',
-    id: 'textfield-counter',
-    inputMode: 'numeric',
-  },
+  render: () => (
+    <Textfield
+      id="textfield-counter"
+      multiline
+      rows={4}
+      label="Legg til en beskrivelse"
+      counter={75}
+    />
+  ),
 });
 
 export const Controlled = meta.story({

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -130,8 +130,11 @@ export const Affix = meta.story({
 
 export const Counter = meta.story({
   args: {
-    counter: 10,
-    label: 'Hvor mange kroner koster det per måned?',
+    counter: {
+      limit: 11,
+      over: 'Fødselsnummer må være 11 siffer',
+    },
+    label: 'Fødselsnummer',
     id: 'textfield-counter',
     inputMode: 'numeric',
   },

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -1,9 +1,11 @@
+import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Button } from '../button/Button';
 import { Divider } from '../divider/Divider';
 import { Paragraph } from '../typography/paragraph/Paragraph';
+import { ValidationMessage } from '../typography/validationMessage/ValidationMessage';
 import { Textfield } from './Textfield';
 
 const meta = preview.meta({
@@ -138,6 +140,41 @@ export const Counter = meta.story({
       counter={75}
     />
   ),
+});
+
+export const Format = meta.story({
+  render: () => {
+    const [nationalIdentityNumber, setNationalIdentityNumber] =
+      useState<string>('');
+    const tooLong = nationalIdentityNumber.length > 11;
+    const hasNonDigits = /\D/.test(nationalIdentityNumber);
+
+    const updateNumber = (e: ChangeEvent<HTMLInputElement>) => {
+      // removing spaces from stored value so users can space how they like withour error message
+      setNationalIdentityNumber(e.target.value.replace(/\s+/g, ''));
+    };
+
+    return (
+      <>
+        <Textfield
+          label="Fødselsnummer"
+          id="format"
+          inputMode="numeric"
+          onChange={(e) => updateNumber(e)}
+        />
+        {tooLong && (
+          <ValidationMessage>
+            Fødselsnummer skal kun være 11 tegn
+          </ValidationMessage>
+        )}
+        {hasNonDigits && (
+          <ValidationMessage>
+            Fødselsnummer skal kun inneholde siffere
+          </ValidationMessage>
+        )}
+      </>
+    );
+  },
 });
 
 export const Controlled = meta.story({

--- a/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
+++ b/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
@@ -56,15 +56,15 @@ exports[`Counter 1`] = `
     data-weight="medium"
     for="textfield-counter"
   >
-    Fødselsnummer
+    Legg til en beskrivelse
   </label>
   <div>
-    <input
+    <textarea
       id="textfield-counter"
-      inputmode="numeric"
-      type="text"
+      rows="4"
       aria-describedby="textfield-counter:description:1"
     >
+    </textarea>
   </div>
   <div aria-live="polite">
   </div>
@@ -72,14 +72,14 @@ exports[`Counter 1`] = `
     data-variant="default"
     aria-hidden="true"
   >
-    11 tegn igjen
+    75 tegn igjen
   </p>
   <div
     aria-hidden="true"
     data-field="description"
     id="textfield-counter:description:1"
   >
-    Maks 11 tegn tillatt.
+    Maks 75 tegn tillatt.
   </div>
 </div>
 `;
@@ -129,6 +129,24 @@ exports[`Focused 1`] = `
   <div>
     <input
       id="textfield-preview"
+      type="text"
+    >
+  </div>
+</div>
+`;
+
+exports[`Format 1`] = `
+<div>
+  <label
+    data-weight="medium"
+    for="format"
+  >
+    Fødselsnummer
+  </label>
+  <div>
+    <input
+      id="format"
+      inputmode="numeric"
       type="text"
     >
   </div>

--- a/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
+++ b/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
@@ -56,7 +56,7 @@ exports[`Counter 1`] = `
     data-weight="medium"
     for="textfield-counter"
   >
-    Hvor mange kroner koster det per måned?
+    Fødselsnummer
   </label>
   <div>
     <input
@@ -72,14 +72,14 @@ exports[`Counter 1`] = `
     data-variant="default"
     aria-hidden="true"
   >
-    10 tegn igjen
+    11 tegn igjen
   </p>
   <div
     aria-hidden="true"
     data-field="description"
     id="textfield-counter:description:1"
   >
-    Maks 10 tegn tillatt.
+    Maks 11 tegn tillatt.
   </div>
 </div>
 `;


### PR DESCRIPTION
## Hva er gjort?

Skrevet litt mer om best practice rundt bruk av counter og antall tegn-validering _uten_ counter for `Field` og `TextField`. Fikset rart eksempel og lagt til nytt et nytt for fødselsnummer. 

Se kilder her: 
- https://github.com/digdir/designsystemet/issues/3814
- https://udir.atlassian.net/jira/software/c/projects/DESIGN/boards/129?assignee=712020:8835e9d8-527d-4d31-b49d-25c25ae59ec5&selectedIssue=DESIGN-489
- https://aksel.nav.no/monster-maler/soknadsdialog/monster-for-skjemavalidering#e631b79f5206

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog