### PR TITLE
feat(TableOfContents): support controlled state through `open` and `onToggle` props

### DIFF
--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
@@ -74,6 +74,14 @@ Dersom du har behov for full kontroll over innholdet i `TableOfContents` kan du 
   story={{ inline: false, height: '450px' }}
 />
 
+### Kontrollert tilstand
+
+`TableOfContents` holder selv styr på om den er åpen eller lukket, men dette kan også kontrolleres ved å bruke `open` og `onToggle`. For eksempel kan vi styre tilstanden basert basert på om innholdsfortegnelsen er synlig eller ikke.
+
+<Canvas
+  of={TableOfContentStories.ControlledState}
+  story={{ inline: false, height: '450px' }}
+/>
 ## Retningslinjer
 
 `h1` skal ikke inngå i en `TableOfContents`.

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.stories.tsx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.stories.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useRef, useState } from 'react';
 import { expect, within } from 'storybook/test';
 import { withScrollHashBehavior } from '.storybook/decorators/withScrollHashBehavior';
 import preview from '.storybook/preview';
+import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { useTableOfContents } from 'src/utilities/hooks/useTableOfContents/useTableOfContents';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
@@ -236,5 +238,85 @@ export const DefaultClosed = meta.story({
   args: {
     ...automaticBase.args,
     defaultClosed: true,
+  },
+});
+
+export const ControlledState = meta.story({
+  parameters: {
+    docs: advancedCodeDocs,
+  },
+  args: {
+    headings: [], // we generate these using useTableOfContents inside the story
+    'data-color': 'neutral',
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    const tocRef = useRef<HTMLDivElement>(null);
+    const tocData = useTableOfContents();
+
+    // Use an IntersectionObserver to auto-close the ToC when it starts to go out of view, and
+    // auto-open it again when we scroll it back into view.
+    useEffect(() => {
+      if (!tocRef.current) return;
+      let autoCloseTime: number | undefined;
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (!entries[0].isIntersecting) {
+            autoCloseTime = entries[0].time;
+            setOpen(false);
+          }
+          if (
+            entries[0].isIntersecting &&
+            autoCloseTime &&
+            // Only auto-open if 500 ms has passed since auto-close, so we don't end up in a feedback loop
+            // when closing the ToC makes it visible again
+            entries[0].time > autoCloseTime + 500
+          ) {
+            setOpen(true);
+          }
+        },
+        {
+          root: document,
+          threshold: 0.9,
+        },
+      );
+      observer.observe(tocRef.current);
+      return () => observer.disconnect();
+    }, []);
+
+    return (
+      <Prose>
+        <TableOfContents
+          {...args}
+          {...tocData}
+          style={{ maxWidth: '450px' }}
+          data-testid="table-of-contents"
+          ref={tocRef}
+          open={open}
+          onToggle={() => {
+            setOpen((prev) => !prev);
+          }}
+        />
+        <Paragraph>
+          I dette eksempelet lukker vi innholdsfortegnelsen når den er mindre
+          enn 90% synlig, og åpner den når den blir synlig igjen.
+        </Paragraph>
+        <Heading id="forste-overskrift" level={2} data-size="md">
+          Første overskrift (h2)
+        </Heading>
+        <Heading id="forste-underoverskrift" level={3} data-size="sm">
+          Første underoverskrift (h3)
+        </Heading>
+        <Heading id="andre-underoverskrift" level={3} data-size="sm">
+          Andre underoverskrift (h3)
+        </Heading>
+        <Heading id="andre-overskrift" level={2} data-size="md">
+          Andre overskrift (h2)
+        </Heading>
+        <Heading id="tredje-overskrift" level={2} data-size="md">
+          Tredje overskrift (h2)
+        </Heading>
+      </Prose>
+    );
   },
 });

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.tsx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.tsx
@@ -2,8 +2,9 @@ import type { Color } from '@digdir/designsystemet-types';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
 import { ArrowDownRightIcon } from '@udir-design/icons';
-import type { CardProps as DigdirCardProps } from '../card/Card';
+import type { CardProps } from '../card/Card';
 import { Card } from '../card/Card';
+import type { DetailsProps } from '../details/Details';
 import { Details } from '../details/Details';
 import { Link } from '../link/Link';
 import './tableOfContents.css';
@@ -15,7 +16,7 @@ export type TocHeading = {
 };
 
 export type TableOfContentsProps = Omit<
-  DigdirCardProps,
+  CardProps,
   'data-color' | 'asChild' | 'children'
 > & {
   /**
@@ -28,13 +29,43 @@ export type TableOfContentsProps = Omit<
    * @default false
    */
   defaultClosed?: boolean;
-};
+  /**
+   * Controls open-state.
+   *
+   * Using this removes automatic control of open-state
+   *
+   * @default undefined
+   */
+  open?: boolean;
+  /**
+   * Callback function when TableOfContents toggles due to click on summary or find in page-search
+   */
+  onToggle?: (event: Event) => void;
+} & (
+    | {
+        open: boolean;
+        onToggle: (event: Event) => void;
+      }
+    | {
+        open?: never;
+        onToggle?: (event: Event) => void;
+      }
+  );
 
 export const TableOfContents = forwardRef<HTMLDivElement, TableOfContentsProps>(
   function TableOfContents(
-    { headings, variant, defaultClosed = false, className, ...rest },
+    {
+      headings,
+      variant,
+      defaultClosed = false,
+      className,
+      open,
+      onToggle,
+      ...rest
+    },
     ref,
   ) {
+    const detailsProps = { open, onToggle } as DetailsProps;
     return (
       <Card
         variant={variant}
@@ -42,7 +73,7 @@ export const TableOfContents = forwardRef<HTMLDivElement, TableOfContentsProps>(
         ref={ref}
         {...rest}
       >
-        <Details defaultOpen={!defaultClosed}>
+        <Details defaultOpen={!defaultClosed} {...detailsProps}>
           <Details.Summary>Innhold på denne siden</Details.Summary>
           <Details.Content>
             <ol>

--- a/@udir-design/react/src/components/tableOfContents/__snapshots__/TableOfContents.stories.tsx.snap
+++ b/@udir-design/react/src/components/tableOfContents/__snapshots__/TableOfContents.stories.tsx.snap
@@ -153,6 +153,188 @@ exports[`Automatic 1`] = `
 </div>
 `;
 
+exports[`Controlled State 1`] = `
+<div>
+  <div
+    data-variant="default"
+    data-color="neutral"
+    style="max-width: 450px;"
+  >
+    <u-details
+      open
+      data-variant="default"
+      role="group"
+    >
+      <u-summary
+        aria-expanded="true"
+        role="button"
+        slot="summary"
+        tabindex="0"
+      >
+        Innhold på denne siden
+      </u-summary>
+      <div>
+        <ol>
+          <li>
+            <a href="#forste-overskrift">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M4.5 3.25a.75.75 0 0 1 .75.75v6c0 .69.56 1.25 1.25 1.25h10.69l-3.22-3.22a.75.75 0 1 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H6.5A2.75 2.75 0 0 1 3.75 10V4a.75.75 0 0 1 .75-.75"
+                >
+                </path>
+              </svg>
+              <span>
+                Første overskrift (h2)
+              </span>
+            </a>
+          </li>
+          <li>
+            <a href="#forste-underoverskrift">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M4.5 3.25a.75.75 0 0 1 .75.75v6c0 .69.56 1.25 1.25 1.25h10.69l-3.22-3.22a.75.75 0 1 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H6.5A2.75 2.75 0 0 1 3.75 10V4a.75.75 0 0 1 .75-.75"
+                >
+                </path>
+              </svg>
+              <span>
+                Første underoverskrift (h3)
+              </span>
+            </a>
+          </li>
+          <li>
+            <a href="#andre-underoverskrift">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M4.5 3.25a.75.75 0 0 1 .75.75v6c0 .69.56 1.25 1.25 1.25h10.69l-3.22-3.22a.75.75 0 1 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H6.5A2.75 2.75 0 0 1 3.75 10V4a.75.75 0 0 1 .75-.75"
+                >
+                </path>
+              </svg>
+              <span>
+                Andre underoverskrift (h3)
+              </span>
+            </a>
+          </li>
+          <li>
+            <a href="#andre-overskrift">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M4.5 3.25a.75.75 0 0 1 .75.75v6c0 .69.56 1.25 1.25 1.25h10.69l-3.22-3.22a.75.75 0 1 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H6.5A2.75 2.75 0 0 1 3.75 10V4a.75.75 0 0 1 .75-.75"
+                >
+                </path>
+              </svg>
+              <span>
+                Andre overskrift (h2)
+              </span>
+            </a>
+          </li>
+          <li>
+            <a href="#tredje-overskrift">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  d="M4.5 3.25a.75.75 0 0 1 .75.75v6c0 .69.56 1.25 1.25 1.25h10.69l-3.22-3.22a.75.75 0 1 1 1.06-1.06l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H6.5A2.75 2.75 0 0 1 3.75 10V4a.75.75 0 0 1 .75-.75"
+                >
+                </path>
+              </svg>
+              <span>
+                Tredje overskrift (h2)
+              </span>
+            </a>
+          </li>
+        </ol>
+      </div>
+    </u-details>
+  </div>
+  <p data-variant="default">
+    I dette eksempelet lukker vi innholdsfortegnelsen når den er mindre enn 90% synlig, og åpner den når den blir synlig igjen.
+  </p>
+  <h2
+    data-size="md"
+    id="forste-overskrift"
+    tabindex="-1"
+  >
+    Første overskrift (h2)
+  </h2>
+  <h3
+    data-size="sm"
+    id="forste-underoverskrift"
+    tabindex="-1"
+  >
+    Første underoverskrift (h3)
+  </h3>
+  <h3
+    data-size="sm"
+    id="andre-underoverskrift"
+    tabindex="-1"
+  >
+    Andre underoverskrift (h3)
+  </h3>
+  <h2
+    data-size="md"
+    id="andre-overskrift"
+    tabindex="-1"
+  >
+    Andre overskrift (h2)
+  </h2>
+  <h2
+    data-size="md"
+    id="tredje-overskrift"
+    tabindex="-1"
+  >
+    Tredje overskrift (h2)
+  </h2>
+</div>
+`;
+
 exports[`Default Closed 1`] = `
 <div>
   <h1


### PR DESCRIPTION
## Hva er gjort?

Lagt til relevante props frå `Details` for å kontrollere tilstand: `open` og `onToggle`. Gjort det på samme måten som i `Details` slik at dersom du setter `open` til ein verdi **må** du også sette `onToggle`

Eg kunne ikkje endre base-props frå `CardProps` til `DetailsProps` sidan `Card` forventer props for `HTMLDivElement`, medan`DetailsProps` inneheld props for `HTMLDetailsElement`

Har lagt til story som demonstrerer kontrollert tilstand med IntersectionObserver for auto-lukking.

## Sjekkliste


- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
