### PR TITLE
fix(Header.UserButton): use span instead of Header and Paragraph for …

### DIFF
--- a/@udir-design/react/src/components/header/HeaderUserButton.tsx
+++ b/@udir-design/react/src/components/header/HeaderUserButton.tsx
@@ -1,8 +1,6 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
-import { Heading } from '../typography/heading/Heading';
-import { Paragraph } from '../typography/paragraph/Paragraph';
 
 export type HeaderUserButtonProps = HTMLAttributes<HTMLButtonElement> & {
   /**
@@ -47,10 +45,8 @@ export const HeaderUserButton = forwardRef<
       {...rest}
     >
       <div>
-        <Heading data-size="2xs" level={3}>
-          {name}
-        </Heading>
-        {description && <Paragraph data-size="xs">{description}</Paragraph>}
+        <span>{name}</span>
+        {description && <span>{description}</span>}
       </div>
       {avatar && avatar}
     </button>

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -661,15 +661,12 @@ exports[`Responsive 1`] = `
           data-show="md"
         >
           <div>
-            <h3 data-size="2xs">
+            <span>
               Stian Hansen
-            </h3>
-            <p
-              data-variant="default"
-              data-size="xs"
-            >
+            </span>
+            <span>
               Admin
-            </p>
+            </span>
           </div>
           <span
             data-variant="circle"
@@ -778,15 +775,12 @@ exports[`Responsive 1`] = `
             style="<removed>"
           >
             <div>
-              <h3 data-size="2xs">
+              <span>
                 Stian Hansen
-              </h3>
-              <p
-                data-variant="default"
-                data-size="xs"
-              >
+              </span>
+              <span>
                 Admin
-              </p>
+              </span>
             </div>
             <span
               data-variant="circle"
@@ -2411,15 +2405,12 @@ exports[`With User Button 1`] = `
           data-show="sm"
         >
           <div>
-            <h3 data-size="2xs">
+            <span>
               Stian Hansen
-            </h3>
-            <p
-              data-variant="default"
-              data-size="xs"
-            >
+            </span>
+            <span>
               Admin
-            </p>
+            </span>
           </div>
           <span
             data-variant="circle"
@@ -2656,15 +2647,12 @@ exports[`With User Button Test 1`] = `
           data-show="sm"
         >
           <div>
-            <h3 data-size="2xs">
+            <span>
               Stian Hansen
-            </h3>
-            <p
-              data-variant="default"
-              data-size="xs"
-            >
+            </span>
+            <span>
               Admin
-            </p>
+            </span>
           </div>
           <span
             data-variant="circle"

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -212,12 +212,17 @@
       flex-direction: column;
       align-items: flex-end;
       min-width: 0;
-      .ds-heading,
-      .ds-paragraph {
+      span {
         max-width: 100%;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        &:first-child {
+          font-weight: var(--ds-font-weight-medium);
+        }
+        &:nth-child(2) {
+          font-size: var(--ds-body-xs-font-size);
+        }
       }
     }
 

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -219,6 +219,7 @@
         text-overflow: ellipsis;
         &:first-child {
           font-weight: var(--ds-font-weight-medium);
+          line-height: var(--ds-heading-2xs-line-height);
         }
         &:nth-child(2) {
           font-size: var(--ds-body-xs-font-size);

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -30,15 +30,12 @@ exports[`Dashboard Page 2 1`] = `
         data-show="md"
       >
         <div>
-          <h3 data-size="2xs">
+          <span>
             Stian Hansen
-          </h3>
-          <p
-            data-variant="default"
-            data-size="xs"
-          >
+          </span>
+          <span>
             Admin
-          </p>
+          </span>
         </div>
         <span
           data-variant="circle"
@@ -680,15 +677,12 @@ exports[`Dashboard Page 3 1`] = `
         data-show="md"
       >
         <div>
-          <h3 data-size="2xs">
+          <span>
             Stian Hansen
-          </h3>
-          <p
-            data-variant="default"
-            data-size="xs"
-          >
+          </span>
+          <span>
             Admin
-          </p>
+          </span>
         </div>
         <span
           data-variant="circle"
@@ -1330,15 +1324,12 @@ exports[`Dashboard Page 4 1`] = `
         data-show="md"
       >
         <div>
-          <h3 data-size="2xs">
+          <span>
             Stian Hansen
-          </h3>
-          <p
-            data-variant="default"
-            data-size="xs"
-          >
+          </span>
+          <span>
             Admin
-          </p>
+          </span>
         </div>
         <span
           data-variant="circle"
@@ -1980,15 +1971,12 @@ exports[`Dashboard Story 1`] = `
         data-show="md"
       >
         <div>
-          <h3 data-size="2xs">
+          <span>
             Stian Hansen
-          </h3>
-          <p
-            data-variant="default"
-            data-size="xs"
-          >
+          </span>
+          <span>
             Admin
-          </p>
+          </span>
         </div>
         <span
           data-variant="circle"


### PR DESCRIPTION
…name and description

BREAKING CHANGE: Consumers using @udir-design/css without React must swap out the `h3` and `p` elements in Header.UserButton with `span`.

