### PR TITLE
fix(Paragraph): remove "variant" prop

### DIFF
--- a/@udir-design/react/src/components/typography/paragraph/Paragraph.stories.tsx
+++ b/@udir-design/react/src/components/typography/paragraph/Paragraph.stories.tsx
@@ -22,6 +22,5 @@ export const Preview = meta.story({
   args: {
     children:
       'Personvernerklæringen gir informasjon om hvilke personopplysninger vi behandler, hvordan disse blir behandlet og hvilke rettigheter du har.',
-    variant: 'default',
   },
 });

--- a/@udir-design/react/src/components/typography/paragraph/Paragraph.tsx
+++ b/@udir-design/react/src/components/typography/paragraph/Paragraph.tsx
@@ -1,4 +1,18 @@
-import { Paragraph, type ParagraphProps } from '@digdir/designsystemet-react';
+import {
+  Paragraph as DigdirParagraph,
+  type ParagraphProps as DigdirParagraphProps,
+} from '@digdir/designsystemet-react';
+import type {
+  ComponentRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from 'react';
+
+type ParagraphProps = Omit<DigdirParagraphProps, 'variant'>;
+
+const Paragraph = DigdirParagraph as ForwardRefExoticComponent<
+  ParagraphProps & RefAttributes<ComponentRef<typeof DigdirParagraph>>
+>;
 
 export type { ParagraphProps };
 export { Paragraph };


### PR DESCRIPTION
We had no guidelines on when to use "long" or "short" variant, and are of the opinion that we should rather have more semantic typography components in the future, with proper guidelines.

BREAKING CHANGE: if you used `variant="long"`, `"short"` or `"default"`, you must remove the prop usage.

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog
