### PR TITLE
chore(Header): use css-icons

### DIFF
--- a/@udir-design/css/src/icons.css
+++ b/@udir-design/css/src/icons.css
@@ -18,3 +18,6 @@
 @import '../node_modules/@udir-design/icons/dist/css/tasklistFill.css';
 @import '../node_modules/@udir-design/icons/dist/css/xMarkOctagon.css';
 @import '../node_modules/@udir-design/icons/dist/css/xMarkOctagonFill.css';
+@import '../node_modules/@udir-design/icons/dist/css/menuHamburger.css';
+@import '../node_modules/@udir-design/icons/dist/css/xMark.css';
+@import '../node_modules/@udir-design/icons/dist/css/arrowRight.css';

--- a/@udir-design/react/src/components/header/HeaderMenuButton.tsx
+++ b/@udir-design/react/src/components/header/HeaderMenuButton.tsx
@@ -1,6 +1,5 @@
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
-import { MenuHamburgerIcon, XMarkIcon } from '@udir-design/icons';
 import type { ButtonProps } from '../button/Button';
 import { Button } from '../button/Button';
 
@@ -18,10 +17,6 @@ export const HeaderMenuButton = forwardRef<
       ref={ref}
       {...props}
     >
-      <>
-        <MenuHamburgerIcon aria-hidden />
-        <XMarkIcon aria-hidden />
-      </>
       {children ? children : 'Meny'}
     </Button>
   );

--- a/@udir-design/react/src/components/header/HeaderThemeMenuButton.tsx
+++ b/@udir-design/react/src/components/header/HeaderThemeMenuButton.tsx
@@ -1,6 +1,5 @@
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
-import { ChevronDownIcon, ChevronUpIcon } from '@udir-design/icons';
 import type { ButtonProps } from '../button/Button';
 import { Button } from '../button/Button';
 
