### PR TITLE
docs(DemoVersion): make example interactive in docs by using WithInertInitialRender decorator

### DIFF
--- a/@udir-design/react/.storybook/decorators/WithInertInitialRender.tsx
+++ b/@udir-design/react/.storybook/decorators/WithInertInitialRender.tsx
@@ -1,14 +1,62 @@
 import type { Decorator } from '@storybook/react-vite';
-import { useEffect, useState } from 'react';
+import React from 'react';
+import { useContext, useEffect, useState } from 'react';
 
+const IsInertContext = React.createContext<boolean | null>(null);
+
+/** Use this decorator to initially render a story in an inert state, e.g. to prevent the story
+ * from stealing focus and scrolling the reader to the middle of a documentation page.
+ *
+ * It sets the `inert` attribute on a parent element of the story, which is usually enough to block
+ * focus stealing. However, if the element that steals focus renders in the top layer (e.g. a `Dialog`)
+ * you must additionally do something like this in the story:
+ * ```
+ * const isInert = useIsInert();
+ * return (
+ *   <Dialog
+ *     open={true}
+ *     {...(isInert && { inert: true })} // this is the important line
+ *   >
+ *     <SomeContent />
+ *   </Dialog>
+ * )
+ * ```
+ *
+ */
 export const WithInertInitialRender: Decorator = (Story, context) => {
+  if (context.viewMode === 'story') {
+    // Hacky way to detect docs mode in iframe-rendered story
+    const isInDocsPage =
+      window.parent.location.search.includes('viewMode=docs');
+    if (isInDocsPage) {
+      // Set viewMode since Storybook doesn't detect it properly when rendered with "inline: false" (iframe mode)
+      context.viewMode = 'docs';
+    }
+  }
   const [inert, setInert] = useState(context.viewMode === 'docs');
   useEffect(() => {
     setTimeout(() => setInert(false), 500);
   }, []);
   return (
     <div data-storybook-decorator inert={inert}>
-      <Story />
+      <IsInertContext value={inert}>
+        <Story />
+      </IsInertContext>
     </div>
   );
 };
+
+/**
+ * This hook is necessary to use the `WithInertInitialRender` decorator for Dialog or other
+ * elements that render in the top layer, because they are unaffected by the `inert` attribute
+ * set on an ancestor
+ */
+export function useIsInert(): boolean {
+  const isInert = useContext(IsInertContext);
+  if (isInert === null) {
+    throw new Error(
+      'You must add the decorator WithInertInitialRender to the story for the useIsInert hook to work',
+    );
+  }
+  return isInert;
+}

--- a/@udir-design/react/src/patterns/DemoVersion.mdx
+++ b/@udir-design/react/src/patterns/DemoVersion.mdx
@@ -27,8 +27,6 @@ Vis en dialog når brukeren først går inn i demo-modusen. Dialogen bør ha en 
 
 Behovet for bruk av dialog ved oppstart vil variere fra tjeneste til tjeneste. I noen tilfeller kan det være tilstrekkelig med kun et vedvarende banner. Noen tjenester blir brukt ofte av de samme brukerne, og da kan en dialog ved hver oppstart bli forstyrrende, mens tjenester som brukes sjeldnere kan ha behov for det, siden faren for at brukeren misforstår at de er i feil versjon er større.
 
-Merk: eksempelet er ikke interaktivt. [Gå til interaktivt eksempel](/story/patterns-demoversjon-av-tjenester--preview).
-
 <Canvas
   story={{ inline: false, height: '800px' }}
   of={DemoVersionStories.Preview}

--- a/@udir-design/react/src/patterns/DemoVersion.stories.tsx
+++ b/@udir-design/react/src/patterns/DemoVersion.stories.tsx
@@ -1,4 +1,8 @@
 import { type CSSProperties } from 'react';
+import {
+  WithInertInitialRender,
+  useIsInert,
+} from '.storybook/decorators/WithInertInitialRender';
 import preview from '.storybook/preview';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Alert } from 'src/components/alert';
@@ -31,17 +35,9 @@ export const Preview = meta.story({
       padding: 0,
     },
   },
-  decorators: (Story, context) => {
-    // Hacky way to detect docs mode in iframe-rendered story
-    const isInDocsPage =
-      window.parent.location.search.includes('viewMode=docs');
-    if (isInDocsPage) {
-      // Set viewMode since Storybook doesn't detect it properly when rendered with "inline: false" (iframe mode)
-      context.viewMode = 'docs';
-    }
-    return <Story />;
-  },
-  render: (_args, context) => {
+  decorators: WithInertInitialRender,
+  render: () => {
+    const isInert = useIsInert();
     return (
       <DemoBanner
         style={{
@@ -100,8 +96,8 @@ export const Preview = meta.story({
           open={true}
           style={{ maxWidth: '650px' }}
           id="demo-version-dialog"
-          // Render the dialog as inert in docs page, so it doesn't steal focus
-          {...(context.viewMode === 'docs' && { inert: true })}
+          // In docs, initially render Dialog as inert so it doesn't steal focus
+          {...(isInert && { inert: true })}
         >
           <Heading style={{ marginBlockEnd: 'var(--ds-size-4)' }}>
             Lorem ipsum dolor sit amet consectetur


### PR DESCRIPTION
## Kva er gjort?

Fann ei betre løysing på problemet der DemoVersion-mønsteret sitt eksempel måtte vere ikkje-interaktivt for å hindre at man blei scrolla til midten av sida. Løysinga er å starte som ikkje-interaktiv, men skru på igjen interaktivitet etter 500ms.

Logikken for å gjere dette er no i decorator `WithInertInitialRender` (laga i forbindelse med Digdir-oppgradering der ErrorSummary begynte å stjele fokus i dokumentasjonen), som er utvida til å innehalde ein context man kan slå opp med `useIsInert()` dersom man treng å sette dette på ein top-layer komponent som f.eks. Dialog.

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Dokumentasjonen er oppdatert om nødvendig