### PR TITLE
build(nextjs): fix nx cache issues

### DIFF
--- a/test-apps/nextjs/project.json
+++ b/test-apps/nextjs/project.json
@@ -1,6 +1,9 @@
 {
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
+    "build": {
+      "outputs": ["{projectRoot}/.next"]
+    },
     "start": {
       "dependsOn": ["build"]
     },


### PR DESCRIPTION
nextjs uses `.next` and not `dist` as output dir, so nx cache didn't work

## Hva er gjort?

Dette skal fikse at `pnpm nx build` eller `pnpm nx start` i test-apps/nextjs av og til endte opp med å kjøre gamal kode. Det skjedde fordi vi aldri faktisk fortalte Nx at den skulle cache nextjs sin output, så cachen lagra ingenting — og skreiv dermed heller ikkje over noko når den henta ut output frå cachen 😬