### PR TITLE
refactor(FileUpload): move compound component from index.ts to FileUpload.tsx so github link works

### DIFF
--- a/@udir-design/react/src/components/fileUpload/FileUpload.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.tsx
@@ -1,0 +1,39 @@
+import { FileUploadDropzone } from './FileUploadDropzone';
+import { FileUploadItem } from './FileUploadItem';
+import { FileUploadTrigger } from './FileUploadTrigger';
+
+export type FileUpload = {
+  /**
+   * Component that provides a file upload button.
+   *
+   * @example
+   * <FileUpload.Trigger />
+   */
+  Trigger: typeof FileUploadTrigger;
+  /**
+   * Component that provides a dropzone
+   * for file upload
+   *
+   * @example
+   * <FileUpload.Dropzone />
+   */
+  Dropzone: typeof FileUploadDropzone;
+  /**
+   * Component that previews a file
+   * uploaded by the user
+   *
+   * @example
+   * <FileUpload.Item />
+   */
+  Item: typeof FileUploadItem;
+};
+
+export const FileUpload: FileUpload = {
+  Trigger: FileUploadTrigger,
+  Dropzone: FileUploadDropzone,
+  Item: FileUploadItem,
+};
+
+FileUpload.Trigger.displayName = 'FileUpload.Trigger';
+FileUpload.Dropzone.displayName = 'FileUpload.Dropzone';
+FileUpload.Item.displayName = 'FileUpload.Item';

--- a/@udir-design/react/src/components/fileUpload/index.ts
+++ b/@udir-design/react/src/components/fileUpload/index.ts
@@ -1,48 +1,8 @@
+import { FileUpload } from './FileUpload';
 import { FileUploadDropzone } from './FileUploadDropzone';
 import { FileUploadItem } from './FileUploadItem';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
-type FileUpload = {
-  /**
-   * Component that provides a file upload button.
-   *
-   * @example
-   * <FileUpload.Trigger />
-   */
-  Trigger: typeof FileUploadTrigger;
-  /**
-   * Component that provides a dropzone
-   * for file upload
-   *
-   * @example
-   * <FileUpload.Dropzone />
-   */
-  Dropzone: typeof FileUploadDropzone;
-  /**
-   * Component that previews a file
-   * uploaded by the user
-   *
-   * @example
-   * <FileUpload.Item />
-   */
-  Item: typeof FileUploadItem;
-};
-
-const FileUploadComponent: FileUpload = {
-  Trigger: FileUploadTrigger,
-  Dropzone: FileUploadDropzone,
-  Item: FileUploadItem,
-};
-
-FileUploadComponent.Trigger.displayName = 'FileUpload.Trigger';
-FileUploadComponent.Dropzone.displayName = 'FileUpload.Dropzone';
-FileUploadComponent.Item.displayName = 'FileUpload.Item';
-
 export type { FileUploadProps } from './FileUploadTrigger';
 export type { FileUploadItemProps } from './FileUploadItem';
-export {
-  FileUploadComponent as FileUpload,
-  FileUploadDropzone,
-  FileUploadItem,
-  FileUploadTrigger,
-};
+export { FileUpload, FileUploadDropzone, FileUploadItem, FileUploadTrigger };


### PR DESCRIPTION
## Hva er gjort?

"See source code"-menyen si lenke til komponent-kildekoden for FileUpload funka ikkje fordi det ikkje var ei fil som heitte `FileUpload.tsx`. Flytta derfor definisjonen av den samansatte komponente frå `index.ts` til ny fil `FileUpload.tsx`. Eksporten skjer framleis i `index.ts`.

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog
