### PR TITLE
docs: fix Highcharts examples after upgrade to Vite 8

### DIFF
--- a/@udir-design/react/demo-pages/dashboard-demo/tabs/test-answers/TestAnswers.tsx
+++ b/@udir-design/react/demo-pages/dashboard-demo/tabs/test-answers/TestAnswers.tsx
@@ -1,5 +1,5 @@
 import * as Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
+import { HighchartsReact } from 'highcharts-react-official';
 import { useRef, useState } from 'react';
 import { Table } from 'src/components/table';
 import { Heading } from 'src/components/typography/heading/Heading';

--- a/@udir-design/react/demo-pages/dashboard-demo/tabs/tests/Tests.tsx
+++ b/@udir-design/react/demo-pages/dashboard-demo/tabs/tests/Tests.tsx
@@ -1,5 +1,5 @@
 import * as Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
+import { HighchartsReact } from 'highcharts-react-official';
 import { useRef, useState } from 'react';
 import { Card } from 'src/components/card/Card';
 import { Table } from 'src/components/table';

--- a/@udir-design/react/src/utilities/datavis/docs/highchartsCategoricalExample.tsx
+++ b/@udir-design/react/src/utilities/datavis/docs/highchartsCategoricalExample.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
+import { HighchartsReact } from 'highcharts-react-official';
 import { getHighchartsTheme } from '@udir-design/react/utilities/datavis/alpha';
 import '@udir-design/theme/datavis.css';
 import 'highcharts/i18n/nb-NO'; // Norsk språkpakke

--- a/@udir-design/react/src/utilities/datavis/docs/highchartsSequentialExample.tsx
+++ b/@udir-design/react/src/utilities/datavis/docs/highchartsSequentialExample.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import Highcharts from 'highcharts';
-import HighchartsReact from 'highcharts-react-official';
+import { HighchartsReact } from 'highcharts-react-official';
 import { getHighchartsTheme } from '@udir-design/react/utilities/datavis/alpha';
 import { getSequentialMonochromaticColors } from '@udir-design/react/utilities/datavis/alpha';
 import '@udir-design/theme/datavis.css';

--- a/@udir-design/react/src/utilities/datavis/highcharts.ts
+++ b/@udir-design/react/src/utilities/datavis/highcharts.ts
@@ -25,7 +25,7 @@ import { getCategoricalColors } from './dataVisualisation';
  * @example
  * ```tsx
  * import Highcharts from 'highcharts';
- * import HighchartsReact from 'highcharts-react-official';
+ * import { HighchartsReact } from 'highcharts-react-official';
  * import { getHighchartsTheme } from '@udir-design/react/utilities/datavis/alpha';
  * import '@udir-design/theme/datavis.css';
  * import 'highcharts/i18n/nb-NO'; // Norwegian Bokmål language pack


### PR DESCRIPTION
Har samanheng med denne endringa i Vite 8: [Consistent CommonJS Interop](https://vite.dev/guide/migration#consistent-commonjs-interop)