### PR TITLE
fix: active drop styling fileupload

### DIFF
--- a/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
@@ -32,21 +32,22 @@ export const DocumentationPage = ({
     );
   };
 
-  const { getRootProps, getInputProps } = useDropzone({
-    onDropAccepted: (file) => {
-      setValue('documentation', [...uploadedFiles, ...file], {
-        shouldValidate: true,
-      });
-    },
-    onDropRejected: (rej) => {
-      setRejected((prev) => [...prev, ...rej]);
-    },
-    maxSize: 25000000,
-    multiple: true,
-    accept: {
-      'application/pdf': [],
-    },
-  });
+  const { getRootProps, getInputProps, isDragGlobal, isDragActive } =
+    useDropzone({
+      onDropAccepted: (file) => {
+        setValue('documentation', [...uploadedFiles, ...file], {
+          shouldValidate: true,
+        });
+      },
+      onDropRejected: (rej) => {
+        setRejected((prev) => [...prev, ...rej]);
+      },
+      maxSize: 25000000,
+      multiple: true,
+      accept: {
+        'application/pdf': [],
+      },
+    });
 
   return (
     <>
@@ -58,7 +59,6 @@ export const DocumentationPage = ({
         label={<span>Last opp dokumentasjon</span>}
         description="Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB."
         {...getRootProps()}
-        error={errors.documentation?.message}
         inputProps={{
           ...getInputProps({
             required: true,
@@ -66,6 +66,9 @@ export const DocumentationPage = ({
           }),
           id: 'dokumentasjon-dropzone',
         }}
+        isDragActive={isDragActive}
+        isDragGlobal={isDragGlobal}
+        error={errors.documentation?.message}
         aria-invalid={!!errors.documentation}
       />
       {uploadedFiles.length > 0 && (

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -35,6 +35,8 @@ Det finnes flere måter å håndtere opplasting av filer. Se eksempler på dette
 
 Varianten `FileUpload.Dropzone`er et stipla område med en knapp inni, ment å bruke for dra og slipp ved filopplasting. I dette eksempelet bruker vi [biblioteket `react-dropzone`](https://react-dropzone.js.org/). Komponenten er utviklet slik at den støtter dette biblioteket, men man står fritt til å velge løsningen man selv ønsker.
 
+Komponenten er stylet slik at man kan bruke `isDragActive` for å endre utseendet på dropzone når brukeren holder en fil over den. Du kan også bruke `isDragGlobal` for å utheve dropzone når brukeren drar en fil over vinduet. Disse propertiesene får du ut av boksen med `react-dropzone`, men du kan også skrive din egen logikk så lenge du bruker samme property-navn. Se eksempelet under for hvordan dette ser ut.
+
 <Canvas of={FileUploadStories.ExampleDropZone} />
 
 ### Knapp

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -25,21 +25,22 @@ export const Preview = meta.story({
     description: 'Beskrivelse',
   },
   render: (args) => {
-    const { getRootProps, getInputProps } = useDropzone({
-      onDropAccepted: (files) => {
-        window.alert(
-          `Accepted dropped file(s):\n  - ${files.map((x) => x.name).join(',\n  - ')}`,
-        );
-      },
-      onDropRejected: (rej) => {
-        window.alert(
-          `Rejected dropped file(s):\n  - ${rej.map((x) => `${x.file.name} (reason: ${x.errors.map((err) => err.message).join(', ')})`).join(',\n  - ')}`,
-        );
-      },
-      accept: {
-        'application/pdf': [],
-      },
-    });
+    const { getRootProps, getInputProps, isDragActive, isDragGlobal } =
+      useDropzone({
+        onDropAccepted: (files) => {
+          window.alert(
+            `Accepted dropped file(s):\n  - ${files.map((x) => x.name).join(',\n  - ')}`,
+          );
+        },
+        onDropRejected: (rej) => {
+          window.alert(
+            `Rejected dropped file(s):\n  - ${rej.map((x) => `${x.file.name} (reason: ${x.errors.map((err) => err.message).join(', ')})`).join(',\n  - ')}`,
+          );
+        },
+        accept: {
+          'application/pdf': [],
+        },
+      });
     return (
       <div
         style={{
@@ -55,6 +56,8 @@ export const Preview = meta.story({
         <FileUpload.Dropzone
           {...getRootProps(args)}
           inputProps={getInputProps({ ...args.inputProps, id: 'dropzone' })}
+          isDragGlobal={isDragGlobal}
+          isDragActive={isDragActive}
         />
       </div>
     );
@@ -108,18 +111,19 @@ export const ExampleDropZone = meta.story({
       );
     };
 
-    const { getRootProps, getInputProps } = useDropzone({
-      onDropAccepted: (file) => {
-        setFiles((prev) => [...prev, ...file]);
-      },
-      onDropRejected: (rej) => {
-        setRejected((prev) => [...prev, ...rej]);
-      },
-      maxSize: 5242880,
-      accept: {
-        'application/pdf': [],
-      },
-    });
+    const { getRootProps, getInputProps, isDragActive, isDragGlobal } =
+      useDropzone({
+        onDropAccepted: (file) => {
+          setFiles((prev) => [...prev, ...file]);
+        },
+        onDropRejected: (rej) => {
+          setRejected((prev) => [...prev, ...rej]);
+        },
+        maxSize: 5242880,
+        accept: {
+          'application/pdf': [],
+        },
+      });
 
     return (
       <div
@@ -136,6 +140,8 @@ export const ExampleDropZone = meta.story({
             ...getInputProps(),
             id: 'dokumentasjon',
           }}
+          isDragGlobal={isDragGlobal}
+          isDragActive={isDragActive}
           data-testid="dropzone"
           error={files.length > 2 && 'Du har lastet opp for mange filer.'}
           {...getRootProps()}
@@ -215,12 +221,13 @@ export const TooManyFiles = meta.story({
       );
     };
 
-    const { getRootProps, getInputProps } = useDropzone({
-      onDropAccepted: (file) => {
-        setFiles((prev) => [...prev, ...file]);
-      },
-      multiple: true,
-    });
+    const { getRootProps, getInputProps, isDragActive, isDragGlobal } =
+      useDropzone({
+        onDropAccepted: (file) => {
+          setFiles((prev) => [...prev, ...file]);
+        },
+        multiple: true,
+      });
 
     return (
       <div
@@ -240,6 +247,8 @@ export const TooManyFiles = meta.story({
           }
           inputProps={{ ...getInputProps(), id: 'dokumentasjon-for-mange' }}
           {...getRootProps()}
+          isDragGlobal={isDragGlobal}
+          isDragActive={isDragActive}
           style={{ maxWidth: '450px', width: '100%' }}
           {...args}
         />

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -37,6 +37,7 @@ export const Preview = meta.story({
             `Rejected dropped file(s):\n  - ${rej.map((x) => `${x.file.name} (reason: ${x.errors.map((err) => err.message).join(', ')})`).join(',\n  - ')}`,
           );
         },
+        multiple: false,
         accept: {
           'application/pdf': [],
         },

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -9,7 +9,18 @@ import { Label } from '../typography/label/Label';
 import { ValidationMessage } from '../typography/validationMessage/ValidationMessage';
 import type { FileUploadProps } from './FileUploadTrigger';
 
-export type FileUploadDropzoneProps = FileUploadProps;
+export type FileUploadDropzoneProps = FileUploadProps & {
+  /**
+   * True if the user holds files
+   * over the drop-area
+   */
+  isDragActive?: boolean;
+  /**
+   * True if the user holds files
+   * anywhere in the document
+   */
+  isDragGlobal?: boolean;
+};
 
 export const FileUploadDropzone = forwardRef<
   HTMLDivElement,
@@ -21,6 +32,8 @@ export const FileUploadDropzone = forwardRef<
     label,
     error,
     description,
+    isDragActive,
+    isDragGlobal,
     variant = 'secondary',
     inputProps,
     ...rest
@@ -52,6 +65,8 @@ export const FileUploadDropzone = forwardRef<
         }
         rest.onDrop?.(e);
       }}
+      data-drag-active={isDragActive || undefined}
+      data-drag-global={isDragGlobal || undefined}
       ref={ref}
       {...rest}
     >

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -712,7 +712,7 @@ exports[`Preview 1`] = `
       <button
         data-variant="secondary"
         type="button"
-        aria-label="Velg filer"
+        aria-label="Velg fil"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -736,7 +736,6 @@ exports[`Preview 1`] = `
     </div>
     <input
       accept="application/pdf"
-      multiple
       tabindex="-1"
       id="dropzone"
       type="file"

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -6,6 +6,8 @@
   --udsc-fileUpload-chooseFiles-text: 'Velg filer';
   --udsc-fileUpload-dropFile-text: 'Dra og slipp filen her';
   --udsc-fileUpload-dropFiles-text: 'Dra og slipp filer her';
+  --udsc-fileUpload-dropFile-active-text: 'Slipp filen her';
+  --udsc-fileUpload-dropFiles-active-text: 'Slipp filen(e) her';
   --udsc-fileUpload-or-text: 'eller';
   --udsc-fileUpload-uploading-text: 'Laster opp...';
   --udsc-fileUpload-removeFile-text: 'Fjern filen';
@@ -20,6 +22,8 @@
   --udsc-fileUpload-chooseFiles-text: 'Vel filer';
   --udsc-fileUpload-dropFile-text: 'Dra og slepp fila her';
   --udsc-fileUpload-dropFiles-text: 'Dra og slepp filer her';
+  --udsc-fileUpload-dropFile-active-text: 'Slepp fila her';
+  --udsc-fileUpload-dropFiles-active-text: 'Slepp filan(e) her';
   --udsc-fileUpload-or-text: 'eller';
   --udsc-fileUpload-uploading-text: 'Lastar opp...';
   --udsc-fileUpload-removeFile-text: 'Fjern fila';
@@ -34,6 +38,8 @@
   --udsc-fileUpload-chooseFiles-text: 'Choose files';
   --udsc-fileUpload-dropFile-text: 'Drag and drop file here';
   --udsc-fileUpload-dropFiles-text: 'Drag and drop files here';
+  --udsc-fileUpload-dropFile-active-text: 'Drop the file here';
+  --udsc-fileUpload-dropFiles-active-text: 'Drop the files here';
   --udsc-fileUpload-or-text: 'or';
   --udsc-fileUpload-uploading-text: 'Uploading...';
   --udsc-fileUpload-removeFile-text: 'Remove file';
@@ -72,6 +78,34 @@
     gap: var(--ds-size-2);
     --dsc-card-border-style: dashed;
     --dsc-card-border-color: var(--ds-color-border-strong);
+  }
+
+  &[data-drag-global]:not([data-drag-active]),
+  &[data-drag-active] {
+    --udsc-fileUpload-dropzone-text: var(
+      --udsc-fileUpload-dropFile-active-text
+    );
+
+    &:has(input[type='file'][multiple]) {
+      --udsc-fileUpload-dropzone-text: var(
+        --udsc-fileUpload-dropFiles-active-text
+      );
+
+      > .ds-card {
+        --udsc-fileUpload-dropzone-text: var(
+          --udsc-fileUpload-dropFiles-active-text
+        );
+      }
+    }
+  }
+
+  &[data-drag-global]:not([data-drag-active]) > .ds-card {
+    background: var(--ds-color-surface-tinted);
+  }
+
+  &[data-drag-active] > .ds-card {
+    background: var(--ds-color-surface-active);
+    --dsc-card-border-style: solid;
   }
 
   &:has(input[readOnly]) {


### PR DESCRIPTION
## Hva er gjort?

Extenda typen for `FileUpload.Dropzone` til å inkludere isDragActive og isDragGlobal som brukes i biblioketet _react-dropzone_. Disse brukes til å sette data-attribute som brukes til å stilsette komponenten i disse tilstandene. 

Oppdatert eksempler i storybook til å bruke disser propsa. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er testet i test-app