### PR TITLE
fix(FileUpload): ensure Dropzone expands vertically when setting height on FileUpload

### DIFF
--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -96,6 +96,13 @@ export const Readonly = meta.story({
 });
 
 export const ExampleDropZone = meta.story({
+  parameters: {
+    customStyles: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 'var(--ds-size-3)',
+    },
+  },
   render: (args) => {
     const [files, setFiles] = useState<File[]>([]);
     const [rejected, setRejected] = useState<FileRejection[]>([]);
@@ -127,13 +134,7 @@ export const ExampleDropZone = meta.story({
       });
 
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 'var(--ds-size-3)',
-        }}
-      >
+      <>
         <FileUpload.Dropzone
           label="Last opp dokumentasjon"
           description="Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB."
@@ -177,7 +178,7 @@ export const ExampleDropZone = meta.story({
             ))}
           </>
         )}
-      </div>
+      </>
     );
   },
   play: async ({ canvasElement, step }) => {
@@ -206,6 +207,17 @@ export const ExampleDropZone = meta.story({
     // uploaded file will be replaced by the dummyFile used in the test
     dropzone.value = '';
   },
+});
+
+export const ExampleDropzoneWithExplicitSize = ExampleDropZone.extend({
+  decorators: [
+    (Story) => (
+      <>
+        <style>{`.uds-file-upload { height: 600px; width: 100%; }`}</style>
+        <Story />
+      </>
+    ),
+  ],
 });
 
 export const TooManyFiles = meta.story({

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -1,146 +1,290 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Example Drop Zone 1`] = `
-<div style="display: flex; flex-direction: column; gap: var(--ds-size-3);">
-  <div
-    role="presentation"
-    tabindex="0"
+<div
+  role="presentation"
+  tabindex="0"
+>
+  <label
+    data-weight="medium"
+    for="dokumentasjon"
   >
-    <label
-      data-weight="medium"
-      for="dokumentasjon"
-    >
-      Last opp dokumentasjon
-    </label>
-    <div
-      data-field="description"
-      id="dokumentasjon:description:1"
-    >
-      Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
-    </div>
-    <div data-variant="default">
-      <div>
-      </div>
-      <button
-        data-variant="secondary"
-        type="button"
-        aria-label="Velg filer"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M6.97 9.03a.75.75 0 0 0 1.06 0l3.22-3.22v8.69a.75.75 0 0 0 1.5 0V5.81l3.22 3.22a.75.75 0 1 0 1.06-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0l-4.5 4.5a.75.75 0 0 0 0 1.06M4.75 15.5a.75.75 0 0 0-1.5 0V19c0 .966.784 1.75 1.75 1.75h14A1.75 1.75 0 0 0 20.75 19v-3.5a.75.75 0 0 0-1.5 0V19a.25.25 0 0 1-.25.25H5a.25.25 0 0 1-.25-.25z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <input
-      accept="application/pdf"
-      multiple
-      tabindex="-1"
-      id="dokumentasjon"
-      type="file"
-      aria-describedby="dokumentasjon:description:1"
-      style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
-    >
+    Last opp dokumentasjon
+  </label>
+  <div
+    data-field="description"
+    id="dokumentasjon:description:1"
+  >
+    Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
   </div>
-  <h3 data-size="2xs">
-    Vedlegg (1):
-  </h3>
-  <div
-    data-variant="default"
-    aria-invalid="false"
-  >
+  <div data-variant="default">
     <div>
-      <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
-          >
-          </path>
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </div>
-      <div>
-        <a download="eksempel1.pdf">
-          eksempel1.pdf
-        </a>
-        <p
-          data-variant="default"
-          data-size="sm"
-        >
-          0.29 MB
-        </p>
-      </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        popovertarget="_r_5_"
-        popovertargetaction="show"
-        aria-labelledby="_r_5_"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-      <span
-        role="tooltip"
-        id="_r_5_"
-        popover="manual"
-        style="opacity: 0;"
-      >
-        Fjern filen
-      </span>
     </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
+    <button
+      data-variant="secondary"
+      type="button"
+      aria-label="Velg filer"
     >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M6.97 9.03a.75.75 0 0 0 1.06 0l3.22-3.22v8.69a.75.75 0 0 0 1.5 0V5.81l3.22 3.22a.75.75 0 1 0 1.06-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0l-4.5 4.5a.75.75 0 0 0 0 1.06M4.75 15.5a.75.75 0 0 0-1.5 0V19c0 .966.784 1.75 1.75 1.75h14A1.75 1.75 0 0 0 20.75 19v-3.5a.75.75 0 0 0-1.5 0V19a.25.25 0 0 1-.25.25H5a.25.25 0 0 1-.25-.25z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </button>
+  </div>
+  <input
+    accept="application/pdf"
+    multiple
+    tabindex="-1"
+    id="dokumentasjon"
+    type="file"
+    aria-describedby="dokumentasjon:description:1"
+    style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+  >
+</div>
+<h3 data-size="2xs">
+  Vedlegg (1):
+</h3>
+<div
+  data-variant="default"
+  aria-invalid="false"
+>
+  <div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+        >
+        </path>
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
     </div>
+    <div>
+      <a download="eksempel1.pdf">
+        eksempel1.pdf
+      </a>
+      <p
+        data-variant="default"
+        data-size="sm"
+      >
+        0.29 MB
+      </p>
+    </div>
+    <button
+      data-icon="true"
+      data-variant="tertiary"
+      type="button"
+      popovertarget="_r_5_"
+      popovertargetaction="show"
+      aria-labelledby="_r_5_"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </button>
+    <span
+      role="tooltip"
+      id="_r_5_"
+      popover="manual"
+      style="opacity: 0;"
+    >
+      Fjern filen
+    </span>
+  </div>
+  <div
+    aria-relevant="additions removals"
+    aria-live="polite"
+  >
+  </div>
+</div>
+`;
+
+exports[`Example Dropzone With Explicit Size 1`] = `
+<style>
+  .uds-file-upload { height: 600px; width: 100%; }
+</style>
+<div
+  role="presentation"
+  tabindex="0"
+>
+  <label
+    data-weight="medium"
+    for="dokumentasjon"
+  >
+    Last opp dokumentasjon
+  </label>
+  <div
+    data-field="description"
+    id="dokumentasjon:description:1"
+  >
+    Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
+  </div>
+  <div data-variant="default">
+    <div>
+    </div>
+    <button
+      data-variant="secondary"
+      type="button"
+      aria-label="Velg filer"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M6.97 9.03a.75.75 0 0 0 1.06 0l3.22-3.22v8.69a.75.75 0 0 0 1.5 0V5.81l3.22 3.22a.75.75 0 1 0 1.06-1.06l-4.5-4.5a.75.75 0 0 0-1.06 0l-4.5 4.5a.75.75 0 0 0 0 1.06M4.75 15.5a.75.75 0 0 0-1.5 0V19c0 .966.784 1.75 1.75 1.75h14A1.75 1.75 0 0 0 20.75 19v-3.5a.75.75 0 0 0-1.5 0V19a.25.25 0 0 1-.25.25H5a.25.25 0 0 1-.25-.25z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </button>
+  </div>
+  <input
+    accept="application/pdf"
+    multiple
+    tabindex="-1"
+    id="dokumentasjon"
+    type="file"
+    aria-describedby="dokumentasjon:description:1"
+    style="border: 0px; clip: rect(0px, 0px, 0px, 0px); clip-path: inset(50%); height: 1px; margin: 0px -1px -1px 0px; overflow: hidden; padding: 0px; position: absolute; width: 1px; white-space: nowrap;"
+  >
+</div>
+<h3 data-size="2xs">
+  Vedlegg (1):
+</h3>
+<div
+  data-variant="default"
+  aria-invalid="false"
+>
+  <div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+        >
+        </path>
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </div>
+    <div>
+      <a download="eksempel1.pdf">
+        eksempel1.pdf
+      </a>
+      <p
+        data-variant="default"
+        data-size="sm"
+      >
+        0.29 MB
+      </p>
+    </div>
+    <button
+      data-icon="true"
+      data-variant="tertiary"
+      type="button"
+      popovertarget="_r_9_"
+      popovertargetaction="show"
+      aria-labelledby="_r_9_"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+      >
+        <path
+          fill="currentColor"
+          fill-rule="evenodd"
+          d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+    </button>
+    <span
+      role="tooltip"
+      id="_r_9_"
+      popover="manual"
+      style="opacity: 0;"
+    >
+      Fjern filen
+    </span>
+  </div>
+  <div
+    aria-relevant="additions removals"
+    aria-live="polite"
+  >
   </div>
 </div>
 `;
@@ -195,9 +339,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_m_"
+        popovertarget="_r_q_"
         popovertargetaction="show"
-        aria-labelledby="_r_m_"
+        aria-labelledby="_r_q_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -220,7 +364,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_m_"
+        id="_r_q_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -278,9 +422,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_p_"
+        popovertarget="_r_t_"
         popovertargetaction="show"
-        aria-labelledby="_r_p_"
+        aria-labelledby="_r_t_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -303,7 +447,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_p_"
+        id="_r_t_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -452,9 +596,9 @@ exports[`Example Items 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_t_"
+        popovertarget="_r_11_"
         popovertargetaction="show"
-        aria-labelledby="_r_t_"
+        aria-labelledby="_r_11_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -477,7 +621,7 @@ exports[`Example Items 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_t_"
+        id="_r_11_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -603,9 +747,9 @@ exports[`Example Trigger 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_j_"
+        popovertarget="_r_n_"
         popovertargetaction="show"
-        aria-labelledby="_r_j_"
+        aria-labelledby="_r_n_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -628,7 +772,7 @@ exports[`Example Trigger 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_j_"
+        id="_r_n_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -931,9 +1075,9 @@ exports[`Too Many Files 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_9_"
+        popovertarget="_r_d_"
         popovertargetaction="show"
-        aria-labelledby="_r_9_"
+        aria-labelledby="_r_d_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -956,7 +1100,7 @@ exports[`Too Many Files 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_9_"
+        id="_r_d_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -1014,9 +1158,9 @@ exports[`Too Many Files 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_c_"
+        popovertarget="_r_g_"
         popovertargetaction="show"
-        aria-labelledby="_r_c_"
+        aria-labelledby="_r_g_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -1039,7 +1183,7 @@ exports[`Too Many Files 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_c_"
+        id="_r_g_"
         popover="manual"
         style="opacity: 0;"
       >
@@ -1092,9 +1236,9 @@ exports[`Too Many Files 1`] = `
         data-icon="true"
         data-variant="tertiary"
         type="button"
-        popovertarget="_r_f_"
+        popovertarget="_r_j_"
         popovertargetaction="show"
-        aria-labelledby="_r_f_"
+        aria-labelledby="_r_j_"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -1117,7 +1261,7 @@ exports[`Too Many Files 1`] = `
       </button>
       <span
         role="tooltip"
-        id="_r_f_"
+        id="_r_j_"
         popover="manual"
         style="opacity: 0;"
       >

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -69,9 +69,15 @@
   }
 
   /* Design of dropzone */
+  &:has(> .ds-card) {
+    display: flex;
+    flex-direction: column;
+  }
   > .ds-card {
     margin-block-start: var(--ds-size-2);
     width: 100%;
+    flex-basis: 100%;
+    justify-content: center;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
## Hva er gjort?

Har satt Dropzone til column flex og Dropzone-kortet til å ekspandere, med innholdet midtstilt i kortet.

Dette skal gi ingen visuell endring med mindre man eksplisitt sett høgde på FileUpload.

### Eksempel med `height: 500px; width 100%`

Før / etter:
<div>
<img width="320" height="auto" alt="image" src="https://github.com/user-attachments/assets/a9091188-7ec3-4ec6-ac51-6798556de886" />
<img width="320" height="auto" alt="image" src="https://github.com/user-attachments/assets/90ad8584-7775-4f39-80e6-0defac8c14ad" />
</div>


## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog