### PR TITLE
fix(symbols): prevent bundling of react and react/jsx-runtime, should now work with React 18

### DIFF
--- a/@udir-design/symbols/package.json
+++ b/@udir-design/symbols/package.json
@@ -14,21 +14,6 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "tsdown": {
-    "entry": [
-      "generated-src/**/*.{ts,tsx}"
-    ],
-    "format": [
-      "cjs",
-      "esm"
-    ],
-    "dts": true,
-    "sourcemap": true,
-    "clean": true,
-    "neverBundle": [
-      "react"
-    ]
-  },
   "exports": {
     ".": {
       "import": {

--- a/@udir-design/symbols/tsdown.config.ts
+++ b/@udir-design/symbols/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['generated-src/**/*.{ts,tsx}'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  deps: {
+    neverBundle: ['react', 'react/jsx-runtime'],
+  },
+});


### PR DESCRIPTION
## Hva er gjort?

Då vi bytta frå tsup til tsdown konfigurerte vi ikkje React som ekstern kode på riktig måte. Dermed enda vi opp med å bundle inn heile react og react/jsx-runtime versjon 19 i symbolbiblioteket, som både tar unødvendig plass og gjer at det ikkje funker saman med React versjon 18.

tsup-generert kode i versjon -beta.25:
<img width="723" height="255" alt="image" src="https://github.com/user-attachments/assets/5b46d656-52bd-421f-bcfa-21a3c18ff64f" />

tsdown-generert kode i versjon -beta.28:
<img width="751" height="136" alt="image" src="https://github.com/user-attachments/assets/660189a7-be8b-41d9-821a-30e59be5be55" />
... der `./jsx-runtime-...` er ein bundla versjon av React 😅 

tsdown med korrekt konfigurasjon (denne PRen):
<img width="601" height="96" alt="image" src="https://github.com/user-attachments/assets/83229572-181b-48bb-a1c7-1895f21a35bd" />


### Kva skjedde?

Todelt årsak. Vi hadde satt `neverBundle: ["react"]` på rotnivå av tsdown sin config heller enn korrekt under `deps`. Vi kunne oppdaga det ved å ha config i ei eiga `tsdown.config.ts`-fil, så eg har bytta til det. Men sjølv om vi hadde gjort det riktig ville vi ha bundla med `react/jsx-runtime`, fordi ulikt tsup sin `external` må vi eksplisitt ignorere submodular på tsdown sin `deps.neverBundle`.

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Commitmeldingene gir mening i kontekst av changelog