@@ -15,15 +14,11 @@ export const HeaderThemeMenuButton = forwardRef<
 ) {
   return (
     <Button
-      className={cl('uds-header__menu-button', className)}
+      className={cl('uds-header__theme-menu-button', className)}
       variant="tertiary"
       ref={ref}
       {...props}
     >
-      <>
-        <ChevronDownIcon aria-hidden />
-        <ChevronUpIcon aria-hidden />
-      </>
       {children}
     </Button>
   );

--- a/@udir-design/react/src/components/header/HeaderUserButton.tsx
+++ b/@udir-design/react/src/components/header/HeaderUserButton.tsx
@@ -1,7 +1,6 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
-import { ChevronDownIcon, ChevronUpIcon } from '@udir-design/icons';
 import { Heading } from '../typography/heading/Heading';
 import { Paragraph } from '../typography/paragraph/Paragraph';
 
@@ -54,8 +53,6 @@ export const HeaderUserButton = forwardRef<
         {description && <Paragraph data-size="xs">{description}</Paragraph>}
       </div>
       {avatar && avatar}
-      <ChevronDownIcon aria-hidden />
-      <ChevronUpIcon aria-hidden />
     </button>
   );
 });

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -93,40 +93,6 @@ exports[`Auto Hide Sticky 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -149,64 +115,16 @@ exports[`Auto Hide Sticky 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 3
                   </a>
                 </li>
@@ -222,106 +140,26 @@ exports[`Auto Hide Sticky 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 5
                   </a>
                 </li>
@@ -337,85 +175,21 @@ exports[`Auto Hide Sticky 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -565,40 +339,6 @@ exports[`Auto Hide Sticky Test 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -621,64 +361,16 @@ exports[`Auto Hide Sticky Test 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 3
                   </a>
                 </li>
@@ -694,106 +386,26 @@ exports[`Auto Hide Sticky Test 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 5
                   </a>
                 </li>
@@ -809,85 +421,21 @@ exports[`Auto Hide Sticky Test 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -992,40 +540,6 @@ exports[`Long Application Name 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           <span>
             Meny
           </span>
@@ -1166,42 +680,6 @@ exports[`Responsive 1`] = `
               SH
             </span>
           </span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
         </button>
         <div
           id="<removed>"
@@ -1284,40 +762,6 @@ exports[`Responsive 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -1353,42 +797,6 @@ exports[`Responsive 1`] = `
                 SH
               </span>
             </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
           </button>
           <div
             id="<removed>"
@@ -1480,64 +888,16 @@ exports[`Responsive 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 3
                   </a>
                 </li>
@@ -1553,106 +913,26 @@ exports[`Responsive 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 5
                   </a>
                 </li>
@@ -1668,85 +948,21 @@ exports[`Responsive 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -1815,40 +1031,6 @@ exports[`Udir No 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -1888,169 +1070,41 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Barnehage
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Grunnskole
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Videregående
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Opplæring i bedrift
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Voksenopplæring
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     SFO
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kulturskolen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Folkehøgskole
                   </a>
                 </li>
@@ -2066,127 +1120,31 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Rammeplaner
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Læreplaner
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Skolemiljø
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Tilpasset opplæring
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Spesialpedagogikk
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Fravær
                   </a>
                 </li>
@@ -2202,106 +1160,26 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Eksamen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kartleggingsprøver
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Nasjonale prøver
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Vitnemål og kompetansebevis
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Realkompetansevurdering
                   </a>
                 </li>
@@ -2317,148 +1195,36 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Lede kvalitetsutvikling
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Videreutdanning
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kompetansetilbud
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Sikkerhet og beredskap
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kvalitet i læremidler
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Digital praksis
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Tilskudd
                   </a>
                 </li>
@@ -2474,169 +1240,41 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Elevundersøkelsen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Læringsundersøkelsen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Foreldreundersøkelsen i barnehage
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Statistikk
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Forskning
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Internasjonale studier
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kunnskapsoversikter
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Datainnsamling
                   </a>
                 </li>
@@ -2652,85 +1290,21 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Regelverk for barnehage
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Regelverk for skole og opplæring
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Tilsyn
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Melde bekymring
                   </a>
                 </li>
@@ -2892,40 +1466,6 @@ exports[`With Menu 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -2950,64 +1490,16 @@ exports[`With Menu 1`] = `
               <ul>
                 <li>
                   <a href="https://www.udir.no/om-udir/designprofil/identitet/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Identitet
                   </a>
                 </li>
                 <li>
                   <a href="https://www.udir.no/om-udir/designprofil/farger/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Farger
                   </a>
                 </li>
                 <li>
                   <a href="https://www.udir.no/om-udir/designprofil/typografi/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Typografi
                   </a>
                 </li>
@@ -3025,64 +1517,16 @@ exports[`With Menu 1`] = `
               <ul>
                 <li>
                   <a href="https://www.figma.com/design/QeYBL9fzDCk87WNWcDSQi7/01-Illustrasjoner---barnehage?node-id=457-13863">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Illustrasjoner
                   </a>
                 </li>
                 <li>
                   <a href="https://www.figma.com/design/SSdGSjSYPDSyX2IfHLfmEL/Symbolbibliotek?node-id=0-1&amp;p=f&amp;m=dev">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Symboler
                   </a>
                 </li>
                 <li>
                   <a href="https://www.figma.com/design/W4tl2t6G22muQfVF8jGeQX/Ikonbibliotek?node-id=9-2879&amp;p=f&amp;m=dev">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Ikoner
                   </a>
                 </li>
@@ -3100,64 +1544,16 @@ exports[`With Menu 1`] = `
               <ul>
                 <li>
                   <a href="https://design.udir.no/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Komponenter
                   </a>
                 </li>
                 <li>
                   <a href="https://www.figma.com/files/1290654482467394866/team/1306917640909073413/Team?fuid=1464219835118877209">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Figma
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Github
                   </a>
                 </li>
@@ -3243,40 +1639,6 @@ exports[`With Navigation Links 1`] = `
           popovertarget="uds-header-menu"
           data-hide="sm"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -3289,64 +1651,16 @@ exports[`With Navigation Links 1`] = `
             <ul>
               <li>
                 <a href="#">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="1em"
-                    height="1em"
-                    fill="none"
-                    viewbox="0 0 24 24"
-                    focusable="false"
-                    role="img"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                    >
-                    </path>
-                  </svg>
                   Navlink 1
                 </a>
               </li>
               <li>
                 <a href="#">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="1em"
-                    height="1em"
-                    fill="none"
-                    viewbox="0 0 24 24"
-                    focusable="false"
-                    role="img"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                    >
-                    </path>
-                  </svg>
                   Navlink 2
                 </a>
               </li>
               <li>
                 <a href="#">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="1em"
-                    height="1em"
-                    fill="none"
-                    viewbox="0 0 24 24"
-                    focusable="false"
-                    role="img"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                    >
-                    </path>
-                  </svg>
                   Navlink 3
                 </a>
               </li>
@@ -3429,40 +1743,6 @@ exports[`With Navigation Links And Menu 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -3485,43 +1765,11 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
@@ -3537,64 +1785,16 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -3610,85 +1810,21 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -3704,64 +1840,16 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -3907,42 +1995,6 @@ exports[`With Theme Menus 1`] = `
           popovertarget="header-education-menu"
           data-show="md"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
           Temameny 1
         </button>
         <div
@@ -3965,64 +2017,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4038,85 +2042,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4132,64 +2072,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4203,42 +2095,6 @@ exports[`With Theme Menus 1`] = `
           popovertarget="header-learning-menu"
           data-show="md"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
           Temameny 2
         </button>
         <div
@@ -4261,64 +2117,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4334,85 +2142,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4426,40 +2170,6 @@ exports[`With Theme Menus 1`] = `
           popovertarget="header-mobile-menu"
           data-hide="md"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -4482,64 +2192,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4555,85 +2217,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4649,64 +2247,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4722,64 +2272,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4795,85 +2297,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4994,42 +2432,6 @@ exports[`With User Button 1`] = `
               src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&amp;w=1480&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             >
           </span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
         </button>
         <div
           id="<removed>"
@@ -5275,42 +2677,6 @@ exports[`With User Button Test 1`] = `
               src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&amp;w=1480&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             >
           </span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
         </button>
         <div
           id="<removed>"

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -93,40 +93,6 @@ exports[`Auto Hide Sticky 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -148,64 +114,16 @@ exports[`Auto Hide Sticky 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 3
                   </a>
                 </li>
@@ -221,106 +139,26 @@ exports[`Auto Hide Sticky 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 5
                   </a>
                 </li>
@@ -336,85 +174,21 @@ exports[`Auto Hide Sticky 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -564,40 +338,6 @@ exports[`Auto Hide Sticky Test 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -621,64 +361,16 @@ exports[`Auto Hide Sticky Test 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 3
                   </a>
                 </li>
@@ -694,106 +386,26 @@ exports[`Auto Hide Sticky Test 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 5
                   </a>
                 </li>
@@ -809,85 +421,21 @@ exports[`Auto Hide Sticky Test 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -992,40 +540,6 @@ exports[`Long Application Name 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           <span>
             Meny
           </span>
@@ -1168,42 +682,6 @@ exports[`Responsive 1`] = `
               SH
             </span>
           </span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
         </button>
         <div
           id="usermenu2"
@@ -1287,40 +765,6 @@ exports[`Responsive 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -1358,42 +802,6 @@ exports[`Responsive 1`] = `
                 SH
               </span>
             </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
           </button>
           <div
             id="usermenuInMenu"
@@ -1486,64 +894,16 @@ exports[`Responsive 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 3
                   </a>
                 </li>
@@ -1559,106 +919,26 @@ exports[`Responsive 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 5
                   </a>
                 </li>
@@ -1674,85 +954,21 @@ exports[`Responsive 1`] = `
               <ul>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -1821,40 +1037,6 @@ exports[`Udir No 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -1893,169 +1075,41 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Barnehage
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Grunnskole
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Videregående
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Opplæring i bedrift
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Voksenopplæring
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     SFO
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kulturskolen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Folkehøgskole
                   </a>
                 </li>
@@ -2071,127 +1125,31 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Rammeplaner
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Læreplaner
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Skolemiljø
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Tilpasset opplæring
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Spesialpedagogikk
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Fravær
                   </a>
                 </li>
@@ -2207,106 +1165,26 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Eksamen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kartleggingsprøver
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Nasjonale prøver
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Vitnemål og kompetansebevis
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Realkompetansevurdering
                   </a>
                 </li>
@@ -2322,148 +1200,36 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Lede kvalitetsutvikling
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Videreutdanning
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kompetansetilbud
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Sikkerhet og beredskap
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kvalitet i læremidler
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Digital praksis
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Tilskudd
                   </a>
                 </li>
@@ -2479,169 +1245,41 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Elevundersøkelsen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Læringsundersøkelsen
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Foreldreundersøkelsen i barnehage
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Statistikk
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Forskning
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Internasjonale studier
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Kunnskapsoversikter
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Datainnsamling
                   </a>
                 </li>
@@ -2657,85 +1295,21 @@ exports[`Udir No 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Regelverk for barnehage
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Regelverk for skole og opplæring
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Tilsyn
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Melde bekymring
                   </a>
                 </li>
@@ -2896,40 +1470,6 @@ exports[`With Menu 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -2953,64 +1493,16 @@ exports[`With Menu 1`] = `
               <ul>
                 <li>
                   <a href="https://www.udir.no/om-udir/designprofil/identitet/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Identitet
                   </a>
                 </li>
                 <li>
                   <a href="https://www.udir.no/om-udir/designprofil/farger/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Farger
                   </a>
                 </li>
                 <li>
                   <a href="https://www.udir.no/om-udir/designprofil/typografi/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Typografi
                   </a>
                 </li>
@@ -3028,64 +1520,16 @@ exports[`With Menu 1`] = `
               <ul>
                 <li>
                   <a href="https://www.figma.com/design/QeYBL9fzDCk87WNWcDSQi7/01-Illustrasjoner---barnehage?node-id=457-13863">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Illustrasjoner
                   </a>
                 </li>
                 <li>
                   <a href="https://www.figma.com/design/SSdGSjSYPDSyX2IfHLfmEL/Symbolbibliotek?node-id=0-1&amp;p=f&amp;m=dev">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Symboler
                   </a>
                 </li>
                 <li>
                   <a href="https://www.figma.com/design/W4tl2t6G22muQfVF8jGeQX/Ikonbibliotek?node-id=9-2879&amp;p=f&amp;m=dev">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Ikoner
                   </a>
                 </li>
@@ -3103,64 +1547,16 @@ exports[`With Menu 1`] = `
               <ul>
                 <li>
                   <a href="https://design.udir.no/">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Komponenter
                   </a>
                 </li>
                 <li>
                   <a href="https://www.figma.com/files/1290654482467394866/team/1306917640909073413/Team?fuid=1464219835118877209">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Figma
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Github
                   </a>
                 </li>
@@ -3246,40 +1642,6 @@ exports[`With Navigation Links 1`] = `
           popovertarget="uds-header-menu"
           data-hide="sm"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -3291,64 +1653,16 @@ exports[`With Navigation Links 1`] = `
             <ul>
               <li>
                 <a href="#">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="1em"
-                    height="1em"
-                    fill="none"
-                    viewbox="0 0 24 24"
-                    focusable="false"
-                    role="img"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                    >
-                    </path>
-                  </svg>
                   Navlink 1
                 </a>
               </li>
               <li>
                 <a href="#">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="1em"
-                    height="1em"
-                    fill="none"
-                    viewbox="0 0 24 24"
-                    focusable="false"
-                    role="img"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                    >
-                    </path>
-                  </svg>
                   Navlink 2
                 </a>
               </li>
               <li>
                 <a href="#">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="1em"
-                    height="1em"
-                    fill="none"
-                    viewbox="0 0 24 24"
-                    focusable="false"
-                    role="img"
-                    aria-hidden="true"
-                  >
-                    <path
-                      fill="currentColor"
-                      d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                    >
-                    </path>
-                  </svg>
                   Navlink 3
                 </a>
               </li>
@@ -3431,40 +1745,6 @@ exports[`With Navigation Links And Menu 1`] = `
           type="button"
           popovertarget="uds-header-menu"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -3486,43 +1766,11 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Navlink 2
                   </a>
                 </li>
@@ -3538,64 +1786,16 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -3611,85 +1811,21 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -3705,64 +1841,16 @@ exports[`With Navigation Links And Menu 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -3908,42 +1996,6 @@ exports[`With Theme Menus 1`] = `
           popovertarget="header-education-menu"
           data-show="md"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
           Temameny 1
         </button>
         <div
@@ -3965,64 +2017,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4038,85 +2042,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4132,64 +2072,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4203,42 +2095,6 @@ exports[`With Theme Menus 1`] = `
           popovertarget="header-learning-menu"
           data-show="md"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
           Temameny 2
         </button>
         <div
@@ -4260,64 +2116,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4333,85 +2141,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4425,40 +2169,6 @@ exports[`With Theme Menus 1`] = `
           popovertarget="header-mobile-menu"
           data-hide="md"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            >
-            </path>
-          </svg>
           Meny
         </button>
         <div
@@ -4480,64 +2190,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4553,85 +2215,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4647,64 +2245,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4720,64 +2270,16 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
@@ -4793,85 +2295,21 @@ exports[`With Theme Menus 1`] = `
               <ul>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 1
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 2
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 3
                   </a>
                 </li>
                 <li>
                   <a href="#">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="1em"
-                      height="1em"
-                      fill="none"
-                      viewbox="0 0 24 24"
-                      focusable="false"
-                      role="img"
-                      aria-hidden="true"
-                    >
-                      <path
-                        fill="currentColor"
-                        d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                      >
-                      </path>
-                    </svg>
                     Link 4
                   </a>
                 </li>
@@ -4995,42 +2433,6 @@ exports[`With User Button 1`] = `
               src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&amp;w=1480&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             >
           </span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
         </button>
         <div
           id="usermenu"
@@ -5281,42 +2683,6 @@ exports[`With User Button Test 1`] = `
               src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?q=80&amp;w=1480&amp;auto=format&amp;fit=crop&amp;ixlib=rb-4.0.3&amp;ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
             >
           </span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1em"
-            height="1em"
-            fill="none"
-            viewbox="0 0 24 24"
-            focusable="false"
-            role="img"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-              clip-rule="evenodd"
-            >
-            </path>
-          </svg>
         </button>
         <div
           id="usermenu"

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -86,20 +86,33 @@
   }
 
   .uds-header__menu-button {
-    > svg:first-of-type {
-      display: block;
-    }
+    --uds-header__menu-button-icon-default: var(--uds-icon-menuHamburger);
+    --uds-header__menu-button-icon-active: var(--uds-icon-xMark);
+  }
 
-    > svg:last-of-type {
-      display: none;
+  .uds-header__theme-menu-button {
+    --uds-header__menu-button-icon-default: var(--uds-icon-chevronDown);
+    --uds-header__menu-button-icon-active: var(--uds-icon-chevronUp);
+  }
+
+  .uds-header__menu-button,
+  .uds-header__theme-menu-button {
+    &::before {
+      content: '';
+      display: block;
+      width: 1.3em;
+      height: 1.3em;
+      background: currentColor;
+      mask-image: var(--uds-header__menu-button-icon-default);
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
+      flex-shrink: 0;
     }
 
     &:has(+ [popover]:popover-open) {
-      > svg:first-of-type {
-        display: none;
-      }
-      > svg:last-of-type {
-        display: block;
+      &::before {
+        mask-image: var(--uds-header__menu-button-icon-active);
       }
     }
   }
@@ -125,7 +138,16 @@
         display: flex;
         gap: var(--ds-size-1);
         width: fit-content;
-        & > svg {
+        &::before {
+          content: '';
+          display: block;
+          width: 1em;
+          height: 1em;
+          background: currentColor;
+          mask-image: var(--uds-icon-arrowRight);
+          mask-size: contain;
+          mask-repeat: no-repeat;
+          mask-position: center;
           transform: translateY(var(--ds-size-1));
           flex-shrink: 0;
         }
@@ -199,30 +221,24 @@
       }
     }
 
-    > svg {
+    --uds-header__user-button-icon: var(--uds-icon-chevronDown);
+
+    &::after {
+      content: '';
+      display: block;
+      width: var(--ds-size-6);
+      height: var(--ds-size-6);
+      background: currentColor;
+      mask-image: var(--uds-header__user-button-icon);
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
       margin-inline-start: var(--ds-size-1);
       flex-shrink: 0;
     }
 
-    > svg:nth-last-child(2) {
-      display: block;
-      width: auto;
-      height: var(--ds-size-6);
-    }
-
-    > svg:last-child {
-      display: none;
-      width: auto;
-      height: var(--ds-size-6);
-    }
-
     &:has(+ [popover]:popover-open) {
-      > svg:nth-last-child(2) {
-        display: none;
-      }
-      > svg:last-child {
-        display: block;
-      }
+      --uds-header__user-button-icon: var(--uds-icon-chevronUp);
     }
 
     @composes ds-focus from '@digdir/designsystemet-css/base.css';

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -86,20 +86,33 @@
   }
 
   .uds-header__menu-button {
-    > svg:first-of-type {
-      display: block;
-    }
+    --uds-header__menu-button-icon-default: var(--uds-icon-menuHamburger);
+    --uds-header__menu-button-icon-active: var(--uds-icon-xMark);
+  }
 
-    > svg:last-of-type {
-      display: none;
+  .uds-header__theme-menu-button {
+    --uds-header__menu-button-icon-default: var(--uds-icon-chevronDown);
+    --uds-header__menu-button-icon-active: var(--uds-icon-chevronUp);
+  }
+
+  .uds-header__menu-button,
+  .uds-header__theme-menu-button {
+    &::before {
+      content: '';
+      display: block;
+      width: 1.3em;
+      height: 1.3em;
+      background: currentColor;
+      mask-image: var(--uds-header__menu-button-icon-default);
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
+      flex-shrink: 0;
     }
 
     &:has(+ [popover]:popover-open) {
-      > svg:first-of-type {
-        display: none;
-      }
-      > svg:last-of-type {
-        display: block;
+      &::before {
+        mask-image: var(--uds-header__menu-button-icon-active);
       }
     }
   }
@@ -131,7 +144,16 @@
         display: flex;
         gap: var(--ds-size-1);
         width: fit-content;
-        & > svg {
+        &::before {
+          content: '';
+          display: block;
+          width: 1em;
+          height: 1em;
+          background: currentColor;
+          mask-image: var(--uds-icon-arrowRight);
+          mask-size: contain;
+          mask-repeat: no-repeat;
+          mask-position: center;
           transform: translateY(var(--ds-size-1));
           flex-shrink: 0;
         }
@@ -205,30 +227,24 @@
       }
     }
 
-    > svg {
+    --uds-header__user-button-icon: var(--uds-icon-chevronDown);
+
+    &::after {
+      content: '';
+      display: block;
+      width: var(--ds-size-6);
+      height: var(--ds-size-6);
+      background: currentColor;
+      mask-image: var(--uds-header__user-button-icon);
+      mask-size: contain;
+      mask-repeat: no-repeat;
+      mask-position: center;
       margin-inline-start: var(--ds-size-1);
       flex-shrink: 0;
     }
 
-    > svg:nth-last-child(2) {
-      display: block;
-      width: auto;
-      height: var(--ds-size-6);
-    }
-
-    > svg:last-child {
-      display: none;
-      width: auto;
-      height: var(--ds-size-6);
-    }
-
     &:has(+ [popover]:popover-open) {
-      > svg:nth-last-child(2) {
-        display: none;
-      }
-      > svg:last-child {
-        display: block;
-      }
+      --uds-header__user-button-icon: var(--uds-icon-chevronUp);
     }
 
     @composes ds-focus from '@digdir/designsystemet-css/base.css';

--- a/@udir-design/react/src/components/header/headerMenu/HeaderMenuLink.tsx
+++ b/@udir-design/react/src/components/header/headerMenu/HeaderMenuLink.tsx
@@ -1,6 +1,5 @@
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
-import { ArrowRightIcon } from '@udir-design/icons';
 import type { LinkProps } from '../../link/Link';
 import { Link } from '../../link/Link';
 
@@ -17,7 +16,6 @@ export const HeaderMenuLink = forwardRef<
         ref={ref}
         {...props}
       >
-        <ArrowRightIcon aria-hidden />
         {children}
       </Link>
     </li>

--- a/@udir-design/react/src/demo/__snapshots__/ArticleDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/ArticleDemo.stories.tsx.snap
@@ -33,40 +33,6 @@ exports[`Article Story 1`] = `
             type="button"
             popovertarget="uds-header-menu"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-              >
-              </path>
-            </svg>
             Meny
           </button>
           <div
@@ -89,85 +55,21 @@ exports[`Article Story 1`] = `
                 <ul>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 1
                     </a>
                   </li>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 2
                     </a>
                   </li>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 3
                     </a>
                   </li>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 4
                     </a>
                   </li>

--- a/@udir-design/react/src/demo/__snapshots__/ArticleDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/ArticleDemo.stories.tsx.snap
@@ -33,40 +33,6 @@ exports[`Article Story 1`] = `
             type="button"
             popovertarget="uds-header-menu"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M2.75 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17A.75.75 0 0 1 2.75 6m0 6a.75.75 0 0 1 .75-.75h17a.75.75 0 0 1 0 1.5h-17a.75.75 0 0 1-.75-.75m.75 5.25a.75.75 0 0 0 0 1.5h17a.75.75 0 0 0 0-1.5z"
-                clip-rule="evenodd"
-              >
-              </path>
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="1em"
-              height="1em"
-              fill="none"
-              viewbox="0 0 24 24"
-              focusable="false"
-              role="img"
-              aria-hidden="true"
-            >
-              <path
-                fill="currentColor"
-                d="M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z"
-              >
-              </path>
-            </svg>
             Meny
           </button>
           <div
@@ -90,85 +56,21 @@ exports[`Article Story 1`] = `
                 <ul>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 1
                     </a>
                   </li>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 2
                     </a>
                   </li>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 3
                     </a>
                   </li>
                   <li>
                     <a href="#">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="1em"
-                        height="1em"
-                        fill="none"
-                        viewbox="0 0 24 24"
-                        focusable="false"
-                        role="img"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fill="currentColor"
-                          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-                        >
-                        </path>
-                      </svg>
                       Navigasjonslenke 4
                     </a>
                   </li>

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -49,42 +49,6 @@ exports[`Dashboard Page 2 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="<removed>"
@@ -176,7 +140,7 @@ exports[`Dashboard Page 2 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_i_-overview"
+        aria-controls="_r_e_-overview"
         data-value="overview"
         role="tab"
         aria-selected="false"
@@ -186,7 +150,7 @@ exports[`Dashboard Page 2 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_i_-tests"
+        aria-controls="_r_e_-tests"
         data-value="tests"
         role="tab"
         aria-selected="true"
@@ -196,7 +160,7 @@ exports[`Dashboard Page 2 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_i_-test-answers"
+        aria-controls="_r_e_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="false"
@@ -205,7 +169,7 @@ exports[`Dashboard Page 2 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_i_-settings"
+        aria-controls="_r_e_-settings"
         data-value="settings"
         role="tab"
         aria-selected="false"
@@ -735,42 +699,6 @@ exports[`Dashboard Page 3 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="<removed>"
@@ -862,7 +790,7 @@ exports[`Dashboard Page 3 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_10_-overview"
+        aria-controls="_r_q_-overview"
         data-value="overview"
         role="tab"
         aria-selected="false"
@@ -872,7 +800,7 @@ exports[`Dashboard Page 3 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_10_-tests"
+        aria-controls="_r_q_-tests"
         data-value="tests"
         role="tab"
         aria-selected="false"
@@ -881,7 +809,7 @@ exports[`Dashboard Page 3 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_10_-test-answers"
+        aria-controls="_r_q_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="true"
@@ -891,7 +819,7 @@ exports[`Dashboard Page 3 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_10_-settings"
+        aria-controls="_r_q_-settings"
         data-value="settings"
         role="tab"
         aria-selected="false"
@@ -1421,42 +1349,6 @@ exports[`Dashboard Page 4 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="<removed>"
@@ -1548,7 +1440,7 @@ exports[`Dashboard Page 4 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_1e_-overview"
+        aria-controls="_r_16_-overview"
         data-value="overview"
         role="tab"
         aria-selected="false"
@@ -1558,7 +1450,7 @@ exports[`Dashboard Page 4 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_1e_-tests"
+        aria-controls="_r_16_-tests"
         data-value="tests"
         role="tab"
         aria-selected="false"
@@ -1567,7 +1459,7 @@ exports[`Dashboard Page 4 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_1e_-test-answers"
+        aria-controls="_r_16_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="false"
@@ -1576,7 +1468,7 @@ exports[`Dashboard Page 4 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_1e_-settings"
+        aria-controls="_r_16_-settings"
         data-value="settings"
         role="tab"
         aria-selected="true"
@@ -2107,42 +1999,6 @@ exports[`Dashboard Story 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="<removed>"
@@ -2234,7 +2090,7 @@ exports[`Dashboard Story 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_4_-overview"
+        aria-controls="_r_2_-overview"
         data-value="overview"
         role="tab"
         aria-selected="true"
@@ -2244,7 +2100,7 @@ exports[`Dashboard Story 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_4_-tests"
+        aria-controls="_r_2_-tests"
         data-value="tests"
         role="tab"
         aria-selected="false"
@@ -2253,7 +2109,7 @@ exports[`Dashboard Story 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_4_-test-answers"
+        aria-controls="_r_2_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="false"
@@ -2262,7 +2118,7 @@ exports[`Dashboard Story 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_4_-settings"
+        aria-controls="_r_2_-settings"
         data-value="settings"
         role="tab"
         aria-selected="false"

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -52,42 +52,6 @@ exports[`Dashboard Page 2 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="usermenu2"
@@ -183,60 +147,60 @@ exports[`Dashboard Page 2 1`] = `
       tabindex="0"
     >
       <button
-        id="tab-_r_g_"
+        id="tab-_r_c_"
         aria-selected="false"
         data-value="overview"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_k_"
+        aria-controls="tabpanel-_r_g_"
       >
         Oversikt
       </button>
       <button
-        id="tab-_r_h_"
+        id="tab-_r_d_"
         aria-selected="true"
         data-value="tests"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="0"
-        aria-controls="tabpanel-_r_l_"
+        aria-controls="tabpanel-_r_h_"
       >
         Prøver
       </button>
       <button
-        id="tab-_r_i_"
+        id="tab-_r_e_"
         aria-selected="false"
         data-value="test-answers"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_m_"
+        aria-controls="tabpanel-_r_i_"
       >
         Prøvesvar
       </button>
       <button
-        id="tab-_r_j_"
+        id="tab-_r_f_"
         aria-selected="false"
         data-value="settings"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_n_"
+        aria-controls="tabpanel-_r_j_"
       >
         Innstillinger
       </button>
     </div>
     <div
-      id="tabpanel-_r_k_"
+      id="tabpanel-_r_g_"
       role="tabpanel"
       tabindex="0"
       hidden
-      aria-labelledby="tab-_r_g_"
+      aria-labelledby="tab-_r_c_"
     >
       <p data-variant="default">
         Her får du en oversikt over all den overordnede informasjonen.
@@ -305,9 +269,9 @@ exports[`Dashboard Page 2 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_l_"
+      id="tabpanel-_r_h_"
       role="tabpanel"
-      aria-labelledby="tab-_r_h_"
+      aria-labelledby="tab-_r_d_"
     >
       <p data-variant="default">
         Oversikt over prøver for Schweigaardsgate skole.
@@ -396,11 +360,11 @@ exports[`Dashboard Page 2 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_m_"
+      id="tabpanel-_r_i_"
       role="tabpanel"
       tabindex="0"
       hidden
-      aria-labelledby="tab-_r_i_"
+      aria-labelledby="tab-_r_e_"
     >
       <p data-variant="default">
         Oversikt over prøvesvar for Schweigaardsgate skole.
@@ -469,10 +433,10 @@ exports[`Dashboard Page 2 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_n_"
+      id="tabpanel-_r_j_"
       role="tabpanel"
       hidden
-      aria-labelledby="tab-_r_j_"
+      aria-labelledby="tab-_r_f_"
     >
       <div>
         <div>
@@ -748,42 +712,6 @@ exports[`Dashboard Page 3 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="usermenu2"
@@ -879,60 +807,60 @@ exports[`Dashboard Page 3 1`] = `
       tabindex="0"
     >
       <button
-        id="tab-_r_s_"
+        id="tab-_r_m_"
         aria-selected="false"
         data-value="overview"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_10_"
+        aria-controls="tabpanel-_r_q_"
       >
         Oversikt
       </button>
       <button
-        id="tab-_r_t_"
+        id="tab-_r_n_"
         aria-selected="false"
         data-value="tests"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_11_"
+        aria-controls="tabpanel-_r_r_"
       >
         Prøver
       </button>
       <button
-        id="tab-_r_u_"
+        id="tab-_r_o_"
         aria-selected="true"
         data-value="test-answers"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="0"
-        aria-controls="tabpanel-_r_12_"
+        aria-controls="tabpanel-_r_s_"
       >
         Prøvesvar
       </button>
       <button
-        id="tab-_r_v_"
+        id="tab-_r_p_"
         aria-selected="false"
         data-value="settings"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_13_"
+        aria-controls="tabpanel-_r_t_"
       >
         Innstillinger
       </button>
     </div>
     <div
-      id="tabpanel-_r_10_"
+      id="tabpanel-_r_q_"
       role="tabpanel"
       tabindex="0"
       hidden
-      aria-labelledby="tab-_r_s_"
+      aria-labelledby="tab-_r_m_"
     >
       <p data-variant="default">
         Her får du en oversikt over all den overordnede informasjonen.
@@ -1001,10 +929,10 @@ exports[`Dashboard Page 3 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_11_"
+      id="tabpanel-_r_r_"
       role="tabpanel"
       hidden
-      aria-labelledby="tab-_r_t_"
+      aria-labelledby="tab-_r_n_"
     >
       <p data-variant="default">
         Oversikt over prøver for Schweigaardsgate skole.
@@ -1093,10 +1021,10 @@ exports[`Dashboard Page 3 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_12_"
+      id="tabpanel-_r_s_"
       role="tabpanel"
       tabindex="0"
-      aria-labelledby="tab-_r_u_"
+      aria-labelledby="tab-_r_o_"
     >
       <p data-variant="default">
         Oversikt over prøvesvar for Schweigaardsgate skole.
@@ -1165,10 +1093,10 @@ exports[`Dashboard Page 3 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_13_"
+      id="tabpanel-_r_t_"
       role="tabpanel"
       hidden
-      aria-labelledby="tab-_r_v_"
+      aria-labelledby="tab-_r_p_"
     >
       <div>
         <div>
@@ -1444,42 +1372,6 @@ exports[`Dashboard Page 4 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="usermenu2"
@@ -1575,60 +1467,60 @@ exports[`Dashboard Page 4 1`] = `
       tabindex="0"
     >
       <button
-        id="tab-_r_18_"
+        id="tab-_r_10_"
         aria-selected="false"
         data-value="overview"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_1c_"
+        aria-controls="tabpanel-_r_14_"
       >
         Oversikt
       </button>
       <button
-        id="tab-_r_19_"
+        id="tab-_r_11_"
         aria-selected="false"
         data-value="tests"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_1d_"
+        aria-controls="tabpanel-_r_15_"
       >
         Prøver
       </button>
       <button
-        id="tab-_r_1a_"
+        id="tab-_r_12_"
         aria-selected="false"
         data-value="test-answers"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_1e_"
+        aria-controls="tabpanel-_r_16_"
       >
         Prøvesvar
       </button>
       <button
-        id="tab-_r_1b_"
+        id="tab-_r_13_"
         aria-selected="true"
         data-value="settings"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="0"
-        aria-controls="tabpanel-_r_1f_"
+        aria-controls="tabpanel-_r_17_"
       >
         Innstillinger
       </button>
     </div>
     <div
-      id="tabpanel-_r_1c_"
+      id="tabpanel-_r_14_"
       role="tabpanel"
       tabindex="0"
       hidden
-      aria-labelledby="tab-_r_18_"
+      aria-labelledby="tab-_r_10_"
     >
       <p data-variant="default">
         Her får du en oversikt over all den overordnede informasjonen.
@@ -1697,10 +1589,10 @@ exports[`Dashboard Page 4 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_1d_"
+      id="tabpanel-_r_15_"
       role="tabpanel"
       hidden
-      aria-labelledby="tab-_r_19_"
+      aria-labelledby="tab-_r_11_"
     >
       <p data-variant="default">
         Oversikt over prøver for Schweigaardsgate skole.
@@ -1789,11 +1681,11 @@ exports[`Dashboard Page 4 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_1e_"
+      id="tabpanel-_r_16_"
       role="tabpanel"
       tabindex="0"
       hidden
-      aria-labelledby="tab-_r_1a_"
+      aria-labelledby="tab-_r_12_"
     >
       <p data-variant="default">
         Oversikt over prøvesvar for Schweigaardsgate skole.
@@ -1862,9 +1754,9 @@ exports[`Dashboard Page 4 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_1f_"
+      id="tabpanel-_r_17_"
       role="tabpanel"
-      aria-labelledby="tab-_r_1b_"
+      aria-labelledby="tab-_r_13_"
     >
       <div>
         <div>
@@ -2140,42 +2032,6 @@ exports[`Dashboard Story 1`] = `
             SH
           </span>
         </span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M11.47 7.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 1 1-1.06 1.06L12 9.56l-4.97 4.97a.75.75 0 0 1-1.06-1.06z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </button>
       <div
         id="usermenu2"
@@ -2271,59 +2127,59 @@ exports[`Dashboard Story 1`] = `
       tabindex="0"
     >
       <button
-        id="tab-_r_4_"
+        id="tab-_r_2_"
         aria-selected="true"
         data-value="overview"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="0"
-        aria-controls="tabpanel-_r_8_"
+        aria-controls="tabpanel-_r_6_"
       >
         Oversikt
       </button>
       <button
-        id="tab-_r_5_"
+        id="tab-_r_3_"
         aria-selected="false"
         data-value="tests"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_9_"
+        aria-controls="tabpanel-_r_7_"
       >
         Prøver
       </button>
       <button
-        id="tab-_r_6_"
+        id="tab-_r_4_"
         aria-selected="false"
         data-value="test-answers"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_a_"
+        aria-controls="tabpanel-_r_8_"
       >
         Prøvesvar
       </button>
       <button
-        id="tab-_r_7_"
+        id="tab-_r_5_"
         aria-selected="false"
         data-value="settings"
         role="tab"
         type="button"
         data-roving-tabindex-item="true"
         tabindex="-1"
-        aria-controls="tabpanel-_r_b_"
+        aria-controls="tabpanel-_r_9_"
       >
         Innstillinger
       </button>
     </div>
     <div
-      id="tabpanel-_r_8_"
+      id="tabpanel-_r_6_"
       role="tabpanel"
       tabindex="0"
-      aria-labelledby="tab-_r_4_"
+      aria-labelledby="tab-_r_2_"
     >
       <p data-variant="default">
         Her får du en oversikt over all den overordnede informasjonen.
@@ -2392,10 +2248,10 @@ exports[`Dashboard Story 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_9_"
+      id="tabpanel-_r_7_"
       role="tabpanel"
       hidden
-      aria-labelledby="tab-_r_5_"
+      aria-labelledby="tab-_r_3_"
     >
       <p data-variant="default">
         Oversikt over prøver for Schweigaardsgate skole.
@@ -2484,11 +2340,11 @@ exports[`Dashboard Story 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_a_"
+      id="tabpanel-_r_8_"
       role="tabpanel"
       tabindex="0"
       hidden
-      aria-labelledby="tab-_r_6_"
+      aria-labelledby="tab-_r_4_"
     >
       <p data-variant="default">
         Oversikt over prøvesvar for Schweigaardsgate skole.
@@ -2557,10 +2413,10 @@ exports[`Dashboard Story 1`] = `
       </div>
     </div>
     <div
-      id="tabpanel-_r_b_"
+      id="tabpanel-_r_9_"
       role="tabpanel"
       hidden
-      aria-labelledby="tab-_r_7_"
+      aria-labelledby="tab-_r_5_"
     >
       <div>
         <div>


### PR DESCRIPTION
## Hva er gjort?

Byttet ut alle ikoner i tsx for `Header` med css-ikoner i stedet. Funker fint i test-app og ser bra ut for det blåtte øyet. Se kommentar om visuelle tester i chromatic. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Komponenten er testet i test-app
