### PR TITLE
feat: scroll offsets for header, demobanner and form fields

### DIFF
--- a/@udir-design/css/package.json
+++ b/@udir-design/css/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "postcss src/*.css --dir dist/",
+    "watch": "pnpm run build --watch --verbose",
     "lint": "oxlint"
   },
   "dependencies": {

--- a/@udir-design/css/turbo.json
+++ b/@udir-design/css/turbo.json
@@ -8,6 +8,9 @@
         "../react/src/components/**/*.css",
         "!../react/src/components/**/*.module.css"
       ]
+    },
+    "watch": {
+      "persistent": true
     }
   }
 }

--- a/@udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
+++ b/@udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
@@ -12,8 +12,19 @@ const handleScrollHash = (event: MouseEvent) => {
   event.preventDefault();
   const element = document.getElementById(decodeURIComponent(hash).slice(1));
   if (element && (event.currentTarget as HTMLElement)?.contains(element)) {
-    element.scrollIntoView({ behavior: 'smooth' });
-    element.focus({ preventScroll: true });
+    if (anchor.closest('ds-error-summary')) {
+      // This is an anchor inside an error summary.
+      // We scroll the entire field (label, optional description, and input) into view,
+      // then focus the input field. This prevents scrolling to an input field without showing
+      // the related label.
+      const target = element.closest('ds-field') ?? element;
+      const input = element.querySelector<HTMLElement>('.ds-input') ?? element;
+      target.scrollIntoView();
+      input.focus({ preventScroll: true });
+    } else {
+      element.scrollIntoView();
+      element.focus({ preventScroll: true });
+    }
   }
 };
 

--- a/@udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
+++ b/@udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
@@ -1,4 +1,5 @@
 import type { Decorator } from '@storybook/react-vite';
+import { focusFormField } from 'src/utilities/form/focus';
 
 const handleScrollHash = (event: MouseEvent) => {
   if (event.defaultPrevented) {
@@ -17,10 +18,7 @@ const handleScrollHash = (event: MouseEvent) => {
       // We scroll the entire field (label, optional description, and input) into view,
       // then focus the input field. This prevents scrolling to an input field without showing
       // the related label.
-      const target = element.closest('ds-field') ?? element;
-      const input = element.querySelector<HTMLElement>('.ds-input') ?? element;
-      target.scrollIntoView();
-      input.focus({ preventScroll: true });
+      focusFormField(element);
     } else {
       element.scrollIntoView();
       element.focus({ preventScroll: true });

--- a/@udir-design/react/.storybook/style.css
+++ b/@udir-design/react/.storybook/style.css
@@ -10,6 +10,10 @@
 @import '../../css/src/icons.css';
 @import '../../theme/dist/datavis.css';
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: 'Inter', sans-serif;
   font-feature-settings: 'cv05' 1; /* Enable lowercase l with tail */

--- a/@udir-design/react/.storybook/style.css
+++ b/@udir-design/react/.storybook/style.css
@@ -12,6 +12,7 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: var(--uds-scroll-padding-top);
 }
 
 body {

--- a/@udir-design/react/README.md
+++ b/@udir-design/react/README.md
@@ -42,9 +42,23 @@ Alternativt kan du importere stilsettet fra en CSS-fil:
 @import '@udir-design/react/style.css';
 ```
 
-### Konfigurere standard typografi
+### Sette opp globale stiler
 
-Biblioteket setter ingen globale stiler. For å få konsistent typografi også på innhold som ikke bruker komponenter fra biblioteket, må du selv definere standard typografi for applikasjonen.
+Biblioteket setter ingen globale stiler, men vi har noen anbefalinger.
+
+#### Scroll offset
+
+Ved lenking innad i siden, for eksempel fra en innholdsfortegnelse, er det lurt å definere en scroll offset. Dette gjør at Header eller DemoBanner aldri legger seg på toppen av innholdet du scroller til:
+
+```css
+html {
+  scroll-padding-top: var(--uds-scroll-padding-top);
+}
+```
+
+#### Typografi
+
+For å få konsistent typografi også på innhold som ikke bruker komponenter fra biblioteket, må du selv definere standard typografi for applikasjonen.
 
 Dette kan gjøres slik:
 

--- a/@udir-design/react/demo-pages/article-demo/ArticleDemo.tsx
+++ b/@udir-design/react/demo-pages/article-demo/ArticleDemo.tsx
@@ -66,7 +66,7 @@ export const ArticleDemo = () => {
       </Breadcrumbs>
       <div
         className={classes.contentWrapper}
-        id="main"
+        id="main-content"
         tabIndex={-1}
         ref={containerRef}
       >

--- a/@udir-design/react/demo-pages/dashboard-demo/DashboardDemo.tsx
+++ b/@udir-design/react/demo-pages/dashboard-demo/DashboardDemo.tsx
@@ -24,6 +24,7 @@ export const DashboardDemo = ({
       className={cl(classes.card, classes.container)}
       data-size="auto"
       lang="nb"
+      id="main-content"
     >
       <Heading level={1} data-size="md">
         Schweigaardsgate skole

--- a/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
+++ b/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
@@ -51,44 +51,29 @@ export function ErrorSummaryContent({
   if (!shouldShow) return null;
 
   const renderErrorList = () => {
-    if (isFinalPage) {
-      const allKeys = Object.keys(errors) as FieldId[];
-
-      return (
-        <ErrorSummary.List>
-          {allKeys.map((fieldName) => {
-            const err = errors[fieldName];
-            return (
-              <ErrorSummary.Item key={fieldName}>
-                <ErrorSummary.Link
-                  href={`#${fieldName}`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    const pageId = findPageForField(fieldName);
-                    if (!pageId) return;
-                    setId(pageId);
-                    window.setTimeout(() => {
-                      const el = document.getElementById(fieldName);
-                      el?.focus();
-                    }, 50);
-                  }}
-                >
-                  {getMessage(err)}
-                </ErrorSummary.Link>
-              </ErrorSummary.Item>
-            );
-          })}
-        </ErrorSummary.List>
-      );
-    }
-
+    const keys = isFinalPage ? (Object.keys(errors) as FieldId[]) : pageErrors;
     return (
       <ErrorSummary.List>
-        {pageErrors.map((fieldName) => {
+        {keys.map((fieldName) => {
           const err = errors[fieldName];
           return (
             <ErrorSummary.Item key={fieldName}>
-              <ErrorSummary.Link href={`#${fieldName}`}>
+              <ErrorSummary.Link
+                href={`#${fieldName}`}
+                onClick={(e) => {
+                  e.preventDefault();
+                  const pageId = findPageForField(fieldName);
+                  if (!pageId) return;
+                  setId(pageId);
+                  window.setTimeout(() => {
+                    const el = document.getElementById(fieldName);
+                    const field = el?.closest('ds-field') ?? el;
+                    const input = el?.querySelector('input') ?? el;
+                    field?.scrollIntoView();
+                    input?.focus({ preventScroll: true });
+                  }, 50);
+                }}
+              >
                 {getMessage(err)}
               </ErrorSummary.Link>
             </ErrorSummary.Item>

--- a/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
+++ b/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
@@ -2,6 +2,7 @@ import type { DSErrorSummaryElement } from '@digdir/designsystemet-web';
 import type { FieldError, FieldErrors } from 'react-hook-form';
 import { ErrorSummary } from 'src/components/errorSummary';
 import type { UseFormNavigationReturn } from 'src/hooks/useFormNavigation';
+import { focusFormField } from 'src/utilities/form/focus';
 import type { FieldId, FormValues, PageFields, PageId } from './FormDemo';
 import { findPageForField } from './FormDemo';
 
@@ -65,13 +66,7 @@ export function ErrorSummaryContent({
                   const pageId = findPageForField(fieldName);
                   if (!pageId) return;
                   setId(pageId);
-                  window.setTimeout(() => {
-                    const el = document.getElementById(fieldName);
-                    const field = el?.closest('ds-field') ?? el;
-                    const input = el?.querySelector('input') ?? el;
-                    field?.scrollIntoView();
-                    input?.focus({ preventScroll: true });
-                  }, 50);
+                  window.setTimeout(() => focusFormField(fieldName), 50);
                 }}
               >
                 {getMessage(err)}

--- a/@udir-design/react/demo-pages/form-demo/FormDemo.tsx
+++ b/@udir-design/react/demo-pages/form-demo/FormDemo.tsx
@@ -235,7 +235,7 @@ export const FormDemo = ({
 
   return (
     <FormProvider {...methods}>
-      <div className={classes.page} data-size="auto">
+      <div className={classes.page} data-size="auto" id="main-content">
         <div className={classes.desktop}>{formNavigationContent}</div>
         <div className={classes.mobile}>
           <Dialog.TriggerContext>

--- a/@udir-design/react/demo-pages/page-demo/DemoPage.tsx
+++ b/@udir-design/react/demo-pages/page-demo/DemoPage.tsx
@@ -13,7 +13,7 @@ export function DemoPage(props: Props) {
   return (
     <div className={styles.page} {...props} data-size="">
       <BreadcrumbsDemo />
-      <div className={styles.examples}>
+      <div className={styles.examples} id="main-content">
         <Shoppinglist />
         <Login />
         <Progress />

--- a/@udir-design/react/demo-pages/table-demo/TableDemo.tsx
+++ b/@udir-design/react/demo-pages/table-demo/TableDemo.tsx
@@ -112,7 +112,7 @@ export const TableDemo = ({ ...props }: TableDemoProps) => {
   };
 
   return (
-    <div {...props} data-size="auto">
+    <div {...props} data-size="auto" id="main-content">
       <div className={cl(classes.card)}>
         <Alert>Elevlisten vil bli oppdatert ved semesterstart.</Alert>
         <Heading data-size="md" className={classes.cardTitle}>

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -106,7 +106,7 @@ Feilmeldinger håndteres ved hjelp av valgfri skjemavalidering, sammen med inlin
 - Feilmeldinger skal vanligvis først vises når brukeren har forsøkt å sende inn skjemaet. Dette er for å unngå forvirring under utfylling.
 - Sider som inneholder flere felter, skal ha en [`ErrorSummary`](/docs/components-errorsummary--docs) som oppsummerer feilene på den aktuelle siden. Det er ikke nødvendig dersom siden kun inneholder ett felt.
 - Bruk en [`ErrorSummary`](/docs/components-errorsummary--docs) på innleveringssiden for å gi en oversikt over alle feil i skjemaet. Dette hjelper brukeren med å raskt identifisere og navigere til feilene som må rettes opp.
-- Lenkene i [`ErrorSummary`](/docs/components-errorsummary--docs) skal navigere til riktig side og fokusere de aktuelle feltene når de klikkes. Du må også sørge for at label og beskrivelse vises på skjermen når feltet fokuseres, da standardoppførsel i nettleser er å plassere det fokuserte elementet på toppen av skjermen.
+- Lenkene i [`ErrorSummary`](/docs/components-errorsummary--docs) skal navigere til riktig side og fokusere de aktuelle feltene når de klikkes. Du må også sørge for at label og beskrivelse vises på skjermen når feltet fokuseres, da standardoppførsel i nettleser er å plassere det fokuserte elementet på toppen av skjermen. Funksjonen `focusFormField` fra [hjelpefunksjoner for skjema](/docs/utilities-hjelpefunksjoner-for-skjema--docs) hjelper deg med dette.
 - Bruk `markInvalid` og `markCompleted` fra [`useFormNavigation`](/docs/utilities-useformnavigation--docs) for å oppdatere stegenes tilstand basert på valideringsresultatene.
 
 ### Tekst i FormNavigation

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -106,7 +106,7 @@ Feilmeldinger håndteres ved hjelp av valgfri skjemavalidering, sammen med inlin
 - Feilmeldinger skal vanligvis først vises når brukeren har forsøkt å sende inn skjemaet. Dette er for å unngå forvirring under utfylling.
 - Sider som inneholder flere felter, skal ha en [`ErrorSummary`](/docs/components-errorsummary--docs) som oppsummerer feilene på den aktuelle siden. Det er ikke nødvendig dersom siden kun inneholder ett felt.
 - Bruk en [`ErrorSummary`](/docs/components-errorsummary--docs) på innleveringssiden for å gi en oversikt over alle feil i skjemaet. Dette hjelper brukeren med å raskt identifisere og navigere til feilene som må rettes opp.
-- Lenkene i [`ErrorSummary`](/docs/components-errorsummary--docs) skal navigere til riktig side og fokusere de aktuelle feltene når de klikkes.
+- Lenkene i [`ErrorSummary`](/docs/components-errorsummary--docs) skal navigere til riktig side og fokusere de aktuelle feltene når de klikkes. Du må også sørge for at label og beskrivelse vises på skjermen når feltet fokuseres, da standardoppførsel i nettleser er å plassere det fokuserte elementet på toppen av skjermen.
 - Bruk `markInvalid` og `markCompleted` fra [`useFormNavigation`](/docs/utilities-useformnavigation--docs) for å oppdatere stegenes tilstand basert på valideringsresultatene.
 
 ### Tekst i FormNavigation

--- a/@udir-design/react/src/components/header/Header.mdx
+++ b/@udir-design/react/src/components/header/Header.mdx
@@ -145,7 +145,7 @@ Er navnet så langt at det må brekke på tre linjer, kan det være nødvendig �
 
 ```css
 @media (max-width: <største bredde der navn går over tre linjer>) {
-  .uds-header {
+  :root {
     --udsc-header-height: var(--ds-size-26);
   }
 }
@@ -201,6 +201,8 @@ Resultatet er at knappen alltid finnes tilgjengelig for brukeren – bare på ul
 ### Header skjules og vises automatisk
 
 `Header` er `sticky` og skjules automatisk ved scrolling. Det vil si at når brukeren scroller nedover på siden, vil `Header` skjule seg for å gi mer plass til innholdet. Når brukeren starter å scrolle opp igjen, vil den vises igjen. Slik har brukerne alltid tilgang til viktig funksjonalitet, uavhengig av hvor langt ned på siden de har scrollet.
+
+For at lenking innad i en side skal fungere optimalt, for eksempel fra `TableOfContents` eller `ErrorSummary`, må du sette en scroll offset som tar høyde for at `Header` kan ligge øverst på skjermen. Dette gjør du med `scroll-padding-top` i global CSS, som beskrevet i [kom i gang som utvikler](/docs/introduksjon-kom-i-gang-som-utvikler--docs#scroll-offset).
 
 Foreldreelementet får automatisk `overflow: visible`. Sørg for at dette ikke blir overskrevet. Ønsker du at headeren skal bli igjen på toppen av siden, setter du `sticky=false`.
 

--- a/@udir-design/react/src/components/header/header.css
+++ b/@udir-design/react/src/components/header/header.css
@@ -1,8 +1,15 @@
-.uds-header {
+/* Make header height available outside header element */
+:root,
+[data-size] {
   --udsc-header-height: var(--ds-size-22);
-  --udsc-header-padding: var(--ds-size-5);
   @media (max-width: 30rem) {
     --udsc-header-height: calc(var(--ds-size-22) - var(--ds-size-2));
+  }
+}
+
+.uds-header {
+  --udsc-header-padding: var(--ds-size-5);
+  @media (max-width: 30rem) {
     --udsc-header-padding: var(--ds-size-4);
   }
 
@@ -397,4 +404,15 @@
 /* Prevent body from scrolling when menu is open */
 body:has(.uds-header .uds-header__menu:popover-open) {
   overflow: hidden;
+}
+
+/* Scroll offset for sticky header */
+html:has(:not(.uds-demo-banner) > .uds-header[data-scroll-direction]) {
+  --uds-scroll-padding-top: calc(var(--ds-size-4) + var(--udsc-header-height));
+}
+/* Scroll offset for sticky header with demo banner */
+html:has(.uds-demo-banner > .uds-header[data-scroll-direction]) {
+  --uds-scroll-padding-top: calc(
+    1.5lh + var(--ds-size-4) + var(--udsc-header-height)
+  );
 }

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
@@ -21,6 +21,13 @@ import * as TableOfContentStories from './TableOfContents.stories';
 <Canvas of={TableOfContentStories.Preview} withToolbar />
 <Controls of={TableOfContentStories.Preview} />
 
+```css
+/* global css om du ønsker smooth scroll */
+html {
+  scroll-behavior: smooth;
+}
+```
+
 ```jsx
 import { TableOfContents, useTableOfContents } from '@udir-design/react';
 

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.tsx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.tsx
@@ -79,14 +79,7 @@ export const TableOfContents = forwardRef<HTMLDivElement, TableOfContentsProps>(
             <ol>
               {headings.map((header) => (
                 <li key={header.id} className={`level-${header.level}`}>
-                  <Link
-                    href={`#${header.id}`}
-                    onClick={() => {
-                      document
-                        .querySelector(`#${header.id}`)
-                        ?.scrollIntoView({ behavior: 'smooth' });
-                    }}
-                  >
+                  <Link href={`#${header.id}`}>
                     <ArrowDownRightIcon aria-hidden />
                     <span>{header.name}</span>
                   </Link>

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -265,6 +265,7 @@ exports[`Dashboard Page 2 1`] = `
   data-color-scheme="light"
   data-size="auto"
   lang="nb"
+  id="<removed>"
 >
   <h1 data-size="md">
     Schweigaardsgate skole
@@ -1037,6 +1038,7 @@ exports[`Dashboard Page 3 1`] = `
   data-color-scheme="light"
   data-size="auto"
   lang="nb"
+  id="<removed>"
 >
   <h1 data-size="md">
     Schweigaardsgate skole
@@ -1809,6 +1811,7 @@ exports[`Dashboard Page 4 1`] = `
   data-color-scheme="light"
   data-size="auto"
   lang="nb"
+  id="<removed>"
 >
   <h1 data-size="md">
     Schweigaardsgate skole
@@ -2581,6 +2584,7 @@ exports[`Dashboard Story 1`] = `
   data-color-scheme="light"
   data-size="auto"
   lang="nb"
+  id="<removed>"
 >
   <h1 data-size="md">
     Schweigaardsgate skole

--- a/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
@@ -35,7 +35,7 @@ exports[`Page Story 1`] = `
       </li>
     </ol>
   </ds-breadcrumbs>
-  <div>
+  <div id="<removed>">
     <div>
       <fieldset aria-labelledby="<removed>">
         <legend id="<removed>">

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -1,7 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Form Page 2 1`] = `
-<div data-size="auto">
+<div
+  data-size="auto"
+  id="<removed>"
+>
   <div>
     <div>
       <details
@@ -628,7 +631,10 @@ exports[`Form Page 2 1`] = `
 `;
 
 exports[`Form Page 3 1`] = `
-<div data-size="auto">
+<div
+  data-size="auto"
+  id="<removed>"
+>
   <div>
     <div>
       <details
@@ -980,7 +986,10 @@ exports[`Form Page 3 1`] = `
 `;
 
 exports[`Form Page 4 1`] = `
-<div data-size="auto">
+<div
+  data-size="auto"
+  id="<removed>"
+>
   <div>
     <div>
       <details
@@ -1258,7 +1267,10 @@ exports[`Form Page 4 1`] = `
 `;
 
 exports[`Form Page 5 1`] = `
-<div data-size="auto">
+<div
+  data-size="auto"
+  id="<removed>"
+>
   <div>
     <div>
       <details
@@ -1494,7 +1506,10 @@ exports[`Form Page 5 1`] = `
 `;
 
 exports[`Form Story 1`] = `
-<div data-size="auto">
+<div
+  data-size="auto"
+  id="<removed>"
+>
   <div>
     <div>
       <details

--- a/@udir-design/react/src/demo/__snapshots__/TableDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/TableDemo.stories.tsx.snap
@@ -4,6 +4,7 @@ exports[`Table Story 1`] = `
 <div
   data-color-scheme="light"
   data-size="auto"
+  id="<removed>"
 >
   <div>
     <div data-color="info">

--- a/@udir-design/react/src/utilities/beta.ts
+++ b/@udir-design/react/src/utilities/beta.ts
@@ -6,4 +6,5 @@
 
 export * from './datavis/dataVisualisation';
 export * from './datavis/highcharts';
+export * from './form/focus';
 export * from './form/navigation';

--- a/@udir-design/react/src/utilities/form/beta.ts
+++ b/@udir-design/react/src/utilities/form/beta.ts
@@ -8,4 +8,5 @@
  * Note: Members must be imported from `@udir-design/react/beta/utilities`
  * @module
  */
+export * from './focus';
 export * from './navigation';

--- a/@udir-design/react/src/utilities/form/focus/index.ts
+++ b/@udir-design/react/src/utilities/form/focus/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Scrolls the label of the given form field into view, respecting css `scroll-behavior`, then focuses the form control
+ * @param fieldId The id of the form control or a wrapper element like ds-field or fieldset
+ */
+export function focusFormField(fieldId: string): void;
+/**
+ * Scrolls the label of the given form field into view, respecting css `scroll-behavior`, then focuses the form control
+ * @param field The form control or a wrapper element like ds-field or fieldset
+ */
+export function focusFormField(field: HTMLElement): void;
+export function focusFormField(fieldIdOrElement: string | HTMLElement) {
+  const el =
+    typeof fieldIdOrElement === 'string'
+      ? document.getElementById(fieldIdOrElement)
+      : fieldIdOrElement;
+  const field = el?.closest('ds-field') ?? el;
+  const control = el?.matches('input, select, textarea')
+    ? el
+    : (el?.querySelector<HTMLElement>('input, select, textarea') ?? el);
+  field?.scrollIntoView();
+  control?.focus({ preventScroll: true });
+}

--- a/@udir-design/react/src/utilities/form/formUtilities.mdx
+++ b/@udir-design/react/src/utilities/form/formUtilities.mdx
@@ -19,6 +19,7 @@ Les også <Link href="./typedoc/modules/utilities_form_beta.html" target="_none"
 - `GetFieldId` lar deg utlede en TypeScript-type for feltidentifikatorer
 - `getFieldIds` gir deg en liste med alle feltidentifikatorer
 - `makeStepFinder` gir deg en funksjon som du kan bruke for å hente steget som et gitt felt tilhører
+- `focusFormField` flytter fokus til et gitt skjemafelt, og sørger for at label er synlig på skjermen
 
 ## Eksempel
 

--- a/test-apps/nextjs/e2e/smoke.spec.ts
+++ b/test-apps/nextjs/e2e/smoke.spec.ts
@@ -9,7 +9,7 @@ for (const route of routes) {
 
     expect(response?.status()).toBe(200);
 
-    const main = page.locator('main#main-content');
+    const main = page.locator('main');
     await expect(main).toBeVisible();
     await expect(main).not.toBeEmpty();
 

--- a/test-apps/nextjs/src/app/global.css
+++ b/test-apps/nextjs/src/app/global.css
@@ -1,6 +1,6 @@
 html {
   height: 100%;
-  scroll-padding-top: 10rem;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/test-apps/nextjs/src/app/global.css
+++ b/test-apps/nextjs/src/app/global.css
@@ -1,6 +1,7 @@
 html {
   height: 100%;
   scroll-behavior: smooth;
+  scroll-padding-top: var(--uds-scroll-padding-top);
 }
 
 body {

--- a/test-apps/nextjs/src/app/layout.tsx
+++ b/test-apps/nextjs/src/app/layout.tsx
@@ -26,9 +26,7 @@ export default function RootLayout({
         <DemoBanner>
           <SkipLink href="#main-content">Hopp til hovedinnholdet</SkipLink>
           <Header />
-          <main className="content" id="main-content">
-            {children}
-          </main>
+          <main className="content">{children}</main>
           <Footer className="footer" />
         </DemoBanner>
       </body>

--- a/test-apps/nextjs/turbo.json
+++ b/test-apps/nextjs/turbo.json
@@ -9,6 +9,7 @@
       "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**"]
     },
     "dev": {
+      "with": ["@udir-design/css#watch"],
       "persistent": true,
       "dependsOn": ["^build", "^inject"]
     },

--- a/test-apps/vite/src/styles.scss
+++ b/test-apps/vite/src/styles.scss
@@ -1,18 +1,9 @@
 /* You can add global styles to this file, and also import other style files */
 
-// .content {
-//   display: grid;
-//   grid-template-rows: auto 1fr auto;
-//   min-height: 100vh;
-// }
-
-// .outlet {
-//   padding: var(--ds-size-6);
-// }
-
 html {
   height: 100%;
   scroll-behavior: smooth;
+  scroll-padding-top: var(--uds-scroll-padding-top);
 }
 
 body {

--- a/test-apps/vite/src/styles.scss
+++ b/test-apps/vite/src/styles.scss
@@ -12,7 +12,7 @@
 
 html {
   height: 100%;
-  scroll-padding-top: 10rem;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/test-apps/vite/turbo.json
+++ b/test-apps/vite/turbo.json
@@ -3,6 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "dev": {
+      "with": ["@udir-design/css#watch"],
       "persistent": true,
       "dependsOn": ["^build", "^inject"]
     },


### PR DESCRIPTION
Demobanner legger seg over den øverste delen av siden og vi må da starte scrolling litt lengre ned! Dette fikser både TOC og SkipLink scrolling.

Ved scroll opp pga lenke langt nede på siden (f.eks. fra ErrorSummary til et skjemafelt) vil sticky Header vises igjen, så offset må også ta høyde for dette.

Begge problemene ovenfor er løst ved å tilby en kalkulert `--uds-scroll-padding-top` som brukere av designsystemet kan legge inn der det passer, vanligvis slik
```css
html {
  scroll-padding-top: var(--uds-scroll-padding-top);
}
```

Vi tilbyr nå også en `focusFormField`-funksjon i hjelpeverktøy for skjema, som man kan bruke når man linker til et skjemafelt fra ErrorSummary. Funksjonen sørger for at vi scroller hele skjemafeltet (inkl label og description) inn i viewport, og så fokuserer inputelementet. Vi kan dessverre ikke sørge for at label er synlig med scroll offsets i CSS siden mengden linjer mellom label og input kan variere, og vi kan ikke bygge funksjonaliteten inn i ErrorSummary siden vi ikke vet hvordan applikasjonen har implementert sidebytte. Men funksjonen hjelper med logikken for å gjøre hele feltet synlig.

I tillegg respekterer nå scroll i TableOfContents `scroll-behavior` satt i CSS heller enn å hardkode smooth scrolling.