### PR TITLE
build: storybook build now depends on branch name

### DIFF
--- a/@udir-design/react/project.json
+++ b/@udir-design/react/project.json
@@ -32,7 +32,14 @@
       "outputs": ["{projectRoot}/dist"]
     },
     "build:storybook": {
-      "inputs": ["default", "^default", "{workspaceRoot}/README.md"],
+      "inputs": [
+        "default",
+        "^default",
+        "{workspaceRoot}/README.md",
+        // The Storybook build now "bakes in" links to the current git branch, so the branch must be part of the hash
+        { "env": "GITHUB_HEAD_REF" },
+        { "runtime": "git rev-parse --abbrev-ref HEAD" }
+      ],
       "dependsOn": ["build"],
       "cache": true,
       "outputs": ["{projectRoot}/storybook-static"]


### PR DESCRIPTION
Fixes incorrect branch in links due to cache