### PR TITLE
docs: improved props docs subcomponents

### DIFF
--- a/@udir-design/react/.storybook/main.ts
+++ b/@udir-design/react/.storybook/main.ts
@@ -90,6 +90,7 @@ export default defineMain({
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
+      setDisplayName: false,
       propFilter: (prop) => {
         // Remove popovertarget prop which @digdir/designsystemet-react adds to all elements
         if (prop.name === 'popovertarget') {

--- a/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
@@ -19,9 +19,20 @@ import { Badge } from '../badge/Badge';
 import { Button } from '../button/Button';
 import { Divider } from '../divider/Divider';
 import { Dropdown } from './Dropdown';
+import { Dropdown as FakeDropdown } from './docs/FakeDropdown';
+import { DropdownButton } from './docs/FakeDropdownButton';
+import { DropdownHeading } from './docs/FakeDropdownHeading';
+import { DropdownTrigger } from './docs/FakeDropdownTrigger';
+import { DropdownTriggerContext } from './docs/FakeDropdownTriggerContext';
 
 const meta = preview.meta({
-  component: Dropdown,
+  component: FakeDropdown,
+  subcomponents: {
+    'Dropdown.Button': DropdownButton,
+    'Dropdown.Heading': DropdownHeading,
+    'Dropdown.Trigger': DropdownTrigger,
+    'Dropdown.TriggerContext': DropdownTriggerContext,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
@@ -18,9 +18,20 @@ import { Badge } from '../badge/Badge';
 import { Button } from '../button/Button';
 import { Divider } from '../divider/Divider';
 import { Dropdown } from './Dropdown';
+import { Dropdown as FakeDropdown } from './docs/FakeDropdown';
+import { DropdownButton } from './docs/FakeDropdownButton';
+import { DropdownHeading } from './docs/FakeDropdownHeading';
+import { DropdownTrigger } from './docs/FakeDropdownTrigger';
+import { DropdownTriggerContext } from './docs/FakeDropdownTriggerContext';
 
 const meta = preview.meta({
-  component: Dropdown,
+  component: FakeDropdown,
+  subcomponents: {
+    'Dropdown.Button': DropdownButton,
+    'Dropdown.Heading': DropdownHeading,
+    'Dropdown.Trigger': DropdownTrigger,
+    'Dropdown.TriggerContext': DropdownTriggerContext,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/dropdown/docs/FakeDropdown.tsx
+++ b/@udir-design/react/src/components/dropdown/docs/FakeDropdown.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { DropdownProps } from '../Dropdown';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Dropdown directly :(
+ */
+export const Dropdown: FunctionComponent<DropdownProps> = () => null;

--- a/@udir-design/react/src/components/dropdown/docs/FakeDropdownButton.tsx
+++ b/@udir-design/react/src/components/dropdown/docs/FakeDropdownButton.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { DropdownButtonProps } from '../Dropdown';
+
+/**
+ * This component only exists to add relevant html props for DropdownButton
+ */
+export const DropdownButton: FunctionComponent<DropdownButtonProps> = () =>
+  null;

--- a/@udir-design/react/src/components/dropdown/docs/FakeDropdownHeading.tsx
+++ b/@udir-design/react/src/components/dropdown/docs/FakeDropdownHeading.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { DropdownHeadingProps } from '../Dropdown';
+
+/**
+ * This component only exists to add relevant html props for DropdownHeading
+ */
+export const DropdownHeading: FunctionComponent<DropdownHeadingProps> = () =>
+  null;

--- a/@udir-design/react/src/components/dropdown/docs/FakeDropdownTrigger.tsx
+++ b/@udir-design/react/src/components/dropdown/docs/FakeDropdownTrigger.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { DropdownButtonProps } from '../Dropdown';
+
+/**
+ * This component only exists to add relevant html props for DropdownTrigger
+ */
+export const DropdownTrigger: FunctionComponent<DropdownButtonProps> = () =>
+  null;

--- a/@udir-design/react/src/components/dropdown/docs/FakeDropdownTriggerContext.tsx
+++ b/@udir-design/react/src/components/dropdown/docs/FakeDropdownTriggerContext.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { DropdownTriggerContextProps } from '../Dropdown';
+
+/**
+ * This component only exists to add relevant html props for DropdownTriggerContext
+ */
+export const DropdownTriggerContext: FunctionComponent<
+  DropdownTriggerContextProps
+> = () => null;

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
@@ -6,9 +6,20 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 import { Button } from '../button/Button';
 import { Textfield } from '../textfield/Textfield';
 import { ErrorSummary } from './ErrorSummary';
+import { ErrorSummary as FakeErrorSummary } from './docs/FakeErrorSummary';
+import { ErrorSummaryHeading } from './docs/FakeErrorSummaryHeading';
+import { ErrorSummaryItem } from './docs/FakeErrorSummaryItem';
+import { ErrorSummaryLink } from './docs/FakeErrorSummaryLink';
+import { ErrorSummaryList } from './docs/FakeErrorSummaryList';
 
 const meta = preview.meta({
-  component: ErrorSummary,
+  component: FakeErrorSummary,
+  subcomponents: {
+    'ErrorSummary.Heading': ErrorSummaryHeading,
+    'ErrorSummary.Item': ErrorSummaryItem,
+    'ErrorSummary.Link': ErrorSummaryLink,
+    'ErrorSummary.List': ErrorSummaryList,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
@@ -7,9 +7,20 @@ import { formatReactSource } from '.storybook/utils/sourceTransformers';
 import { Button } from '../button/Button';
 import { Textfield } from '../textfield/Textfield';
 import { ErrorSummary } from './ErrorSummary';
+import { ErrorSummary as FakeErrorSummary } from './docs/FakeErrorSummary';
+import { ErrorSummaryHeading } from './docs/FakeErrorSummaryHeading';
+import { ErrorSummaryItem } from './docs/FakeErrorSummaryItem';
+import { ErrorSummaryLink } from './docs/FakeErrorSummaryLink';
+import { ErrorSummaryList } from './docs/FakeErrorSummaryList';
 
 const meta = preview.meta({
-  component: ErrorSummary,
+  component: FakeErrorSummary,
+  subcomponents: {
+    'ErrorSummary.Heading': ErrorSummaryHeading,
+    'ErrorSummary.Item': ErrorSummaryItem,
+    'ErrorSummary.Link': ErrorSummaryLink,
+    'ErrorSummary.List': ErrorSummaryList,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.tsx
@@ -4,6 +4,8 @@ import {
   type ErrorSummaryHeadingProps,
   ErrorSummaryItem,
   type ErrorSummaryItemProps,
+  ErrorSummaryLink,
+  type ErrorSummaryLinkProps,
   ErrorSummaryList,
   type ErrorSummaryListProps,
   type ErrorSummaryProps,
@@ -15,6 +17,7 @@ ErrorSummary.displayName = 'ErrorSummary';
 export type {
   ErrorSummaryHeadingProps,
   ErrorSummaryItemProps,
+  ErrorSummaryLinkProps,
   ErrorSummaryListProps,
   ErrorSummaryProps,
 };
@@ -22,5 +25,6 @@ export {
   ErrorSummary,
   ErrorSummaryHeading,
   ErrorSummaryItem,
+  ErrorSummaryLink,
   ErrorSummaryList,
 };

--- a/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummary.tsx
+++ b/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummary.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ErrorSummaryProps } from '../ErrorSummary';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for ErrorSummary directly :(
+ */
+export const ErrorSummary: FunctionComponent<ErrorSummaryProps> = () => null;

--- a/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryHeading.tsx
+++ b/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryHeading.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { ErrorSummaryHeadingProps } from '../ErrorSummary';
+
+/**
+ * This component only exists to add relevant html props for ErrorSummaryHeading
+ */
+export const ErrorSummaryHeading: FunctionComponent<
+  ErrorSummaryHeadingProps
+> = () => null;

--- a/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryItem.tsx
+++ b/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryItem.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ErrorSummaryItemProps } from '../ErrorSummary';
+
+/**
+ * This component only exists to add relevant html props for ErrorSummaryItem
+ */
+export const ErrorSummaryItem: FunctionComponent<ErrorSummaryItemProps> = () =>
+  null;

--- a/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryLink.tsx
+++ b/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryLink.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ErrorSummaryLinkProps } from '../ErrorSummary';
+
+/**
+ * This component only exists to add relevant html props for ErrorSummaryLink
+ */
+export const ErrorSummaryLink: FunctionComponent<ErrorSummaryLinkProps> = () =>
+  null;

--- a/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryList.tsx
+++ b/@udir-design/react/src/components/errorSummary/docs/FakeErrorSummaryList.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ErrorSummaryListProps } from '../ErrorSummary';
+
+/**
+ * This component only exists to add relevant html props for ErrorSummaryList
+ */
+export const ErrorSummaryList: FunctionComponent<ErrorSummaryListProps> = () =>
+  null;

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -7,9 +7,14 @@ import { Textarea } from '../textarea/Textarea';
 import { Label } from '../typography/label/Label';
 import { ValidationMessage } from '../typography/validationMessage/ValidationMessage';
 import { Field } from './Field';
+import { Field as FakeField } from './docs/FakeField';
+import { FieldCounter } from './docs/FakeFieldCounter';
 
 const meta = preview.meta({
-  component: Field,
+  component: FakeField,
+  subcomponents: {
+    'Field.Counter': FieldCounter,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/field/docs/FakeField.tsx
+++ b/@udir-design/react/src/components/field/docs/FakeField.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { FieldProps } from '../Field';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Field directly :(
+ */
+export const Field: FunctionComponent<FieldProps> = () => null;

--- a/@udir-design/react/src/components/field/docs/FakeFieldCounter.tsx
+++ b/@udir-design/react/src/components/field/docs/FakeFieldCounter.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { FieldCounterProps } from '../Field';
+
+/**
+ * This component only exists to add relevant html props for FieldCounter
+ */
+export const FieldCounter: FunctionComponent<FieldCounterProps> = () => null;

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -6,10 +6,17 @@ import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Heading } from '../typography/heading/Heading';
+import { FileUploadDropzone } from './docs/FakeFileUploadDropzone';
+import { FileUploadItem } from './docs/FakeFileUploadItem';
+import { FileUploadTrigger } from './docs/FakeFileUploadTrigger';
 import { FileUpload } from './index';
 
 const meta = preview.meta({
-  component: FileUpload.Trigger,
+  component: FileUploadTrigger,
+  subcomponents: {
+    'FileUpload.Dropzone': FileUploadDropzone,
+    'FileUpload.Item': FileUploadItem,
+  },
   tags: ['alpha', 'udir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -5,10 +5,17 @@ import { useDropzone } from 'react-dropzone';
 import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { Heading } from '../typography/heading/Heading';
+import { FileUploadDropzone } from './docs/FakeFileUploadDropzone';
+import { FileUploadItem } from './docs/FakeFileUploadItem';
+import { FileUploadTrigger } from './docs/FakeFileUploadTrigger';
 import { FileUpload } from './index';
 
 const meta = preview.meta({
-  component: FileUpload.Trigger,
+  component: FileUploadTrigger,
+  subcomponents: {
+    'FileUpload.Dropzone': FileUploadDropzone,
+    'FileUpload.Item': FileUploadItem,
+  },
   tags: ['alpha', 'udir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadDropzone.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { FileUploadDropzoneProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for FileUpload.Dropzone
+ */
+export const FileUploadDropzone: FunctionComponent<
+  FileUploadDropzoneProps
+> = () => null;

--- a/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadItem.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { FileUploadItemProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for FileUpload.Item
+ */
+export const FileUploadItem: FunctionComponent<FileUploadItemProps> = () =>
+  null;

--- a/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadTrigger.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { FileUploadProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for FileUpload.Trigger
+ */
+export const FileUploadTrigger: FunctionComponent<FileUploadProps> = () => null;

--- a/@udir-design/react/src/components/fileUpload/index.ts
+++ b/@udir-design/react/src/components/fileUpload/index.ts
@@ -4,5 +4,6 @@ import { FileUploadItem } from './FileUploadItem';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type { FileUploadProps } from './FileUploadTrigger';
+export type { FileUploadDropzoneProps } from './FileUploadDropzone';
 export type { FileUploadItemProps } from './FileUploadItem';
 export { FileUpload, FileUploadDropzone, FileUploadItem, FileUploadTrigger };

--- a/@udir-design/react/src/components/footer/Footer.stories.tsx
+++ b/@udir-design/react/src/components/footer/Footer.stories.tsx
@@ -1,10 +1,17 @@
 import { expect, userEvent, within } from 'storybook/test';
 import { withResponsiveDataSize } from '.storybook/decorators/withResponsiveDataSize';
 import preview from '.storybook/preview';
+import { Footer as FakeFooter } from './docs/FakeFooter';
+import { FooterItem } from './docs/FakeFooterItem';
+import { FooterList } from './docs/FakeFooterList';
 import { Footer } from './';
 
 const meta = preview.meta({
-  component: Footer,
+  component: FakeFooter,
+  subcomponents: {
+    'Footer.List': FooterList,
+    'Footer.Item': FooterItem,
+  },
   tags: ['beta', 'udir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/footer/docs/FakeFooter.tsx
+++ b/@udir-design/react/src/components/footer/docs/FakeFooter.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { FooterProps } from '../Footer';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Footer directly :(
+ */
+export const Footer: FunctionComponent<FooterProps> = () => null;

--- a/@udir-design/react/src/components/footer/docs/FakeFooterItem.tsx
+++ b/@udir-design/react/src/components/footer/docs/FakeFooterItem.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { FooterItemProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for FooterItem
+ */
+export const FooterItem: FunctionComponent<FooterItemProps> = () => null;

--- a/@udir-design/react/src/components/footer/docs/FakeFooterList.tsx
+++ b/@udir-design/react/src/components/footer/docs/FakeFooterList.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { FooterListProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for FooterList
+ */
+export const FooterList: FunctionComponent<FooterListProps> = () => null;

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
@@ -18,11 +18,18 @@ import { Button } from '../button/Button';
 import { Dialog } from '../dialog/Dialog';
 import { Textfield } from '../textfield/Textfield';
 import { Heading } from '../typography/heading/Heading';
+import { FormNavigation as FakeFormNavigation } from './docs/FakeFormNavigation';
+import { FormNavigationGroup } from './docs/FakeFormNavigationGroup';
+import { FormNavigationStep } from './docs/FakeFormNavigationStep';
 import classes from './formNavigation.stories.module.css';
 import { FormNavigation } from '.';
 
 const meta = preview.meta({
-  component: FormNavigation,
+  component: FakeFormNavigation,
+  subcomponents: {
+    'FormNavigation.Group': FormNavigationGroup,
+    'FormNavigation.Step': FormNavigationStep,
+  },
   tags: ['beta', 'udir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/formNavigation/docs/FakeFormNavigation.tsx
+++ b/@udir-design/react/src/components/formNavigation/docs/FakeFormNavigation.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { FormNavigationProps } from '../FormNavigation';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for FormNavigation directly :(
+ */
+export const FormNavigation: FunctionComponent<FormNavigationProps> = () =>
+  null;

--- a/@udir-design/react/src/components/formNavigation/docs/FakeFormNavigationGroup.tsx
+++ b/@udir-design/react/src/components/formNavigation/docs/FakeFormNavigationGroup.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { FormNavigationGroupProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for FormNavigationGroup
+ */
+export const FormNavigationGroup: FunctionComponent<
+  FormNavigationGroupProps
+> = () => null;

--- a/@udir-design/react/src/components/formNavigation/docs/FakeFormNavigationStep.tsx
+++ b/@udir-design/react/src/components/formNavigation/docs/FakeFormNavigationStep.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { FormNavigationStepProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for FormNavigationStep
+ */
+export const FormNavigationStep: FunctionComponent<
+  FormNavigationStepProps
+> = () => null;

--- a/@udir-design/react/src/components/header/Header.stories.tsx
+++ b/@udir-design/react/src/components/header/Header.stories.tsx
@@ -16,10 +16,29 @@ import { Tag } from '../tag/Tag';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 import { Prose } from '../typography/prose/Prose';
+import { Header as FakeHeader } from './docs/FakeHeader';
+import { HeaderMenu } from './docs/FakeHeaderMenu';
+import { HeaderMenuButton } from './docs/FakeHeaderMenuButton';
+import { HeaderMenuLink } from './docs/FakeHeaderMenuLink';
+import { HeaderNavigationItem } from './docs/FakeHeaderNavigationItem';
+import { HeaderSearch } from './docs/FakeHeaderSearch';
+import { HeaderThemeMenuButton } from './docs/FakeHeaderThemeMenuButton';
+import { HeaderUserButton } from './docs/FakeHeaderUserButton';
+import { HeaderNavigation } from './headerNavigation/HeaderNavigation';
 import { Header } from '.';
 
 const meta = preview.meta({
-  component: Header,
+  component: FakeHeader,
+  subcomponents: {
+    'Header.UserButton': HeaderUserButton,
+    'Header.Search': HeaderSearch,
+    'Header.Navigation': HeaderNavigation,
+    'Header.Navigation.Item': HeaderNavigationItem,
+    'Header.MenuButton': HeaderMenuButton,
+    'Header.Menu': HeaderMenu,
+    'Header.Menu.Link': HeaderMenuLink,
+    'Header.ThemeMenuButton': HeaderThemeMenuButton,
+  },
   tags: ['beta', 'udir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/header/docs/FakeHeader.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeader.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderProps } from '../Header';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Header directly :(
+ */
+export const Header: FunctionComponent<HeaderProps> = () => null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderMenu.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderMenu.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderMenuProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for HeaderMenu
+ */
+export const HeaderMenu: FunctionComponent<HeaderMenuProps> = () => null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderMenuButton.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderMenuButton.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderMenuButtonProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for HeaderMenuButton
+ */
+export const HeaderMenuButton: FunctionComponent<HeaderMenuButtonProps> = () =>
+  null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderMenuLink.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderMenuLink.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderMenuLinkProps } from '../headerMenu/index';
+
+/**
+ * This component only exists to add relevant html props for HeaderMenuLink
+ */
+export const HeaderMenuLink: FunctionComponent<HeaderMenuLinkProps> = () =>
+  null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderNavigation.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderNavigation.tsx
@@ -1,0 +1,10 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderNavigationProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for HeaderNavigation
+ */
+export const HeaderNavigation: FunctionComponent<HeaderNavigationProps> = () =>
+  null;
+
+/** NOTE: kommer ikke none props her atm, se på over påske */

--- a/@udir-design/react/src/components/header/docs/FakeHeaderNavigationItem.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderNavigationItem.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { HeaderNavigationItemProps } from '../headerNavigation/index';
+
+/**
+ * This component only exists to add relevant html props for HeaderNavigationItem
+ */
+export const HeaderNavigationItem: FunctionComponent<
+  HeaderNavigationItemProps & {
+    /** Should be one or more Header.Navigation.Item elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderSearch.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderSearch.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderSearchProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for HeaderSearch
+ */
+export const HeaderSearch: FunctionComponent<HeaderSearchProps> = () => null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderThemeMenuButton.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderThemeMenuButton.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderThemeMenuButtonProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for HeaderThemeMenuButton
+ */
+export const HeaderThemeMenuButton: FunctionComponent<
+  HeaderThemeMenuButtonProps
+> = () => null;

--- a/@udir-design/react/src/components/header/docs/FakeHeaderUserButton.tsx
+++ b/@udir-design/react/src/components/header/docs/FakeHeaderUserButton.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { HeaderUserButtonProps } from '../index';
+
+/**
+ * This component only exists to add relevant html props for HeaderUserButton
+ */
+export const HeaderUserButton: FunctionComponent<HeaderUserButtonProps> = () =>
+  null;

--- a/@udir-design/react/src/components/list/List.stories.tsx
+++ b/@udir-design/react/src/components/list/List.stories.tsx
@@ -4,10 +4,19 @@ import { Heading } from '../typography/heading/Heading';
 import { List } from './List';
 import { ListItem } from './docs/FakeListItem';
 import { ListOrdered } from './docs/FakeListOrdered';
+import { ListUnordered } from './docs/FakeListUnordered';
+
+// Hack to get the first tab in Controls to have the correct name List.Unordered instead of ListUnordered
+if (Object.hasOwn(ListUnordered, '__docgenInfo')) {
+  (
+    ListUnordered as unknown as {
+      __docgenInfo: { displayName: string };
+    }
+  ).__docgenInfo.displayName = 'List.Unordered';
+}
 
 const meta = preview.meta({
-  // Displays as ListUnordered
-  component: List.Unordered,
+  component: ListUnordered,
   subcomponents: {
     'List.Ordered': ListOrdered, // Not subcomponent but want it to be displayed in tab-view for props
     'List.Item': ListItem,
@@ -83,7 +92,7 @@ export const Indented = meta.story({
   args: {
     style: { marginTop: 'var(--ds-size-2)' },
   },
-  render: ({ ref: _ref, ...args }) => (
+  render: (args) => (
     <>
       <Heading level={2} data-size="xs">
         Innhold

--- a/@udir-design/react/src/components/list/List.stories.tsx
+++ b/@udir-design/react/src/components/list/List.stories.tsx
@@ -2,9 +2,16 @@ import preview from '.storybook/preview';
 import { Link } from '../link/Link';
 import { Heading } from '../typography/heading/Heading';
 import { List } from './List';
+import { ListItem } from './docs/FakeListItem';
+import { ListOrdered } from './docs/FakeListOrdered';
 
 const meta = preview.meta({
+  // Displays as ListUnordered
   component: List.Unordered,
+  subcomponents: {
+    'List.Ordered': ListOrdered, // Not subcomponent but want it to be displayed in tab-view for props
+    'List.Item': ListItem,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/list/List.tsx
+++ b/@udir-design/react/src/components/list/List.tsx
@@ -30,6 +30,9 @@ const List = Object.assign(DigdirList, {
 });
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
+List.Unordered.displayName = 'List.Unordered';
+// This no longer works??? Sjekke etter påsken
+List.Ordered.displayName = 'List.Ordered';
 List.Item.displayName = 'List.Item';
 
 export type { ListItemProps, ListOrderedProps, ListUnorderedProps };

--- a/@udir-design/react/src/components/list/docs/FakeListItem.tsx
+++ b/@udir-design/react/src/components/list/docs/FakeListItem.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { ListItemProps } from '../List';
+
+/**
+ * This component only exists to add relevant html props for ListItem
+ */
+export const ListItem: FunctionComponent<ListItemProps> = () => null;

--- a/@udir-design/react/src/components/list/docs/FakeListOrdered.tsx
+++ b/@udir-design/react/src/components/list/docs/FakeListOrdered.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ListOrderedProps } from '../List';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for ListOrdered directly :(
+ */
+export const ListOrdered: FunctionComponent<ListOrderedProps> = () => null;

--- a/@udir-design/react/src/components/list/docs/FakeListUnordered.tsx
+++ b/@udir-design/react/src/components/list/docs/FakeListUnordered.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ListUnorderedProps } from '../List';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for ListUnordered directly :(
+ */
+export const ListUnordered: FunctionComponent<ListUnorderedProps> = () => null;

--- a/@udir-design/react/src/components/pagination/Pagination.stories.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.stories.tsx
@@ -4,9 +4,18 @@ import preview from '.storybook/preview';
 import { usePagination } from 'src/utilities/hooks/usePagination/usePagination';
 import { Search } from '../search/Search';
 import { Pagination } from './Pagination';
+import { Pagination as FakePagination } from './docs/FakePagination';
+import { PaginationButton } from './docs/FakePaginationButton';
+import { PaginationItem } from './docs/FakePaginationItem';
+import { PaginationList } from './docs/FakePaginationList';
 
 const meta = preview.meta({
-  component: Pagination,
+  component: FakePagination,
+  subcomponents: {
+    'Pagination.List': PaginationList,
+    'Pagination.Item': PaginationItem,
+    'Pagination.Button': PaginationButton,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/pagination/docs/FakePagination.tsx
+++ b/@udir-design/react/src/components/pagination/docs/FakePagination.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { PaginationProps } from '../Pagination';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Pagination directly :(
+ */
+export const Pagination: FunctionComponent<PaginationProps> = () => null;

--- a/@udir-design/react/src/components/pagination/docs/FakePaginationButton.tsx
+++ b/@udir-design/react/src/components/pagination/docs/FakePaginationButton.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { PaginationButtonProps } from '../Pagination';
+
+/**
+ * This component only exists to add relevant html props for PaginationButton
+ */
+export const PaginationButton: FunctionComponent<PaginationButtonProps> = () =>
+  null;

--- a/@udir-design/react/src/components/pagination/docs/FakePaginationItem.tsx
+++ b/@udir-design/react/src/components/pagination/docs/FakePaginationItem.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { PaginationItemProps } from '../Pagination';
+
+/**
+ * This component only exists to add relevant html props for PaginationItem
+ */
+export const PaginationItem: FunctionComponent<PaginationItemProps> = () =>
+  null;

--- a/@udir-design/react/src/components/pagination/docs/FakePaginationList.tsx
+++ b/@udir-design/react/src/components/pagination/docs/FakePaginationList.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { PaginationListProps } from '../Pagination';
+
+/**
+ * This component only exists to add relevant html props for PaginationList
+ */
+export const PaginationList: FunctionComponent<PaginationListProps> = () =>
+  null;

--- a/@udir-design/react/src/components/popover/Popover.stories.tsx
+++ b/@udir-design/react/src/components/popover/Popover.stories.tsx
@@ -5,9 +5,16 @@ import preview from '.storybook/preview';
 import { Button } from '../button/Button';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 import { Popover } from './Popover';
+import { Popover as FakePopover } from './docs/FakePopover';
+import { PopoverTrigger } from './docs/FakePopoverTrigger';
+import { PopoverTriggerContext } from './docs/FakePopoverTriggerContext';
 
 const meta = preview.meta({
-  component: Popover,
+  component: FakePopover,
+  subcomponents: {
+    'Popover.Trigger': PopoverTrigger,
+    'Popover.TriggerContext': PopoverTriggerContext,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/popover/docs/FakePopover.tsx
+++ b/@udir-design/react/src/components/popover/docs/FakePopover.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { PopoverProps } from '../Popover';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Popover directly :(
+ */
+export const Popover: FunctionComponent<PopoverProps> = () => null;

--- a/@udir-design/react/src/components/popover/docs/FakePopoverTrigger.tsx
+++ b/@udir-design/react/src/components/popover/docs/FakePopoverTrigger.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { PopoverTriggerProps } from '../Popover';
+
+/**
+ * This component only exists to add relevant html props for PopoverTrigger
+ */
+export const PopoverTrigger: FunctionComponent<PopoverTriggerProps> = () =>
+  null;

--- a/@udir-design/react/src/components/popover/docs/FakePopoverTriggerContext.tsx
+++ b/@udir-design/react/src/components/popover/docs/FakePopoverTriggerContext.tsx
@@ -1,0 +1,9 @@
+import type { FunctionComponent } from 'react';
+import type { PopoverTriggerContextProps } from '../Popover';
+
+/**
+ * This component only exists to add relevant html props for PopoverTriggerContext
+ */
+export const PopoverTriggerContext: FunctionComponent<
+  PopoverTriggerContextProps
+> = () => null;

--- a/@udir-design/react/src/components/search/Search.stories.tsx
+++ b/@udir-design/react/src/components/search/Search.stories.tsx
@@ -11,9 +11,18 @@ import { Spinner } from '../spinner/Spinner';
 import { Label } from '../typography/label/Label';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 import { Search } from './Search';
+import { Search as FakeSearch } from './docs/FakeSearch';
+import { SearchButton } from './docs/FakeSearchButton';
+import { SearchClear } from './docs/FakeSearchClear';
+import { SearchInput } from './docs/FakeSearchInput';
 
 const meta = preview.meta({
-  component: Search,
+  component: FakeSearch,
+  subcomponents: {
+    'Search.Button': SearchButton,
+    'Search.Clear': SearchClear,
+    'Search.Input': SearchInput,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/search/docs/FakeSearch.tsx
+++ b/@udir-design/react/src/components/search/docs/FakeSearch.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SearchProps } from '../Search';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Search directly :(
+ */
+export const Search: FunctionComponent<SearchProps> = () => null;

--- a/@udir-design/react/src/components/search/docs/FakeSearchButton.tsx
+++ b/@udir-design/react/src/components/search/docs/FakeSearchButton.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { SearchButtonProps } from '../Search';
+
+/**
+ * This component only exists to add relevant html props for SearchButton
+ */
+export const SearchButton: FunctionComponent<SearchButtonProps> = () => null;

--- a/@udir-design/react/src/components/search/docs/FakeSearchClear.tsx
+++ b/@udir-design/react/src/components/search/docs/FakeSearchClear.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { SearchClearProps } from '../Search';
+
+/**
+ * This component only exists to add relevant html props for SearchClear
+ */
+export const SearchClear: FunctionComponent<SearchClearProps> = () => null;

--- a/@udir-design/react/src/components/search/docs/FakeSearchInput.tsx
+++ b/@udir-design/react/src/components/search/docs/FakeSearchInput.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { SearchInputProps } from '../Search';
+
+/**
+ * This component only exists to add relevant html props for SearchInput
+ */
+export const SearchInput: FunctionComponent<SearchInputProps> = () => null;

--- a/@udir-design/react/src/components/select/Select.stories.tsx
+++ b/@udir-design/react/src/components/select/Select.stories.tsx
@@ -8,9 +8,16 @@ import { Heading } from '../typography/heading/Heading';
 import { Label } from '../typography/label/Label';
 import { ValidationMessage } from '../typography/validationMessage/ValidationMessage';
 import { Select } from './Select';
+import { Select as FakeSelect } from './docs/FakeSelect';
+import { SelectOptgroup } from './docs/FakeSelectOptgroup';
+import { SelectOption } from './docs/FakeSelectOption';
 
 const meta = preview.meta({
-  component: Select,
+  component: FakeSelect,
+  subcomponents: {
+    'Select.Option': SelectOption,
+    'Select.Optgroup': SelectOptgroup,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/select/docs/FakeSelect.tsx
+++ b/@udir-design/react/src/components/select/docs/FakeSelect.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SelectProps } from '../Select';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Select directly :(
+ */
+export const Select: FunctionComponent<SelectProps> = () => null;

--- a/@udir-design/react/src/components/select/docs/FakeSelectOptgroup.tsx
+++ b/@udir-design/react/src/components/select/docs/FakeSelectOptgroup.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SelectOptgroupProps } from '../Select';
+
+/**
+ * This component only exists to add relevant html props for SelectOptgroup
+ */
+export const SelectOptgroup: FunctionComponent<SelectOptgroupProps> = () =>
+  null;

--- a/@udir-design/react/src/components/select/docs/FakeSelectOption.tsx
+++ b/@udir-design/react/src/components/select/docs/FakeSelectOption.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { SelectOptionProps } from '../Select';
+
+/**
+ * This component only exists to add relevant html props for SelectOption
+ */
+export const SelectOption: FunctionComponent<SelectOptionProps> = () => null;

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -15,9 +15,22 @@ import type {
   SuggestionMultipleProps,
   SuggestionSingleProps,
 } from './Suggestion';
+import { Suggestion as FakeSuggestion } from './docs/FakeSuggestion';
+import { SuggestionClear } from './docs/FakeSuggestionClear';
+import { SuggestionEmpty } from './docs/FakeSuggestionEmpty';
+import { SuggestionInput } from './docs/FakeSuggestionInput';
+import { SuggestionList } from './docs/FakeSuggestionList';
+import { SuggestionOption } from './docs/FakeSuggestionOption';
 
 const meta = preview.meta({
-  component: Suggestion,
+  component: FakeSuggestion,
+  subcomponents: {
+    'Suggestion.Clear': SuggestionClear,
+    'Suggestion.Empty': SuggestionEmpty,
+    'Suggestion.Input': SuggestionInput,
+    'Suggestion.List': SuggestionList,
+    'Suggestion.Option': SuggestionOption,
+  },
   tags: ['alpha', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestion.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestion.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionProps } from '../Suggestion';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Suggestion directly :(
+ */
+export const Suggestion: FunctionComponent<SuggestionProps> = () => null;

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestionClear.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestionClear.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionClearProps } from '../Suggestion';
+
+/**
+ * This component only exists to add relevant html props for SuggestionClear
+ */
+export const SuggestionClear: FunctionComponent<SuggestionClearProps> = () =>
+  null;

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestionEmpty.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestionEmpty.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionEmptyProps } from '../Suggestion';
+
+/**
+ * This component only exists to add relevant html props for SuggestionEmpty
+ */
+export const SuggestionEmpty: FunctionComponent<SuggestionEmptyProps> = () =>
+  null;

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestionInput.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestionInput.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionInputProps } from '../Suggestion';
+
+/**
+ * This component only exists to add relevant html props for SuggestionInput
+ */
+export const SuggestionInput: FunctionComponent<SuggestionInputProps> = () =>
+  null;

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestionList.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestionList.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionListProps } from '../Suggestion';
+
+/**
+ * This component only exists to add relevant html props for SuggestionList
+ */
+export const SuggestionList: FunctionComponent<SuggestionListProps> = () =>
+  null;

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestionOption.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestionOption.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionOptionProps } from '../Suggestion';
+
+/**
+ * This component only exists to add relevant html props for SuggestionOption
+ */
+export const SuggestionOption: FunctionComponent<SuggestionOptionProps> = () =>
+  null;

--- a/@udir-design/react/src/components/table/Table.stories.tsx
+++ b/@udir-design/react/src/components/table/Table.stories.tsx
@@ -7,11 +7,26 @@ import { Checkbox } from '../checkbox/Checkbox';
 import { Tag } from '../tag/Tag';
 import { Textfield } from '../textfield/Textfield';
 import { Heading } from '../typography/heading/Heading';
-import type { TableHeaderCellProps } from '.';
+import { Table as FakeTable } from './docs/FakeTable';
+import { TableBody } from './docs/FakeTableBody';
+import { TableCell } from './docs/FakeTableCell';
+import { TableFoot } from './docs/FakeTableFoot';
+import { TableHead } from './docs/FakeTableHead';
+import { TableHeaderCell } from './docs/FakeTableHeaderCell';
+import { TableRow } from './docs/FakeTableRow';
 import { Table } from '.';
+import type { TableHeaderCellProps } from '.';
 
 const meta = preview.meta({
-  component: Table,
+  component: FakeTable,
+  subcomponents: {
+    'Table.Head': TableHead,
+    'Table.Body': TableBody,
+    'Table.Row': TableRow,
+    'Table.Cell': TableCell,
+    'Table.HeaderCell': TableHeaderCell,
+    'Table.Foot': TableFoot,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/table/docs/FakeTable.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTable.tsx
@@ -1,0 +1,13 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableProps } from '..';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Table directly :(
+ */
+export const Table: FunctionComponent<
+  TableProps & {
+    /** Should be one or more Table.Head, Table.Body or Table.Foot elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/table/docs/FakeTableBody.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTableBody.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableBodyProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for TableBody
+ */
+export const TableBody: FunctionComponent<
+  TableBodyProps & {
+    /** Should be one or more Table.Row elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/table/docs/FakeTableCell.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTableCell.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableCellProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for TableCell
+ */
+export const TableCell: FunctionComponent<
+  TableCellProps & {
+    /** The content of the cell */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/table/docs/FakeTableFoot.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTableFoot.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableFootProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for TableFoot
+ */
+export const TableFoot: FunctionComponent<
+  TableFootProps & {
+    /** Should be one or more Table.Row elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/table/docs/FakeTableHead.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTableHead.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableHeadProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for TableHead
+ */
+export const TableHead: FunctionComponent<
+  TableHeadProps & {
+    /** Should be one or more Table.Row elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/table/docs/FakeTableHeaderCell.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTableHeaderCell.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableHeaderCellProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for TableHeaderCell
+ */
+export const TableHeaderCell: FunctionComponent<
+  TableHeaderCellProps & {
+    /** The content of the header cell */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/table/docs/FakeTableRow.tsx
+++ b/@udir-design/react/src/components/table/docs/FakeTableRow.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TableRowProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for TableRow
+ */
+export const TableRow: FunctionComponent<
+  TableRowProps & {
+    /** Should be one or more Table.Cell or Table.HeaderCell elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -20,9 +20,18 @@ import { Tooltip } from '../tooltip/Tooltip';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 import { Tabs } from './Tabs';
+import { Tabs as FakeTabs } from './docs/FakeTabs';
+import { TabsList } from './docs/FakeTabsList';
+import { TabsPanel } from './docs/FakeTabsPanel';
+import { TabsTab } from './docs/FakeTabsTab';
 
 const meta = preview.meta({
-  component: Tabs,
+  component: FakeTabs,
+  subcomponents: {
+    'Tabs.List': TabsList,
+    'Tabs.Tab': TabsTab,
+    'Tabs.Panel': TabsPanel,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
@@ -46,6 +55,7 @@ export const Preview = meta.story({
       <Tabs.Panel value="value3">Innhold for Tab 3</Tabs.Panel>,
     ],
   },
+  render: (args) => <Tabs {...args} />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const tab1 = canvas.getByRole('tab', { name: /tab 1/i });

--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -20,9 +20,18 @@ import { Tooltip } from '../tooltip/Tooltip';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 import { Tabs } from './Tabs';
+import { Tabs as FakeTabs } from './docs/FakeTabs';
+import { TabsList } from './docs/FakeTabsList';
+import { TabsPanel } from './docs/FakeTabsPanel';
+import { TabsTab } from './docs/FakeTabsTab';
 
 const meta = preview.meta({
-  component: Tabs,
+  component: FakeTabs,
+  subcomponents: {
+    'Tabs.List': TabsList,
+    'Tabs.Tab': TabsTab,
+    'Tabs.Panel': TabsPanel,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
@@ -57,6 +66,7 @@ export const Preview = meta.story({
       <Tabs.Panel value="value3">Innhold for Tab 3</Tabs.Panel>,
     ],
   },
+  render: (args) => <Tabs {...args} />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const tab1 = canvas.getByRole('tab', { name: /tab 1/i });

--- a/@udir-design/react/src/components/tabs/docs/FakeTabs.tsx
+++ b/@udir-design/react/src/components/tabs/docs/FakeTabs.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { TabsProps } from '../Tabs';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for Tabs directly :(
+ */
+export const Tabs: FunctionComponent<TabsProps> = () => null;

--- a/@udir-design/react/src/components/tabs/docs/FakeTabsList.tsx
+++ b/@udir-design/react/src/components/tabs/docs/FakeTabsList.tsx
@@ -1,0 +1,12 @@
+import type { FunctionComponent, ReactNode } from 'react';
+import type { TabsListProps } from '../Tabs';
+
+/**
+ * This component only exists to add relevant html props for TabsList
+ */
+export const TabsList: FunctionComponent<
+  TabsListProps & {
+    /** Should be one or more Tabs.Tab elements */
+    children?: ReactNode;
+  }
+> = () => null;

--- a/@udir-design/react/src/components/tabs/docs/FakeTabsPanel.tsx
+++ b/@udir-design/react/src/components/tabs/docs/FakeTabsPanel.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { TabsPanelProps } from '../Tabs';
+
+/**
+ * This component only exists to add relevant html props for TabsPanel
+ */
+export const TabsPanel: FunctionComponent<TabsPanelProps> = () => null;

--- a/@udir-design/react/src/components/tabs/docs/FakeTabsTab.tsx
+++ b/@udir-design/react/src/components/tabs/docs/FakeTabsTab.tsx
@@ -1,0 +1,7 @@
+import type { FunctionComponent } from 'react';
+import type { TabsTabProps } from '../Tabs';
+
+/**
+ * This component only exists to add relevant html props for TabsTab
+ */
+export const TabsTab: FunctionComponent<TabsTabProps> = () => null;

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -19,12 +19,14 @@ import { Fieldset } from '../fieldset/Fieldset';
 import { Table } from '../table';
 import { Tooltip } from '../tooltip/Tooltip';
 import { Heading } from '../typography/heading/Heading';
+import { ToggleGroup as FakeToggleGroup } from './docs/FakeToggleGroup';
+import { ToggleGroupItem } from './docs/FakeToggleGroupItem';
 import { ToggleGroup } from './';
 
 const meta = preview.meta({
-  component: ToggleGroup,
+  component: FakeToggleGroup,
   subcomponents: {
-    'ToggleGroup.Item': ToggleGroup.Item,
+    'ToggleGroup.Item': ToggleGroupItem,
   },
   tags: ['beta', 'digdir'],
   parameters: {

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -19,9 +19,14 @@ import { Table } from '../table';
 import { Tooltip } from '../tooltip/Tooltip';
 import { Heading } from '../typography/heading/Heading';
 import { ToggleGroup } from './ToggleGroup';
+import { ToggleGroup as FakeToggleGroup } from './docs/FakeToggleGroup';
+import { ToggleGroupItem } from './docs/FakeToggleGroupItem';
 
 const meta = preview.meta({
-  component: ToggleGroup,
+  component: FakeToggleGroup,
+  subcomponents: {
+    'ToggleGroup.Item': ToggleGroupItem,
+  },
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {

--- a/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroup.tsx
+++ b/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroup.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ToggleGroupProps } from '../ToggleGroup';
+
+/**
+ * This component only exists because react-docgen-typescript doesn't manage to generate
+ * Storybook controls for ToggleGroup directly :(
+ */
+export const ToggleGroup: FunctionComponent<ToggleGroupProps> = () => null;

--- a/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroupItem.tsx
+++ b/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroupItem.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { ToggleGroupItemProps } from '../ToggleGroup';
+
+/**
+ * This component only exists to add relevant html props for ToggleGroupItem
+ */
+export const ToggleGroupItem: FunctionComponent<ToggleGroupItemProps> = () =>
+  null;

--- a/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroupItem.tsx
+++ b/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroupItem.tsx
@@ -1,5 +1,5 @@
 import type { FunctionComponent } from 'react';
-import type { ToggleGroupItemProps } from '../ToggleGroup';
+import type { ToggleGroupItemProps } from '../';
 
 /**
  * This component only exists to add relevant html props for ToggleGroupItem


### PR DESCRIPTION
## Hva er gjort?

- Lagt til Fake-komponenter for de som har sub-components og derfor enten har mangelfull controls i dokumentasjon eller som bare har godt av å få dokumentert props for sub-componentsa
- For komponenter som `Table` med flere sub-components er det spesifisert `children` og dokumentert hvilke komponenter som skal brukes som children
- Fortsatt bruk av @unekinn løsning for å vise `List.Unordered` fremfor `ListUnordered` i tabs for controls