### PR TITLE
fix(FileUpload): bugs and accessibility issues

### DIFF
--- a/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
@@ -58,7 +58,7 @@ export const DocumentationPage = ({
       <FileUpload.Dropzone
         label={<span>Last opp dokumentasjon</span>}
         description="Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB."
-        {...getRootProps()}
+        cardProps={getRootProps()}
         inputProps={{
           ...getInputProps({
             required: true,

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -33,7 +33,7 @@ Det finnes flere måter å håndtere opplasting av filer. Se eksempler på dette
 
 ### Dra og slipp
 
-Varianten `FileUpload.Dropzone`er et stipla område med en knapp inni, ment å bruke for dra og slipp ved filopplasting. I dette eksempelet bruker vi [biblioteket `react-dropzone`](https://react-dropzone.js.org/). Komponenten er utviklet slik at den støtter dette biblioteket, men man står fritt til å velge løsningen man selv ønsker.
+Varianten `FileUpload.Dropzone` har et stipla område med en knapp inni, ment å bruke for dra og slipp ved filopplasting. I dette eksempelet bruker vi [biblioteket `react-dropzone`](https://react-dropzone.js.org/). Komponenten er utviklet slik at den støtter dette biblioteket, men man står fritt til å velge løsningen man selv ønsker.
 
 Komponenten er stylet slik at man kan bruke `isDragActive` for å endre utseendet på dropzone når brukeren holder en fil over den. Du kan også bruke `isDragGlobal` for å utheve dropzone når brukeren drar en fil over vinduet. Disse propertiesene får du ut av boksen med `react-dropzone`, men du kan også skrive din egen logikk så lenge du bruker samme property-navn. Se eksempelet under for hvordan dette ser ut.
 

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -4,6 +4,7 @@ import type { FileRejection, FileWithPath } from 'react-dropzone';
 import { useDropzone } from 'react-dropzone';
 import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Heading } from '../typography/heading/Heading';
 import { FileUpload } from './index';
 
@@ -19,6 +20,7 @@ const meta = preview.meta({
 });
 
 export const Preview = meta.story({
+  parameters: { docs: advancedCodeDocs },
   args: {
     'data-size': 'md',
     label: 'Label',
@@ -50,15 +52,13 @@ export const Preview = meta.story({
           justifyContent: 'center',
         }}
       >
-        <FileUpload.Trigger
-          {...args}
-          inputProps={{ ...args.inputProps, id: 'trigger' }}
-        />
+        <FileUpload.Trigger {...args} inputProps={{ ...args.inputProps }} />
         <FileUpload.Dropzone
-          {...getRootProps(args)}
-          inputProps={getInputProps({ ...args.inputProps, id: 'dropzone' })}
+          {...args}
+          inputProps={getInputProps({ ...args.inputProps })}
           isDragGlobal={isDragGlobal}
           isDragActive={isDragActive}
+          cardProps={getRootProps()}
         />
       </div>
     );
@@ -80,13 +80,13 @@ export const Readonly = meta.story({
       >
         <FileUpload.Trigger
           {...args}
-          inputProps={{ readOnly: true, id: 'readonly-trigger' }}
+          inputProps={{ readOnly: true }}
           label="Lesemodus"
           description="Beskrivelse for Trigger"
         />
         <FileUpload.Dropzone
           {...args}
-          inputProps={{ readOnly: true, max: 2, id: 'readonly-dropzone' }}
+          inputProps={{ readOnly: true, max: 2 }}
           label="Lesemodus"
           description="Beskrivelse for Dropzone"
         />
@@ -102,6 +102,7 @@ export const ExampleDropZone = meta.story({
       flexDirection: 'column',
       gap: 'var(--ds-size-3)',
     },
+    docs: advancedCodeDocs,
   },
   render: (args) => {
     const [files, setFiles] = useState<File[]>([]);
@@ -138,15 +139,12 @@ export const ExampleDropZone = meta.story({
         <FileUpload.Dropzone
           label="Last opp dokumentasjon"
           description="Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB."
-          inputProps={{
-            ...getInputProps({ multiple: true }),
-            id: 'dokumentasjon',
-          }}
+          inputProps={getInputProps({ multiple: true })}
           isDragGlobal={isDragGlobal}
           isDragActive={isDragActive}
           data-testid="dropzone"
           error={files.length > 2 && 'Du har lastet opp for mange filer.'}
-          {...getRootProps()}
+          cardProps={getRootProps()}
           {...args}
         />
         {files.length > 0 && (
@@ -221,6 +219,7 @@ export const ExampleDropzoneWithExplicitSize = ExampleDropZone.extend({
 });
 
 export const TooManyFiles = meta.story({
+  parameters: { docs: advancedCodeDocs },
   render: (args) => {
     const [files, setFiles] = useState<File[]>([
       new File(['abc'.repeat(100000)], 'eksempel1.pdf'),
@@ -258,8 +257,8 @@ export const TooManyFiles = meta.story({
             files.length > 2 &&
             'Du har lastet opp for mange filer. Fjern noen for å kunne sende inn skjemaet.'
           }
-          inputProps={{ ...getInputProps(), id: 'dokumentasjon-for-mange' }}
-          {...getRootProps()}
+          inputProps={getInputProps()}
+          cardProps={getRootProps()}
           isDragGlobal={isDragGlobal}
           isDragActive={isDragActive}
           style={{ maxWidth: '450px', width: '100%' }}
@@ -317,7 +316,6 @@ export const ExampleTrigger = meta.story({
         <FileUpload.Trigger
           inputProps={{
             accept: 'image/png, image/jpeg',
-            id: 'profilbilde',
           }}
           onChange={(e) => handleOnChange(e)}
           data-testid="trigger"
@@ -459,7 +457,6 @@ export const Upload = meta.story({
           label="Last opp rapport"
           description="Du kan legge ved 1 fil."
           onChange={handleOnChange}
-          inputProps={{ id: 'rapport' }}
         />
         {file && (
           <>

--- a/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadDropzone.tsx
@@ -1,7 +1,7 @@
 import './fileUpload.css';
-import type { DSFieldElement } from '@digdir/designsystemet-web';
 import cl from 'clsx/lite';
-import { forwardRef, useEffect, useRef } from 'react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef, useEffect, useId, useRef } from 'react';
 import { UploadIcon } from '@udir-design/icons';
 import { Button } from '../button/Button';
 import { Card } from '../card/Card';
@@ -21,10 +21,14 @@ export type FileUploadDropzoneProps = FileUploadProps & {
    * anywhere in the document
    */
   isDragGlobal?: boolean;
+  /**
+   * Props for the card representing the drop zone
+   */
+  cardProps?: Omit<HTMLAttributes<HTMLDivElement>, 'data-size' | 'data-color'>;
 };
 
 export const FileUploadDropzone = forwardRef<
-  DSFieldElement,
+  HTMLDivElement,
   FileUploadDropzoneProps
 >(function FileUploadDropzone(
   {
@@ -37,6 +41,7 @@ export const FileUploadDropzone = forwardRef<
     isDragGlobal,
     variant = 'secondary',
     inputProps,
+    cardProps,
     ...rest
   },
   ref,
@@ -55,29 +60,50 @@ export const FileUploadDropzone = forwardRef<
     buttonRef.current.setAttribute('aria-label', buttonAriaLabel);
   }, [cssVar]);
 
+  const generatedId = useId();
+  const id = rest.id ?? generatedId;
+  const buttonId = `${id}-button`;
+  const labelId = `${id}-label`;
+  const descriptionId = `${id}-description`;
+
   return (
-    <Field
-      className={cl(`uds-file-upload`, className)}
+    <div
+      className={cl('ds-field', 'uds-file-upload', className)}
       data-size={size}
-      onDrop={(e) => {
-        if (inputProps?.readOnly) {
-          e.preventDefault();
-          return;
-        }
-        rest.onDrop?.(e);
-      }}
       data-drag-active={isDragActive || undefined}
       data-drag-global={isDragGlobal || undefined}
       ref={ref}
       {...rest}
     >
-      {!!label && <Label>{label}</Label>}
-      {!!description && <Field.Description>{description}</Field.Description>}
-      <Card>
+      {!!label && (
+        <Label id={labelId} htmlFor={buttonId}>
+          {label}
+        </Label>
+      )}
+      {!!description && (
+        <Field.Description id={descriptionId}>{description}</Field.Description>
+      )}
+      <Card
+        {...cardProps}
+        onDrop={(e) => {
+          if (inputProps?.readOnly) {
+            e.preventDefault();
+            return;
+          }
+          cardProps?.onDrop?.(e);
+        }}
+        tabIndex={undefined}
+      >
         {/* Text in css */}
         <div>{/* Text in css */}</div>
         {!inputProps?.readOnly && (
-          <Button variant={variant} ref={buttonRef}>
+          <Button
+            id={buttonId}
+            aria-labelledby={label ? labelId : undefined}
+            aria-describedby={description ? descriptionId : undefined}
+            variant={variant}
+            ref={buttonRef}
+          >
             <UploadIcon aria-hidden />
             {/* Text in css */}
           </Button>
@@ -94,6 +120,6 @@ export const FileUploadDropzone = forwardRef<
         }}
       />
       {!!error && <ValidationMessage>{error}</ValidationMessage>}
-    </Field>
+    </div>
   );
 });

--- a/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadTrigger.tsx
@@ -1,8 +1,7 @@
 import type { Size } from '@digdir/designsystemet-react';
-import type { DSFieldElement } from '@digdir/designsystemet-web';
 import cl from 'clsx/lite';
 import type { HTMLAttributes, ReactNode } from 'react';
-import { forwardRef, useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useId, useRef } from 'react';
 import { UploadIcon } from '@udir-design/icons';
 import { Button } from '../button/Button';
 import { Field } from '../field/Field';
@@ -16,7 +15,7 @@ type InputProps_ = Omit<
   'prefix' | 'className' | 'style' | 'data-color' | 'type' | 'data-size'
 >;
 
-export type FileUploadProps = HTMLAttributes<DSFieldElement> & {
+export type FileUploadProps = HTMLAttributes<HTMLDivElement> & {
   /**
    * Changes size for descendant Designsystemet components.
    * Select from predefined sizes.
@@ -46,7 +45,7 @@ export type FileUploadProps = HTMLAttributes<DSFieldElement> & {
   variant?: 'primary' | 'secondary';
 };
 
-export const FileUploadTrigger = forwardRef<DSFieldElement, FileUploadProps>(
+export const FileUploadTrigger = forwardRef<HTMLDivElement, FileUploadProps>(
   function FileUploadTrigger(
     {
       className,
@@ -75,16 +74,33 @@ export const FileUploadTrigger = forwardRef<DSFieldElement, FileUploadProps>(
       buttonRef.current.setAttribute('aria-label', buttonAriaLabel);
     }, [cssVar]);
 
+    const generatedId = useId();
+    const id = rest.id ?? generatedId;
+    const buttonId = `${id}-button`;
+    const labelId = `${id}-label`;
+    const descriptionId = `${id}-description`;
+
     return (
-      <Field
-        className={cl(`uds-file-upload`, className)}
+      <div
+        className={cl('ds-field', 'uds-file-upload', className)}
         data-size={size}
         ref={ref}
         {...rest}
       >
-        {!!label && <Label>{label}</Label>}
-        {!!description && <Field.Description>{description}</Field.Description>}
+        {!!label && (
+          <Label id={labelId} htmlFor={buttonId}>
+            {label}
+          </Label>
+        )}
+        {!!description && (
+          <Field.Description id={descriptionId}>
+            {description}
+          </Field.Description>
+        )}
         <Button
+          id={buttonId}
+          aria-labelledby={label ? labelId : undefined}
+          aria-describedby={description ? descriptionId : undefined}
           disabled={inputProps?.readOnly ?? inputProps?.disabled}
           variant={variant}
           onClick={() => {
@@ -107,7 +123,7 @@ export const FileUploadTrigger = forwardRef<DSFieldElement, FileUploadProps>(
           }}
         />
         {!!error && <ValidationMessage>{error}</ValidationMessage>}
-      </Field>
+      </div>
     );
   },
 );

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -1,12 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Example Drop Zone 1`] = `
-<ds-field
-  role="presentation"
-  tabindex="0"
->
+<div>
   <label
     data-weight="medium"
+    id="<removed>"
     for="<removed>"
   >
     Last opp dokumentasjon
@@ -17,12 +15,18 @@ exports[`Example Drop Zone 1`] = `
   >
     Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
   </div>
-  <div data-variant="default">
+  <div
+    data-variant="default"
+    role="presentation"
+  >
     <div>
     </div>
     <button
       data-variant="secondary"
       type="button"
+      id="<removed>"
+      aria-labelledby="<removed>"
+      aria-describedby="<removed>"
       aria-label="Velg filer"
     >
       <svg
@@ -49,12 +53,10 @@ exports[`Example Drop Zone 1`] = `
     accept="application/pdf"
     multiple
     tabindex="-1"
-    id="<removed>"
     type="file"
-    aria-describedby="<removed>"
     style="<removed>"
   >
-</ds-field>
+</div>
 <h3 data-size="2xs">
   Vedlegg (1):
 </h3>
@@ -140,12 +142,10 @@ exports[`Example Dropzone With Explicit Size 1`] = `
 <style>
   .uds-file-upload { height: 600px; width: 100%; }
 </style>
-<ds-field
-  role="presentation"
-  tabindex="0"
->
+<div>
   <label
     data-weight="medium"
+    id="<removed>"
     for="<removed>"
   >
     Last opp dokumentasjon
@@ -156,12 +156,18 @@ exports[`Example Dropzone With Explicit Size 1`] = `
   >
     Du kan laste opp filer i PDF-format. Filer kan være opptil 0.5 MB.
   </div>
-  <div data-variant="default">
+  <div
+    data-variant="default"
+    role="presentation"
+  >
     <div>
     </div>
     <button
       data-variant="secondary"
       type="button"
+      id="<removed>"
+      aria-labelledby="<removed>"
+      aria-describedby="<removed>"
       aria-label="Velg filer"
     >
       <svg
@@ -188,12 +194,10 @@ exports[`Example Dropzone With Explicit Size 1`] = `
     accept="application/pdf"
     multiple
     tabindex="-1"
-    id="<removed>"
     type="file"
-    aria-describedby="<removed>"
     style="<removed>"
   >
-</ds-field>
+</div>
 <h3 data-size="2xs">
   Vedlegg (1):
 </h3>
@@ -625,9 +629,10 @@ exports[`Example Items 1`] = `
 
 exports[`Example Trigger 1`] = `
 <div style="<removed>">
-  <ds-field>
+  <div>
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Last opp profilbilde
@@ -641,6 +646,9 @@ exports[`Example Trigger 1`] = `
     <button
       data-variant="secondary"
       type="button"
+      id="<removed>"
+      aria-labelledby="<removed>"
+      aria-describedby="<removed>"
       aria-label="Legg til fil"
     >
       <svg
@@ -664,11 +672,9 @@ exports[`Example Trigger 1`] = `
     </button>
     <input
       accept="image/png, image/jpeg"
-      id="<removed>"
       type="file"
-      aria-describedby="<removed>"
     >
-  </ds-field>
+  </div>
   <h3 data-size="2xs">
     Vedlegg (1):
   </h3>
@@ -748,9 +754,10 @@ exports[`Example Trigger 1`] = `
 
 exports[`Preview 1`] = `
 <div style="<removed>">
-  <ds-field data-size="md">
+  <div data-size="md">
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Label
@@ -764,6 +771,9 @@ exports[`Preview 1`] = `
     <button
       data-variant="secondary"
       type="button"
+      id="<removed>"
+      aria-labelledby="<removed>"
+      aria-describedby="<removed>"
       aria-label="Legg til fil"
     >
       <svg
@@ -785,19 +795,12 @@ exports[`Preview 1`] = `
         </path>
       </svg>
     </button>
-    <input
-      id="<removed>"
-      type="file"
-      aria-describedby="<removed>"
-    >
-  </ds-field>
-  <ds-field
-    data-size="md"
-    role="presentation"
-    tabindex="0"
-  >
+    <input type="file">
+  </div>
+  <div data-size="md">
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Label
@@ -808,12 +811,18 @@ exports[`Preview 1`] = `
     >
       Beskrivelse
     </div>
-    <div data-variant="default">
+    <div
+      data-variant="default"
+      role="presentation"
+    >
       <div>
       </div>
       <button
         data-variant="secondary"
         type="button"
+        id="<removed>"
+        aria-labelledby="<removed>"
+        aria-describedby="<removed>"
         aria-label="Velg fil"
       >
         <svg
@@ -839,20 +848,19 @@ exports[`Preview 1`] = `
     <input
       accept="application/pdf"
       tabindex="-1"
-      id="<removed>"
       type="file"
-      aria-describedby="<removed>"
       style="<removed>"
     >
-  </ds-field>
+  </div>
 </div>
 `;
 
 exports[`Readonly 1`] = `
 <div style="<removed>">
-  <ds-field>
+  <div>
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Lesemodus
@@ -866,6 +874,9 @@ exports[`Readonly 1`] = `
     <button
       data-variant="secondary"
       type="button"
+      id="<removed>"
+      aria-labelledby="<removed>"
+      aria-describedby="<removed>"
       disabled
       aria-label="Legg til fil"
     >
@@ -890,14 +901,13 @@ exports[`Readonly 1`] = `
     </button>
     <input
       readonly
-      id="<removed>"
       type="file"
-      aria-describedby="<removed>"
     >
-  </ds-field>
-  <ds-field>
+  </div>
+  <div>
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Lesemodus
@@ -915,23 +925,18 @@ exports[`Readonly 1`] = `
     <input
       readonly
       max="2"
-      id="<removed>"
       type="file"
-      aria-describedby="<removed>"
     >
-  </ds-field>
+  </div>
 </div>
 `;
 
 exports[`Too Many Files 1`] = `
 <div style="<removed>">
-  <ds-field
-    role="presentation"
-    tabindex="0"
-    style="<removed>"
-  >
+  <div style="<removed>">
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Last opp dokumentasjon
@@ -942,12 +947,18 @@ exports[`Too Many Files 1`] = `
     >
       Du kan kun laste opp 2 filer.
     </div>
-    <div data-variant="default">
+    <div
+      data-variant="default"
+      role="presentation"
+    >
       <div>
       </div>
       <button
         data-variant="secondary"
         type="button"
+        id="<removed>"
+        aria-labelledby="<removed>"
+        aria-describedby="<removed>"
         aria-label="Velg filer"
       >
         <svg
@@ -973,19 +984,13 @@ exports[`Too Many Files 1`] = `
     <input
       multiple
       tabindex="-1"
-      id="<removed>"
       type="file"
-      aria-describedby="<removed>"
-      aria-invalid="true"
       style="<removed>"
     >
-    <p
-      data-field="validation"
-      id="<removed>"
-    >
+    <p data-field="validation">
       Du har lastet opp for mange filer. Fjern noen for å kunne sende inn skjemaet.
     </p>
-  </ds-field>
+  </div>
   <h3 data-size="2xs">
     Vedlegg (3):
   </h3>
@@ -1217,9 +1222,10 @@ exports[`Too Many Files 1`] = `
 
 exports[`Upload 1`] = `
 <div style="<removed>">
-  <ds-field>
+  <div>
     <label
       data-weight="medium"
+      id="<removed>"
       for="<removed>"
     >
       Last opp rapport
@@ -1233,6 +1239,9 @@ exports[`Upload 1`] = `
     <button
       data-variant="secondary"
       type="button"
+      id="<removed>"
+      aria-labelledby="<removed>"
+      aria-describedby="<removed>"
       aria-label="Legg til fil"
     >
       <svg
@@ -1254,11 +1263,7 @@ exports[`Upload 1`] = `
         </path>
       </svg>
     </button>
-    <input
-      id="<removed>"
-      type="file"
-      aria-describedby="<removed>"
-    >
-  </ds-field>
+    <input type="file">
+  </div>
 </div>
 `;

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -137,14 +137,12 @@
   }
 
   &:not([aria-busy='true']):not(:has(input[readOnly])) {
-    &:hover {
-      > .ds-card {
-        cursor: pointer;
+    > .ds-card:hover {
+      cursor: pointer;
 
-        > .ds-button {
-          background: var(--dsc-button-background--hover);
-          color: var(--dsc-button-color--hover);
-        }
+      > .ds-button {
+        background: var(--dsc-button-background--hover);
+        color: var(--dsc-button-color--hover);
       }
     }
   }

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -147,6 +147,13 @@
     }
   }
 
+  &:has(label:hover) {
+    .ds-button:hover {
+      background: var(--dsc-button-background);
+      color: var(--dsc-button-color);
+    }
+  }
+
   /* Text for multiple files */
   &:has(input[type='file'][multiple]) {
     --udsc-fileUpload-button-text: var(--udsc-fileUpload-addFiles-text);

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -826,12 +826,10 @@ exports[`Form Page 3 1`] = `
       </h2>
       <div>
       </div>
-      <ds-field
-        role="presentation"
-        tabindex="0"
-      >
+      <div>
         <label
           data-weight="medium"
+          id="<removed>"
           for="<removed>"
         >
           <span>
@@ -844,12 +842,18 @@ exports[`Form Page 3 1`] = `
         >
           Du kan laste opp filer i PDF-format. Filer kan være opptil 25 MB.
         </div>
-        <div data-variant="default">
+        <div
+          data-variant="default"
+          role="presentation"
+        >
           <div>
           </div>
           <button
             data-variant="secondary"
             type="button"
+            id="<removed>"
+            aria-labelledby="<removed>"
+            aria-describedby="<removed>"
             aria-label="Velg filer"
           >
             <svg
@@ -879,10 +883,9 @@ exports[`Form Page 3 1`] = `
           required
           id="<removed>"
           type="file"
-          aria-describedby="<removed>"
           style="<removed>"
         >
-      </ds-field>
+      </div>
       <ds-field>
         <label
           data-weight="medium"
@@ -1100,7 +1103,7 @@ exports[`Form Page 4 1`] = `
     >
       <button
         data-icon="true"
-        commandfor="_r_l_"
+        commandfor="_r_m_"
         data-variant="tertiary"
         type="button"
         aria-label="Lukk dialogvindu"
@@ -1380,7 +1383,7 @@ exports[`Form Page 5 1`] = `
     >
       <button
         data-icon="true"
-        commandfor="_r_r_"
+        commandfor="_r_s_"
         data-variant="tertiary"
         type="button"
         aria-label="Lukk dialogvindu"


### PR DESCRIPTION
## Hva er gjort?

- CSS-justeringer for å få hover-effekt til å bli som forventet for våre inputelementer, dvs ingen hover på label eller description
- Erstatter logikken fra `Field` som automatisk koblet opp label/description med det skjulte inputfeltet. Laget vår egen logikk som kobler label/description opp mot den synlige knappen.
  - Dette gjør også at klikk på label åpner filvelger, mens klikk på description ikke gjør det. Dette er slik andre inputelementer også fungerer.
- Flytter react-dropzone props til Card og overstyrer tabindex fra react-dropzone for å unngå å skape et unødvendig ekstra fokuserbart element (som ga en feil i ARC Toolkit). Vi trenger ikke dette fokuselementet fordi vi allerede har en knapp som blir fokusert.
