### PR TITLE
docs(Alert): adjust guidelines and internal usage

### DIFF
--- a/@udir-design/react/src/components/alert/Alert.mdx
+++ b/@udir-design/react/src/components/alert/Alert.mdx
@@ -9,16 +9,17 @@ Vi bruker `Alert` til å gi brukeren informasjon som det er ekstra viktig at de 
 
 **Passer til å**
 
-- gi korte og informative tidsbegrensede varsler
-- informere om feil som kun påvirker én del av systemet eller en mindre funksjon
-- informere om tilkoblingsproblemer eller API-feil som sannsynligvis løser seg ved å laste inn siden på nytt
+- gi korte, informative og ofte tidsbegrensede varsler
+- utheve informasjon brukere må være ekstra oppmerksom på
+- varsle om feil som kun påvirker én del av systemet eller en mindre funksjon
+- varsle om tilkoblingsproblemer eller API-feil som sannsynligvis løser seg ved å laste inn siden på nytt
 
 **Passer ikke til å**
 
 - validere individuelle skjemaelementer, bruk heller komponentens egen feilmelding
 - oppsummere flere feilmeldinger i et skjema, bruk heller [`ErrorSummary`](/docs/components-errorsummary--docs)
 - vise feil som hindrer all videre bruk av tjenesten, bruk heller en feilside
-- vise statisk informasjon som skal vises hele tiden, bruk heller [`Card`](/docs/components-card--docs)
+- lage visuell struktur på siden, bruk heller [`Card`](/docs/components-card--docs)
 
 ## Slik bruker du Alert
 

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -114,7 +114,7 @@ I eksempelet under bruker vi proppen `loading` for å vise at knappen laster.
 
 I eksempelet over blir `aria-disabled` satt av `loading="true"`. Skjermlesere og andre hjelpemidler vil bli informert om at knappen finnes, men ikke er aktiv. I motsetning til `disabled` kan knappen fortsatt få fokus når noen navigerer med tastaturet.
 
-<SimpleAlert type="tip" heading="Tips">
+<SimpleAlert type="info" heading="Vær oppmerksom på">
   `loading="true"` eller `aria-disabled` stopper ikke automatisk knappen fra å
   utløse `onClick`. Du må selv passe på at callback-funksjonen ikke kjører når
   knappen er deaktivert.
@@ -132,14 +132,11 @@ Vi unngår deaktiverte (`disabled`) knapper fordi de kan være vanskelige å opp
 
 Nav har en god forklaring på [hvorfor deaktiverte tilstander er problematisk](https://aksel.nav.no/god-praksis/artikler/deaktiverte-tilstander) og hvilke alternativer som finnes.
 
-<SimpleAlert type="tip" heading="Tips">
 Hvis du mot formodning må bruke en deaktivert knapp:
 
 - Sørg for at alle brukerne dine både opplever og forstår at knappen eksisterer, at den er deaktivert, og hvorfor.
 - Bruk gjerne støttetekst som alltid er synlig når knappen er deaktivert.
 - Dersom det gir mening å fortsatt kunne navigere til knappen med tastaturet, eller det av andre grunner er viktig å beholde tab-rekkefølgen, bruk `aria-disabled` heller enn `disabled`. Da må du også huske å selv blokkere kjøring av callback-funksjoner (f.eks. `onClick`).
-
-</SimpleAlert>
 
 ### En knapp skal utføre kun én handling
 

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.mdx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.mdx
@@ -37,7 +37,7 @@ I `getCheckboxProps`-funksjonen er første parameter enten `value` — en unik i
 <Checkbox label="Barnehage" {...getCheckboxProps({ value: 'barnehage' /* ...and other props... */ }) />;
 ```
 
-<SimpleAlert type="tip" heading="Tips">
+<SimpleAlert type="info" heading="Vær oppmerksom på">
   Dersom du skal sende props til en `Checkbox`, er det viktig at du sender disse
   som objekt til `getCheckboxProps` og **ikke** direkte på `Checkbox`. Ellers
   kan du risikere å overstyre funksjonaliteten fra `useCheckboxGroup`.

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.mdx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.mdx
@@ -26,7 +26,7 @@ I respons får du objektet:
 }
 ```
 
-<SimpleAlert type="tip" heading="Tips">
+<SimpleAlert type="info" heading="Vær oppmerksom på">
   Dersom du skal sende props til en `Radio`, er det viktig at du sender disse
   som objekt til `getRadioProps` og **ikke** direkte på `Radio`. Ellers kan du
   risikere å overstyre funksjonaliteten fra `useRadioGroup`.


### PR DESCRIPTION
## Hva er gjort?

- **Alert**: Endra kulepunkta under "Passer til å"
  - "gi korte og informative tidsbegrensede varsler" → "gi korte, informative og ofte tidsbegrensede varsler"
  -  nytt punkt: "utheve informasjon brukere må være ekstra oppmerksom på"
  -  "informere om ..."  → "varsle om ..."
- **Alert**: Endra kulepunkta under "Passer ikke til å"
  -  "vise statisk informasjon som skal vises hele tiden" → "lage visuell struktur på siden"
- Endra bruk av Alert / Tips i dokumentasjon:
  - **Button**: endra "Tips" om loading / aria-disabled til info-Alert med overskrift "Vær oppmerksom på"
  - **Button**: fjerna kort rundt innholdet som begynner med "Hvis du mot formodning må bruke en deaktivert knapp:"
  - **useCheckboxGroup** og **useRadioGroup**: endra "Tips" om "Dersom du skal sende props..." til info-Alert med overskrift "Vær oppmerksom på"

## Sjekkliste



- [x] Dokumentasjonen er oppdatert om nødvendig