### PR TITLE
fix(FileUpload): add primary variant as option for triggers

### DIFF
--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -21,6 +21,7 @@ export const FileUploadDropzone = forwardRef<
     label,
     error,
     description,
+    variant = 'secondary',
     inputProps,
     ...rest
   },
@@ -60,7 +61,7 @@ export const FileUploadDropzone = forwardRef<
         {/* Text in css */}
         <div>{/* Text in css */}</div>
         {!inputProps?.readOnly && (
-          <Button variant="secondary" ref={buttonRef}>
+          <Button variant={variant} ref={buttonRef}>
             <UploadIcon aria-hidden />
             {/* Text in css */}
           </Button>

--- a/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
@@ -37,6 +37,12 @@ export type FileUploadProps = HTMLAttributes<HTMLDivElement> & {
    * Props for the input field
    */
   inputProps?: InputProps_;
+  /**
+   *  Specify which variant of
+   *  the button to use
+   *  @default 'secondary'
+   */
+  variant?: 'primary' | 'secondary';
 };
 
 export const FileUploadTrigger = forwardRef<HTMLDivElement, FileUploadProps>(
@@ -47,6 +53,7 @@ export const FileUploadTrigger = forwardRef<HTMLDivElement, FileUploadProps>(
       label,
       error,
       description,
+      variant = 'secondary',
       inputProps,
       ...rest
     },
@@ -78,7 +85,7 @@ export const FileUploadTrigger = forwardRef<HTMLDivElement, FileUploadProps>(
         {!!description && <Field.Description>{description}</Field.Description>}
         <Button
           disabled={inputProps?.readOnly ?? inputProps?.disabled}
-          variant="secondary"
+          variant={variant}
           onClick={() => {
             fileInputRef.current?.click();
           }}


### PR DESCRIPTION
## Hva er gjort?

Button i `Trigger` og `Dropzone` kan nå fås i variant `primary`. `Secondary` er fortsatt default verdi

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
