### PR TITLE
feat: update @digdir/* to v1.4.0

### DIFF
--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -7,7 +7,7 @@
     "compile": "tsdown src/index.ts src/metadata.ts --format esm,cjs --dts",
     "build": "pnpm clean && pnpm compile && pnpm copy-aksel-icons && pnpm copy-style && pnpm generate-css",
     "generate-css": "tsx generate-css.ts",
-    "inject": "pnpm i",
+    "inject": "echo 'Dummy script to trigger pnpm injected dependency sync'",
     "clean": "rimraf ./dist && mkdir ./dist"
   },
   "repository": {

--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -7,6 +7,7 @@
     "compile": "tsdown src/index.ts src/metadata.ts --format esm,cjs --dts",
     "build": "pnpm clean && pnpm compile && pnpm copy-aksel-icons && pnpm copy-style && pnpm generate-css",
     "generate-css": "tsx generate-css.ts",
+    "inject": "pnpm i",
     "clean": "rimraf ./dist && mkdir ./dist"
   },
   "repository": {

--- a/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
+++ b/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
@@ -1,3 +1,4 @@
+import type { DSErrorSummaryElement } from '@digdir/designsystemet-web';
 import type { FieldError, FieldErrors } from 'react-hook-form';
 import { ErrorSummary } from 'src/components/errorSummary/ErrorSummary';
 import type { FieldId, FormValues, PageFields, PageId } from './FormDemo';
@@ -7,7 +8,7 @@ type Props = {
   attemptedSubmit: boolean;
   currentPage: PageId | null;
   errors: FieldErrors<FormValues>;
-  errorSummaryRef: React.RefObject<HTMLDivElement | null>;
+  errorSummaryRef: React.RefObject<DSErrorSummaryElement | null>;
   pageFields: PageFields;
   setId: React.Dispatch<React.SetStateAction<PageId | null>>;
 };

--- a/@udir-design/react/demo-pages/form-demo/FormDemo.tsx
+++ b/@udir-design/react/demo-pages/form-demo/FormDemo.tsx
@@ -1,4 +1,4 @@
-import { Paragraph } from '@digdir/designsystemet-react';
+import type { DSErrorSummaryElement } from '@digdir/designsystemet-web';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { HTMLAttributes } from 'react';
 import { useRef, useState } from 'react';
@@ -16,6 +16,7 @@ import { FieldNecessity } from 'src/components/fieldNecessity';
 import type { FieldsetProps } from 'src/components/fieldset/Fieldset';
 import { FormNavigation } from 'src/components/formNavigation';
 import { Heading } from 'src/components/typography/heading/Heading';
+import { Paragraph } from 'src/components/typography/paragraph/Paragraph';
 import type { GetFieldId, GetStepId } from 'src/utilities/form/navigation';
 import {
   defineSteps,
@@ -147,7 +148,7 @@ export const FormDemo = ({
 
   const dialogMobileRef = useRef<HTMLDialogElement>(null);
   const dialogDeliverRef = useRef<HTMLDialogElement>(null);
-  const errorSummaryRef = useRef<HTMLDivElement>(null);
+  const errorSummaryRef = useRef<DSErrorSummaryElement>(null);
 
   const stepHasError = (pageId: PageId): boolean => {
     const fields = pageFields[pageId] ?? [];

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -44,6 +44,7 @@
   ],
   "scripts": {
     "build": "vite build",
+    "inject": "pnpm i",
     "lint:cycles": "pnpm madge --circular ./src/alpha.ts",
     "typecheck": "tsgo --build",
     "dev": "storybook dev --port 6005",

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "inject": "pnpm i",
+    "inject": "echo 'Dummy script to trigger pnpm injected dependency sync'",
     "lint:cycles": "pnpm madge --circular ./src/alpha.ts",
     "typecheck": "tsgo --build",
     "dev": "storybook dev --port 6005",

--- a/@udir-design/react/src/components/checkbox/Checkbox.mdx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.mdx
@@ -54,6 +54,12 @@ Bruk `Fieldset` og `useCheckboxGroup` for gruppering av flere valg.
 
 [Les mer om `useCheckboxGroup`](/docs/utilities-usecheckboxgroup--docs)
 
+### Outline
+
+`variant="outline"` legger på ekstra padding og en ramme rundt valget slik at det blir en større klikkflate.
+
+<Canvas of={useCheckboxGroupStories.Outline} />
+
 ### Velge alle alternativer med en overordnet avmerkingsboks
 
 Legg inn `allowIndeterminate: true` i `getCheckboxProps` for å opprette en overordnet avmerkingsboks som både kan velge og fjerne alle alternativer.

--- a/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
@@ -70,6 +70,12 @@ export const Preview = meta.story({
   },
 });
 
+export const Outline = Preview.extend({
+  args: {
+    variant: 'outline',
+  },
+});
+
 export const OneOption = meta.story({
   args: {
     label: 'Jeg bekrefter at jeg er over 18 år',

--- a/@udir-design/react/src/components/checkbox/__snapshots__/Checkbox.stories.tsx.snap
+++ b/@udir-design/react/src/components/checkbox/__snapshots__/Checkbox.stories.tsx.snap
@@ -81,6 +81,32 @@ exports[`One Option 1`] = `
 </fieldset>
 `;
 
+exports[`Outline 1`] = `
+<ds-field
+  data-variant="outline"
+  data-clickdelegatefor="<removed>"
+>
+  <input
+    id="<removed>"
+    type="checkbox"
+    value="value"
+    aria-describedby="<removed>"
+  >
+  <label
+    data-weight="regular"
+    for="<removed>"
+  >
+    Checkbox label
+  </label>
+  <div
+    data-field="description"
+    id="<removed>"
+  >
+    Description
+  </div>
+</ds-field>
+`;
+
 exports[`Preview 1`] = `
 <ds-field data-clickdelegatefor="<removed>">
   <input

--- a/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
+++ b/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
@@ -326,40 +326,37 @@ exports[`Dialog With Suggestion 1`] = `
           placeholder=" "
           type="text"
           id="<removed>"
-          popovertarget=":ds:3"
-          data-label="Velg en kommune"
-          list=":ds:3"
-          aria-label="Velg en kommune​​​​​"
-          aria-autocomplete="list"
-          aria-controls=":ds:3"
-          aria-expanded="true"
-          autocomplete="off"
-          role="combobox"
+          list=":u-datalist1"
+          popovertarget=":u-datalist1"
         >
-        <del
+        <button
           aria-label="Tøm"
           hidden
-          role="button"
+          type="reset"
+          aria-hidden="false"
+          tabindex="-1"
         >
-        </del>
+        </button>
         <u-datalist
           data-nofilter
           data-sr-plural="%d forslag"
           data-sr-singular="%d forslag"
           popover="manual"
           role="listbox"
-          id="<removed>"
+          data-sr-of="of"
           hidden
           tabindex="-1"
           aria-multiselectable="false"
+          id="<removed>"
+          data-is-floating="true"
         >
           <u-option
             label="Sogndal"
             value="Sogndal"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Sogndal
             <div>
@@ -369,10 +366,10 @@ exports[`Dialog With Suggestion 1`] = `
           <u-option
             label="Oslo"
             value="Oslo"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Oslo
             <div>
@@ -382,10 +379,10 @@ exports[`Dialog With Suggestion 1`] = `
           <u-option
             label="Brønnøysund"
             value="Brønnøysund"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Brønnøysund
             <div>
@@ -395,10 +392,10 @@ exports[`Dialog With Suggestion 1`] = `
           <u-option
             label="Stavanger"
             value="Stavanger"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Stavanger
             <div>
@@ -408,10 +405,10 @@ exports[`Dialog With Suggestion 1`] = `
           <u-option
             label="Trondheim"
             value="Trondheim"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Trondheim
             <div>
@@ -421,10 +418,10 @@ exports[`Dialog With Suggestion 1`] = `
           <u-option
             label="Bergen"
             value="Bergen"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Bergen
             <div>
@@ -434,10 +431,10 @@ exports[`Dialog With Suggestion 1`] = `
           <u-option
             label="Lillestrøm"
             value="Lillestrøm"
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
           >
             Lillestrøm
             <div>

--- a/@udir-design/react/src/components/radio/Radio.mdx
+++ b/@udir-design/react/src/components/radio/Radio.mdx
@@ -47,6 +47,12 @@ Bruk `Fieldset` og `useRadioGroup` for gruppering av radioknapper.
 
 [Les mer om `useRadioGroup`](/docs/utilities-useradiogroup--docs)
 
+### Outline
+
+`variant="outline"` legger på ekstra padding og en ramme rundt valget slik at det blir en større klikkflate.
+
+<Canvas of={useRadioGroupStories.Outline} />
+
 ### Vise feilmelding
 
 Bruk `error` på `Fieldset` for å vise feilmelding.

--- a/@udir-design/react/src/components/radio/Radio.stories.tsx
+++ b/@udir-design/react/src/components/radio/Radio.stories.tsx
@@ -56,6 +56,12 @@ export const Preview = meta.story({
   },
 });
 
+export const Outline = Preview.extend({
+  args: {
+    variant: 'outline',
+  },
+});
+
 export const Inline = meta.story({
   render: () => (
     <Fieldset>

--- a/@udir-design/react/src/components/radio/Radio.tsx
+++ b/@udir-design/react/src/components/radio/Radio.tsx
@@ -8,7 +8,7 @@ import type {
   RefAttributes,
 } from 'react';
 
-type RadioProps = Omit<DigdirRadioProps, 'data-color'>;
+type RadioProps = Omit<DigdirRadioProps, 'data-color' | 'data-indeterminate'>;
 
 const Radio = DigdirRadio as ForwardRefExoticComponent<
   RadioProps & RefAttributes<ComponentRef<typeof DigdirRadio>>

--- a/@udir-design/react/src/components/radio/__snapshots__/Radio.stories.tsx.snap
+++ b/@udir-design/react/src/components/radio/__snapshots__/Radio.stories.tsx.snap
@@ -70,6 +70,32 @@ exports[`Inline 1`] = `
 </fieldset>
 `;
 
+exports[`Outline 1`] = `
+<ds-field
+  data-variant="outline"
+  data-clickdelegatefor="<removed>"
+>
+  <input
+    id="<removed>"
+    type="radio"
+    value="value"
+    aria-describedby="<removed>"
+  >
+  <label
+    data-weight="regular"
+    for="<removed>"
+  >
+    Radio
+  </label>
+  <div
+    data-field="description"
+    id="<removed>"
+  >
+    Description
+  </div>
+</ds-field>
+`;
+
 exports[`Preview 1`] = `
 <ds-field data-clickdelegatefor="<removed>">
   <input

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -5,7 +5,6 @@ exports[`Always Show All 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Viser alle options også når valgt
   </label>
@@ -13,7 +12,6 @@ exports[`Always Show All 1`] = `
     <data
       value="Sogndal"
       aria-label="Sogndal, Press to remove"
-      aria-selected="true"
       role="option"
       slot="items"
       tabindex="-1"
@@ -24,94 +22,97 @@ exports[`Always Show All 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:14"
-      data-label="Viser alle options også når valgt"
-      list=":ds:14"
-      aria-label="Viser alle options også når valgt​​​​​"
+      list=":u-datalist7"
+      popovertarget=":u-datalist7"
       aria-autocomplete="list"
-      aria-controls=":ds:14"
-      aria-expanded="true"
+      aria-controls=":u-datalist7"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Viser alle options også når valgt"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="true"
+        id="<removed>"
         selected
         aria-hidden="false"
       >
         Sogndal
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Oslo
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Brønnøysund
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Stavanger
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Trondheim
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Bergen
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Lillestrøm
@@ -126,7 +127,6 @@ exports[`Controlled Independent Label Value 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Velg person
   </label>
@@ -134,7 +134,6 @@ exports[`Controlled Independent Label Value 1`] = `
     <data
       value="#004"
       aria-label="Lars, Press to remove"
-      aria-selected="true"
       role="option"
       slot="items"
       tabindex="-1"
@@ -145,41 +144,44 @@ exports[`Controlled Independent Label Value 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:8"
-      data-label="Velg person"
-      list=":ds:8"
-      aria-label="Velg person​​​​​"
+      list=":u-datalist4"
+      popovertarget=":u-datalist4"
       aria-autocomplete="list"
-      aria-controls=":ds:8"
-      aria-expanded="true"
+      aria-controls=":u-datalist4"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg person"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
         label="Lars"
         value="#004"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="true"
+        id="<removed>"
         selected
         aria-hidden="false"
       >
@@ -188,10 +190,10 @@ exports[`Controlled Independent Label Value 1`] = `
       <u-option
         label="James"
         value="#007"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         James
@@ -199,10 +201,10 @@ exports[`Controlled Independent Label Value 1`] = `
       <u-option
         label="Nina"
         value="#113"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Nina
@@ -210,10 +212,10 @@ exports[`Controlled Independent Label Value 1`] = `
       <u-option
         label="Tove"
         value="#110"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Tove
@@ -251,7 +253,6 @@ exports[`Controlled Multiple 1`] = `
     <data
       value="Sogndal"
       aria-label="Sogndal, Press to remove"
-      aria-selected="true"
       role="option"
       slot="items"
       tabindex="-1"
@@ -261,7 +262,6 @@ exports[`Controlled Multiple 1`] = `
     <data
       value="Stavanger"
       aria-label="Stavanger, Press to remove"
-      aria-selected="true"
       role="option"
       slot="items"
       tabindex="-1"
@@ -272,40 +272,38 @@ exports[`Controlled Multiple 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:6"
-      data-label="Velg destinasjoner"
-      list=":ds:6"
-      aria-label="Velg destinasjoner, Navigate left to find 2 selected​​​​​"
-      aria-autocomplete="list"
-      aria-controls=":ds:6"
-      aria-expanded="true"
-      autocomplete="off"
-      role="combobox"
+      aria-description="Navigate left to find 2 selected"
+      list=":u-datalist3"
+      popovertarget=":u-datalist3"
     >
-    <del
+    <button
       aria-label="Tøm"
       hidden
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       hidden
       tabindex="-1"
       aria-multiselectable="true"
+      id="<removed>"
+      data-is-floating="true"
     >
       <u-option
         label="Sogndal"
         value="Sogndal"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="true"
+        id="<removed>"
         selected
       >
         Sogndal
@@ -316,10 +314,10 @@ exports[`Controlled Multiple 1`] = `
       <u-option
         label="Oslo"
         value="Oslo"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
       >
         Oslo
         <div>
@@ -329,10 +327,10 @@ exports[`Controlled Multiple 1`] = `
       <u-option
         label="Brønnøysund"
         value="Brønnøysund"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
       >
         Brønnøysund
         <div>
@@ -342,10 +340,10 @@ exports[`Controlled Multiple 1`] = `
       <u-option
         label="Stavanger"
         value="Stavanger"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="true"
+        id="<removed>"
         selected
       >
         Stavanger
@@ -356,10 +354,10 @@ exports[`Controlled Multiple 1`] = `
       <u-option
         label="Trondheim"
         value="Trondheim"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
       >
         Trondheim
         <div>
@@ -369,10 +367,10 @@ exports[`Controlled Multiple 1`] = `
       <u-option
         label="Bergen"
         value="Bergen"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
       >
         Bergen
         <div>
@@ -382,10 +380,10 @@ exports[`Controlled Multiple 1`] = `
       <u-option
         label="Lillestrøm"
         value="Lillestrøm"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
       >
         Lillestrøm
         <div>
@@ -425,7 +423,6 @@ exports[`Controlled Single 1`] = `
     <data
       value="Sogndal"
       aria-label="Sogndal, Press to remove"
-      aria-selected="true"
       role="option"
       slot="items"
       tabindex="-1"
@@ -436,41 +433,37 @@ exports[`Controlled Single 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:4"
-      data-label="Velg destinasjon"
-      list=":ds:4"
-      aria-label="Velg destinasjon​​​​​"
-      aria-autocomplete="list"
-      aria-controls=":ds:4"
-      aria-expanded="true"
-      autocomplete="off"
-      role="combobox"
+      list=":u-datalist2"
+      popovertarget=":u-datalist2"
     >
-    <del
+    <button
       aria-label="Tøm"
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       hidden
       tabindex="-1"
       aria-multiselectable="false"
+      id="<removed>"
+      data-is-floating="true"
     >
       <u-option
         label="Sogndal"
         value="Sogndal"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="true"
+        id="<removed>"
         selected
-        aria-hidden="false"
       >
         Sogndal
         <div>
@@ -480,12 +473,11 @@ exports[`Controlled Single 1`] = `
       <u-option
         label="Oslo"
         value="Oslo"
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
-        aria-hidden="true"
       >
         Oslo
         <div>
@@ -495,12 +487,11 @@ exports[`Controlled Single 1`] = `
       <u-option
         label="Brønnøysund"
         value="Brønnøysund"
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
-        aria-hidden="true"
       >
         Brønnøysund
         <div>
@@ -510,12 +501,11 @@ exports[`Controlled Single 1`] = `
       <u-option
         label="Stavanger"
         value="Stavanger"
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
-        aria-hidden="true"
       >
         Stavanger
         <div>
@@ -525,12 +515,11 @@ exports[`Controlled Single 1`] = `
       <u-option
         label="Trondheim"
         value="Trondheim"
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
-        aria-hidden="true"
       >
         Trondheim
         <div>
@@ -540,12 +529,11 @@ exports[`Controlled Single 1`] = `
       <u-option
         label="Bergen"
         value="Bergen"
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
-        aria-hidden="true"
       >
         Bergen
         <div>
@@ -555,12 +543,11 @@ exports[`Controlled Single 1`] = `
       <u-option
         label="Lillestrøm"
         value="Lillestrøm"
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
-        aria-hidden="true"
       >
         Lillestrøm
         <div>
@@ -593,7 +580,6 @@ exports[`Custom Filter Alt 1 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Skriv inn et tall mellom 1-6
   </label>
@@ -602,101 +588,104 @@ exports[`Custom Filter Alt 1 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:10"
-      data-label="Skriv inn et tall mellom 1-6"
-      list=":ds:10"
-      aria-label="Skriv inn et tall mellom 1-6​​​​​"
+      list=":u-datalist5"
+      popovertarget=":u-datalist5"
       aria-autocomplete="list"
-      aria-controls=":ds:10"
-      aria-expanded="true"
+      aria-controls=":u-datalist5"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
       hidden
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Skriv inn et tall mellom 1-6"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
         value="sogndal"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Sogndal
       </u-option>
       <u-option
         value="oslo"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Oslo
       </u-option>
       <u-option
         value="brønnøysund"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Brønnøysund
       </u-option>
       <u-option
         value="stavanger"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Stavanger
       </u-option>
       <u-option
         value="trondheim"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Trondheim
       </u-option>
       <u-option
         value="bergen"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Bergen
       </u-option>
       <u-option
         value="lillestrøm"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Lillestrøm
@@ -711,7 +700,6 @@ exports[`Custom Filter Alt 2 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Skriv inn et tall mellom 1-6
   </label>
@@ -720,94 +708,97 @@ exports[`Custom Filter Alt 2 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:12"
-      data-label="Skriv inn et tall mellom 1-6"
-      list=":ds:12"
-      aria-label="Skriv inn et tall mellom 1-6​​​​​"
+      list=":u-datalist6"
+      popovertarget=":u-datalist6"
       aria-autocomplete="list"
-      aria-controls=":ds:12"
-      aria-expanded="true"
+      aria-controls=":u-datalist6"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
       hidden
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Skriv inn et tall mellom 1-6"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Sogndal
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Oslo
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Brønnøysund
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Stavanger
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Trondheim
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Bergen
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Lillestrøm
@@ -822,7 +813,6 @@ exports[`Default Value 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Velg en destinasjon
   </label>
@@ -830,7 +820,6 @@ exports[`Default Value 1`] = `
     <data
       value="Sogndal"
       aria-label="Sogndal, Press to remove"
-      aria-selected="true"
       role="option"
       slot="items"
       tabindex="-1"
@@ -841,99 +830,102 @@ exports[`Default Value 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:20"
-      data-label="Velg en destinasjon"
-      list=":ds:20"
-      aria-label="Velg en destinasjon​​​​​"
+      list=":u-datalist10"
+      popovertarget=":u-datalist10"
       aria-autocomplete="list"
-      aria-controls=":ds:20"
-      aria-expanded="true"
+      aria-controls=":u-datalist10"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg en destinasjon"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="true"
+        id="<removed>"
         selected
         aria-hidden="false"
       >
         Sogndal
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
         aria-hidden="true"
       >
         Oslo
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
         aria-hidden="true"
       >
         Brønnøysund
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
         aria-hidden="true"
       >
         Stavanger
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
         aria-hidden="true"
       >
         Trondheim
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
         aria-hidden="true"
       >
         Bergen
       </u-option>
       <u-option
-        tabindex="-1"
         role="option"
         aria-disabled="true"
         aria-selected="false"
+        id="<removed>"
         disabled
         aria-hidden="true"
       >
@@ -949,7 +941,6 @@ exports[`Fetch External 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Search for countries (in english)
   </label>
@@ -958,32 +949,35 @@ exports[`Fetch External 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:16"
-      data-label="Search for countries (in english)"
-      list=":ds:16"
-      aria-label="Search for countries (in english)​​​​​"
+      list=":u-datalist8"
+      popovertarget=":u-datalist8"
       aria-autocomplete="list"
-      aria-controls=":ds:16"
-      aria-expanded="true"
+      aria-controls=":u-datalist8"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
       hidden
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d countries"
       data-sr-singular="%d country"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Search for countries (in english)"
       data-floating="bottom"
       style="<removed>"
     >
@@ -1010,86 +1004,98 @@ exports[`In Details 1`] = `
           placeholder=" "
           type="text"
           id="<removed>"
-          popovertarget=":ds:22"
-          data-label
-          list=":ds:22"
-          aria-label="​​​​​"
+          list=":u-datalist11"
+          popovertarget=":u-datalist11"
           aria-autocomplete="list"
-          aria-controls=":ds:22"
-          aria-expanded="true"
+          aria-controls=":u-datalist11"
           autocomplete="off"
+          enterkeyhint="done"
           role="combobox"
+          aria-expanded="true"
         >
-        <del
+        <button
           aria-label="Tøm"
           hidden
-          role="button"
+          type="reset"
+          aria-hidden="false"
+          tabindex="-1"
         >
-        </del>
+        </button>
         <u-datalist
           data-nofilter
           data-sr-plural="%d forslag"
           data-sr-singular="%d forslag"
           popover="manual"
           role="listbox"
-          id="<removed>"
-          hidden
+          data-sr-of="of"
           tabindex="-1"
           aria-multiselectable="false"
+          id="<removed>"
+          data-is-floating="true"
+          aria-label="Velg en destinasjon"
+          data-floating="bottom"
+          style="<removed>"
         >
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Sogndal
           </u-option>
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Oslo
           </u-option>
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Brønnøysund
           </u-option>
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Stavanger
           </u-option>
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Trondheim
           </u-option>
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Bergen
           </u-option>
           <u-option
-            tabindex="-1"
             role="option"
             aria-disabled="false"
             aria-selected="false"
+            id="<removed>"
+            aria-hidden="false"
           >
             Lillestrøm
           </u-option>
@@ -1105,7 +1111,6 @@ exports[`Multiple 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Velg en destinasjon
   </label>
@@ -1114,43 +1119,46 @@ exports[`Multiple 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:18"
-      data-label="Velg en destinasjon"
-      list=":ds:18"
-      aria-label="Velg en destinasjon, No selected​​​​​"
+      aria-description="No selected"
+      list=":u-datalist9"
+      popovertarget=":u-datalist9"
       aria-autocomplete="list"
-      aria-controls=":ds:18"
-      aria-expanded="true"
+      aria-controls=":u-datalist9"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
-      form="#"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
       hidden
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="true"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg en destinasjon"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
         label="Sogndal"
         value="Sogndal"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Sogndal
@@ -1161,10 +1169,10 @@ exports[`Multiple 1`] = `
       <u-option
         label="Oslo"
         value="Oslo"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Oslo
@@ -1175,10 +1183,10 @@ exports[`Multiple 1`] = `
       <u-option
         label="Brønnøysund"
         value="Brønnøysund"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Brønnøysund
@@ -1189,10 +1197,10 @@ exports[`Multiple 1`] = `
       <u-option
         label="Stavanger"
         value="Stavanger"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Stavanger
@@ -1203,10 +1211,10 @@ exports[`Multiple 1`] = `
       <u-option
         label="Trondheim"
         value="Trondheim"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Trondheim
@@ -1217,10 +1225,10 @@ exports[`Multiple 1`] = `
       <u-option
         label="Bergen"
         value="Bergen"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Bergen
@@ -1231,10 +1239,10 @@ exports[`Multiple 1`] = `
       <u-option
         label="Lillestrøm"
         value="Lillestrøm"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Lillestrøm
@@ -1252,7 +1260,6 @@ exports[`Preview 1`] = `
   <label
     data-weight="medium"
     for="<removed>"
-    id="<removed>"
   >
     Velg en destinasjon
   </label>
@@ -1261,42 +1268,45 @@ exports[`Preview 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      popovertarget=":ds:2"
-      data-label="Velg en destinasjon"
-      list=":ds:2"
-      aria-label="Velg en destinasjon​​​​​"
+      list=":u-datalist1"
+      popovertarget=":u-datalist1"
       aria-autocomplete="list"
-      aria-controls=":ds:2"
-      aria-expanded="true"
+      aria-controls=":u-datalist1"
       autocomplete="off"
+      enterkeyhint="done"
       role="combobox"
+      aria-expanded="true"
     >
-    <del
+    <button
       aria-label="Tøm"
       hidden
-      role="button"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
     >
-    </del>
+    </button>
     <u-datalist
       data-nofilter
       data-sr-plural="%d forslag"
       data-sr-singular="%d forslag"
       popover="manual"
       role="listbox"
-      id="<removed>"
+      data-sr-of="of"
       tabindex="-1"
       aria-multiselectable="false"
-      aria-labelledby="<removed>"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg en destinasjon"
       data-floating="bottom"
       style="<removed>"
     >
       <u-option
         label="Sogndal"
         value="Sogndal"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Sogndal
@@ -1307,10 +1317,10 @@ exports[`Preview 1`] = `
       <u-option
         label="Oslo"
         value="Oslo"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Oslo
@@ -1321,10 +1331,10 @@ exports[`Preview 1`] = `
       <u-option
         label="Brønnøysund"
         value="Brønnøysund"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Brønnøysund
@@ -1335,10 +1345,10 @@ exports[`Preview 1`] = `
       <u-option
         label="Stavanger"
         value="Stavanger"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Stavanger
@@ -1349,10 +1359,10 @@ exports[`Preview 1`] = `
       <u-option
         label="Trondheim"
         value="Trondheim"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Trondheim
@@ -1363,10 +1373,10 @@ exports[`Preview 1`] = `
       <u-option
         label="Bergen"
         value="Bergen"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Bergen
@@ -1377,10 +1387,10 @@ exports[`Preview 1`] = `
       <u-option
         label="Lillestrøm"
         value="Lillestrøm"
-        tabindex="-1"
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
         aria-hidden="false"
       >
         Lillestrøm

--- a/@udir-design/react/src/components/switch/Switch.mdx
+++ b/@udir-design/react/src/components/switch/Switch.mdx
@@ -50,6 +50,12 @@ Bruk [`Fieldset`](/docs/components-fieldset--docs) for å gruppere flere `Switch
 
 <Canvas of={SwitchStories.Group} />
 
+### Outline
+
+`variant="outline"` legger på ekstra padding og en ramme rundt valget slik at det blir en større klikkflate.
+
+<Canvas of={SwitchStories.Outline} />
+
 ### Høyrejustert
 
 Det er mulig å plassere `Switch` på høyre siden av ledeteksten ved å bruke `position="end"`. Pass på at avstanden ikke blir for stor slik at det blir vanskelig å se hvilken tekst som hører til hvilken `Switch`.

--- a/@udir-design/react/src/components/switch/Switch.stories.tsx
+++ b/@udir-design/react/src/components/switch/Switch.stories.tsx
@@ -114,6 +114,12 @@ export const Group = meta.story({
   ),
 });
 
+export const Outline = Group.extend({
+  args: {
+    variant: 'outline',
+  },
+});
+
 export const GroupEnd = meta.story({
   args: {
     position: 'end',

--- a/@udir-design/react/src/components/switch/__snapshots__/Switch.stories.tsx.snap
+++ b/@udir-design/react/src/components/switch/__snapshots__/Switch.stories.tsx.snap
@@ -270,6 +270,90 @@ exports[`Group End 1`] = `
 </fieldset>
 `;
 
+exports[`Outline 1`] = `
+<fieldset aria-labelledby="<removed>">
+  <legend
+    data-weight="medium"
+    id="<removed>"
+  >
+    Varsler
+  </legend>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      role="switch"
+      type="checkbox"
+      value="lydvarsler"
+      checked
+      id="<removed>"
+      aria-describedby="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      Lydvarsler
+    </label>
+    <div
+      data-field="description"
+      id="<removed>"
+    >
+      Spill av lyd når et varsel mottas.
+    </div>
+  </ds-field>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      role="switch"
+      type="checkbox"
+      value="popup-varsler"
+      id="<removed>"
+      aria-describedby="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      Popup-varsler
+    </label>
+    <div
+      data-field="description"
+      id="<removed>"
+    >
+      Vis popup-varsler på skjermen.
+    </div>
+  </ds-field>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      role="switch"
+      type="checkbox"
+      value="email-varsler"
+      id="<removed>"
+      aria-describedby="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      E-postvarsler
+    </label>
+    <div
+      data-field="description"
+      id="<removed>"
+    >
+      Tillat e-postvarsler for viktige oppdateringer.
+    </div>
+  </ds-field>
+</fieldset>
+`;
+
 exports[`Preview 1`] = `
 <ds-field data-clickdelegatefor="<removed>">
   <input

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -320,179 +320,177 @@ exports[`Form Page 2 1`] = `
             required
             type="text"
             aria-describedby="<removed>"
-            popovertarget=":ds:4"
-            data-label="Gjennomføringssted"
-            list=":ds:4"
-            aria-label="Gjennomføringssted​​​​​"
-            aria-autocomplete="list"
-            aria-controls=":ds:4"
-            aria-expanded="true"
-            role="combobox"
+            list=":u-datalist1"
+            popovertarget=":u-datalist1"
           >
-          <del
+          <button
             aria-label="Tøm"
             hidden
-            role="button"
+            type="reset"
+            aria-hidden="false"
+            tabindex="-1"
           >
-          </del>
+          </button>
           <u-datalist
             data-nofilter
             data-sr-plural="%d forslag"
             data-sr-singular="%d forslag"
             popover="manual"
             role="listbox"
-            id="<removed>"
+            data-sr-of="of"
             hidden
             tabindex="-1"
             aria-multiselectable="false"
+            id="<removed>"
+            data-is-floating="true"
           >
             <u-option
               label="Agder"
               value="Agder"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Agder
             </u-option>
             <u-option
               label="Akershus"
               value="Akershus"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Akershus
             </u-option>
             <u-option
               label="Buskerud"
               value="Buskerud"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Buskerud
             </u-option>
             <u-option
               label="Finnmark"
               value="Finnmark"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Finnmark
             </u-option>
             <u-option
               label="Innlandet"
               value="Innlandet"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Innlandet
             </u-option>
             <u-option
               label="Møre og Romsdal"
               value="Møre og Romsdal"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Møre og Romsdal
             </u-option>
             <u-option
               label="Nordland"
               value="Nordland"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Nordland
             </u-option>
             <u-option
               label="Oslo"
               value="Oslo"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Oslo
             </u-option>
             <u-option
               label="Rogaland"
               value="Rogaland"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Rogaland
             </u-option>
             <u-option
               label="Telemark"
               value="Telemark"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Telemark
             </u-option>
             <u-option
               label="Troms"
               value="Troms"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Troms
             </u-option>
             <u-option
               label="Trøndelag"
               value="Trøndelag"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Trøndelag
             </u-option>
             <u-option
               label="Vestfold"
               value="Vestfold"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Vestfold
             </u-option>
             <u-option
               label="Vestland"
               value="Vestland"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Vestland
             </u-option>
             <u-option
               label="Østfold"
               value="Østfold"
-              tabindex="-1"
               role="option"
               aria-disabled="false"
               aria-selected="false"
+              id="<removed>"
             >
               Østfold
             </u-option>

--- a/@udir-design/react/src/utilities/hooks/beta.ts
+++ b/@udir-design/react/src/utilities/hooks/beta.ts
@@ -7,6 +7,7 @@
 
 export {
   type UseCheckboxGroupProps,
+  type UseCheckboxGroupReturn,
   useCheckboxGroup,
 } from './useCheckboxGroup/useCheckboxGroup';
 export {
@@ -15,6 +16,7 @@ export {
 } from './usePagination/usePagination';
 export {
   type UseRadioGroupProps,
+  type UseRadioGroupReturn,
   useRadioGroup,
 } from './useRadioGroup/useRadioGroup';
 export {

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/__snapshots__/useCheckboxGroup.stories.tsx.snap
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/__snapshots__/useCheckboxGroup.stories.tsx.snap
@@ -392,6 +392,81 @@ exports[`Indeterminate In Table 1`] = `
 </table>
 `;
 
+exports[`Outline 1`] = `
+<fieldset aria-labelledby="<removed>">
+  <legend
+    data-weight="medium"
+    id="<removed>"
+  >
+    Hvordan vil du helst at vi skal kontakte deg?
+  </legend>
+  <p
+    data-variant="default"
+    id="<removed>"
+  >
+    Velg de alternativene som er relevante for deg.
+  </p>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      type="checkbox"
+      value="epost"
+      checked
+      name="my-group"
+      id="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      E-post
+    </label>
+  </ds-field>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      type="checkbox"
+      value="telefon"
+      name="my-group"
+      id="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      Telefon
+    </label>
+  </ds-field>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      type="checkbox"
+      value="sms"
+      name="my-group"
+      id="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      SMS
+    </label>
+  </ds-field>
+  <p
+    data-field="validation"
+    hidden
+    id="<removed>"
+  >
+  </p>
+</fieldset>
+`;
+
 exports[`Read Only 1`] = `
 <fieldset aria-labelledby="<removed>">
   <legend

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/docs/FakeUseCheckboxGroup.tsx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/docs/FakeUseCheckboxGroup.tsx
@@ -1,0 +1,6 @@
+import type { FunctionComponent } from 'react';
+import type { UseCheckboxGroupProps } from '../useCheckboxGroup';
+
+export const useCheckboxGroup: FunctionComponent<UseCheckboxGroupProps> = () =>
+  null;
+useCheckboxGroup.displayName = 'useCheckboxGroup';

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
@@ -9,6 +9,7 @@ import { Fieldset } from 'src/components/fieldset/Fieldset';
 import { Table } from 'src/components/table';
 import { Paragraph } from 'src/components/typography/paragraph/Paragraph';
 import { ValidationMessage } from 'src/components/typography/validationMessage/ValidationMessage';
+import { useCheckboxGroup as fakeUseCheckboxGroup } from './docs/FakeUseCheckboxGroup';
 import {
   type UseCheckboxGroupProps,
   useCheckboxGroup,
@@ -20,58 +21,11 @@ const meta = preview.meta<
   Partial<UseCheckboxGroupProps>
 >({
   title: 'Utilities/useCheckboxGroup',
+  component: fakeUseCheckboxGroup,
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
     chromatic: { disableSnapshot: true },
-  },
-  argTypes: {
-    name: {
-      table: { type: { summary: 'string' } },
-      description:
-        'Name of all checkboxes. If no name is passed, an auto-generated name will be created.',
-    },
-    value: {
-      description: 'Array of values of selected checkboxes',
-      table: {
-        defaultValue: { summary: '' },
-        type: { summary: 'string[]' },
-      },
-    },
-    onChange: {
-      description: 'Callback when selected checkboxes changes',
-      table: {
-        type: {
-          summary:
-            '(nextValue: string[], prevValue: string[], event: ChangeEvent<HTMLInputElement>) => void;',
-        },
-      },
-    },
-    error: {
-      table: { type: { summary: 'string | ReactNode' } },
-      description: 'Shared error message for all checkboxes.',
-    },
-    disabled: {
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      description: 'Set disabled state of all checkboxes',
-    },
-    readOnly: {
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      description: 'Set read only state of all checkboxes',
-    },
-    required: {
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      description: 'Set required state of all checkboxes',
-    },
   },
 });
 
@@ -123,6 +77,12 @@ const GroupBase = {
 };
 
 export const Group = meta.story(GroupBase);
+
+export const Outline = Group.extend({
+  args: {
+    variant: 'outline',
+  },
+});
 
 export const WithError = meta.story({
   args: {

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
@@ -25,7 +25,6 @@ const meta = preview.meta<
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
-    chromatic: { disableSnapshot: true },
   },
 });
 

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
@@ -1,7 +1,30 @@
 import {
-  type UseCheckboxGroupProps,
-  useCheckboxGroup,
+  type UseCheckboxGroupProps as UseCheckboxGroupPropsDigdir,
+  useCheckboxGroup as useCheckboxGroupDigdir,
 } from '@digdir/designsystemet-react';
+import type { CheckboxProps } from '../../../components/checkbox/Checkbox';
+import type { MergeRight } from '../../type-utils';
 
-export type { UseCheckboxGroupProps };
+type UseCheckboxGroupProps = MergeRight<
+  Omit<
+    CheckboxProps,
+    'aria-label' | 'aria-labelledby' | 'data-size' | 'data-indeterminate'
+  >,
+  UseCheckboxGroupPropsDigdir
+>;
+
+type UseCheckboxGroupReturn = ReturnType<typeof useCheckboxGroupDigdir>;
+const useCheckboxGroup = (
+  props?: UseCheckboxGroupProps,
+): UseCheckboxGroupReturn => {
+  const { onChange: _1, error: _2, ...groupProps } = props || {};
+  const { getCheckboxProps: getCheckboxPropsDigdir, ...rest } =
+    useCheckboxGroupDigdir(props);
+  const getCheckboxProps: typeof getCheckboxPropsDigdir = (propsOrValue) => ({
+    ...(groupProps as ReturnType<typeof getCheckboxPropsDigdir>),
+    ...getCheckboxPropsDigdir(propsOrValue),
+  });
+  return { ...rest, getCheckboxProps };
+};
+export type { UseCheckboxGroupProps, UseCheckboxGroupReturn };
 export { useCheckboxGroup };

--- a/@udir-design/react/src/utilities/hooks/usePagination/usePagination.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/usePagination/usePagination.stories.tsx
@@ -13,7 +13,6 @@ const meta = preview.meta<
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
-    chromatic: { disableSnapshot: true },
   },
   argTypes: {
     currentPage: {

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/__snapshots__/useRadioGroup.stories.tsx.snap
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/__snapshots__/useRadioGroup.stories.tsx.snap
@@ -292,6 +292,80 @@ exports[`Group 1`] = `
 </fieldset>
 `;
 
+exports[`Outline 1`] = `
+<fieldset aria-labelledby="<removed>">
+  <legend
+    data-weight="medium"
+    id="<removed>"
+  >
+    Velg din aldersgruppe.
+  </legend>
+  <p
+    data-variant="default"
+    id="<removed>"
+  >
+    Informasjonen blir brukt til å tilpasse innholdet på siden.
+  </p>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      type="radio"
+      value="10-20"
+      name="my-group"
+      id="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      10-20 år
+    </label>
+  </ds-field>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      type="radio"
+      value="21-45"
+      name="my-group"
+      id="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      21-45 år
+    </label>
+  </ds-field>
+  <ds-field
+    data-variant="outline"
+    data-clickdelegatefor="<removed>"
+  >
+    <input
+      type="radio"
+      value="46-80"
+      name="my-group"
+      id="<removed>"
+    >
+    <label
+      data-weight="regular"
+      for="<removed>"
+    >
+      46-80 år
+    </label>
+  </ds-field>
+  <p
+    data-field="validation"
+    hidden
+    id="<removed>"
+  >
+  </p>
+</fieldset>
+`;
+
 exports[`Read Only 1`] = `
 <fieldset aria-labelledby="<removed>">
   <legend

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/docs/FakeUseRadioGroup.tsx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/docs/FakeUseRadioGroup.tsx
@@ -1,0 +1,5 @@
+import type { FunctionComponent } from 'react';
+import type { UseRadioGroupProps } from '../useRadioGroup';
+
+export const useRadioGroup: FunctionComponent<UseRadioGroupProps> = () => null;
+useRadioGroup.displayName = 'useRadioGroup';

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
@@ -8,6 +8,7 @@ import { Fieldset } from 'src/components/fieldset/Fieldset';
 import { Radio } from 'src/components/radio/Radio';
 import { Paragraph } from 'src/components/typography/paragraph/Paragraph';
 import { ValidationMessage } from 'src/components/typography/validationMessage/ValidationMessage';
+import { useRadioGroup as fakeUseRadioGroup } from './docs/FakeUseRadioGroup';
 import { type UseRadioGroupProps, useRadioGroup } from './useRadioGroup';
 
 const meta = preview.meta<
@@ -16,55 +17,11 @@ const meta = preview.meta<
   Partial<UseRadioGroupProps>
 >({
   title: 'Utilities/useRadioGroup',
+  component: fakeUseRadioGroup,
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
     chromatic: { disableSnapshot: true },
-  },
-  argTypes: {
-    name: {
-      table: { type: { summary: 'string' } },
-      description:
-        'Name of all radios. If no name is passed, an auto-generated name will be created.',
-    },
-    value: {
-      description: 'Value of selected radio',
-      table: { defaultValue: { summary: '' }, type: { summary: 'string' } },
-    },
-    onChange: {
-      description: 'Callback when selected radio changes',
-      table: {
-        type: {
-          summary:
-            '(nextValue: string, prevValue: string, event: Event) => void;',
-        },
-      },
-    },
-    error: {
-      table: { type: { summary: 'string | ReactNode' } },
-      description: 'Shared error message for all radios.',
-    },
-    disabled: {
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      description: 'Set disabled state of all radios',
-    },
-    readOnly: {
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      description: 'Set read only state of all radios',
-    },
-    required: {
-      table: {
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-      description: 'Set required state of all radios',
-    },
   },
 });
 
@@ -210,6 +167,12 @@ export const Group = meta.story({
       expect(radios[0]).toHaveFocus();
       expect(radios[0]).toBeChecked();
     });
+  },
+});
+
+export const Outline = Group.extend({
+  args: {
+    variant: 'outline',
   },
 });
 

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
@@ -21,7 +21,6 @@ const meta = preview.meta<
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
-    chromatic: { disableSnapshot: true },
   },
 });
 

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
@@ -1,7 +1,25 @@
 import {
-  type UseRadioGroupProps,
-  useRadioGroup,
+  type UseRadioGroupProps as UseRadioGroupPropsDigdir,
+  useRadioGroup as useRadioGroupDigdir,
 } from '@digdir/designsystemet-react';
+import type { RadioProps } from '../../../components/radio/Radio';
+import type { MergeRight } from '../../type-utils';
 
-export type { UseRadioGroupProps };
+type UseRadioGroupProps = MergeRight<
+  Omit<RadioProps, 'aria-label' | 'aria-labelledby' | 'data-size'>,
+  UseRadioGroupPropsDigdir
+>;
+
+type UseRadioGroupReturn = ReturnType<typeof useRadioGroupDigdir>;
+const useRadioGroup = (props?: UseRadioGroupProps): UseRadioGroupReturn => {
+  const { onChange: _1, error: _2, ...groupProps } = props || {};
+  const { getRadioProps: getRadioPropsDigdir, ...rest } =
+    useRadioGroupDigdir(props);
+  const getRadioProps: typeof getRadioPropsDigdir = (propsOrValue) => ({
+    ...(groupProps as ReturnType<typeof getRadioPropsDigdir>),
+    ...getRadioPropsDigdir(propsOrValue),
+  });
+  return { ...rest, getRadioProps };
+};
+export type { UseRadioGroupProps, UseRadioGroupReturn };
 export { useRadioGroup };

--- a/@udir-design/react/src/utilities/type-utils.ts
+++ b/@udir-design/react/src/utilities/type-utils.ts
@@ -1,0 +1,5 @@
+/**
+ * Create a new type with the properties of the first type merged with the properties of the second type.
+ * If a key exists in both types, the property from the *second* type will be used.
+ */
+export type MergeRight<T1, T2> = Omit<T1, keyof T2> & T2;

--- a/@udir-design/theme/dist/index.css
+++ b/@udir-design/theme/dist/index.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 /*
-build: v1.13.3
+build: v1.14.0
 design-tokens: v1.9.0
 */
 

--- a/@udir-design/theme/dist/types.d.ts
+++ b/@udir-design/theme/dist/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.13.3 */
+/* build: v1.14.0 */
 import type {} from '@digdir/designsystemet-types';
 
 // Augment types based on theme

--- a/nx.json
+++ b/nx.json
@@ -36,7 +36,9 @@
       "inputs": ["default", "^default"],
       "outputs": ["{projectRoot}/dist"]
     },
-
+    "inject": {
+      "dependsOn": ["build"]
+    },
     "test": {
       "cache": true,
       "dependsOn": ["build"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,20 +19,20 @@ catalogs:
       specifier: ^20.5.0
       version: 20.5.0
     '@digdir/designsystemet':
-      specifier: 1.13.3
-      version: 1.13.3
+      specifier: 1.14.0
+      version: 1.14.0
     '@digdir/designsystemet-css':
-      specifier: 1.13.3
-      version: 1.13.3
+      specifier: 1.14.0
+      version: 1.14.0
     '@digdir/designsystemet-react':
-      specifier: 1.13.3
-      version: 1.13.3
+      specifier: 1.14.0
+      version: 1.14.0
     '@digdir/designsystemet-types':
-      specifier: 1.13.3
-      version: 1.13.3
+      specifier: 1.14.0
+      version: 1.14.0
     '@digdir/designsystemet-web':
-      specifier: 1.13.3
-      version: 1.13.3
+      specifier: 1.14.0
+      version: 1.14.0
     '@eslint/compat':
       specifier: ^2.0.5
       version: 2.0.5
@@ -50,7 +50,7 @@ catalogs:
       version: 5.2.2
     '@navikt/aksel-icons':
       specifier: ^8.10.1
-      version: 8.10.1
+      version: 8.10.5
     '@next/eslint-plugin-next':
       specifier: ^16.2.4
       version: 16.2.4
@@ -260,7 +260,7 @@ catalogs:
       version: 1.59.1
     postcss:
       specifier: ^8.5.10
-      version: 8.5.10
+      version: 8.5.14
     postcss-cli:
       specifier: ^11.0.1
       version: 11.0.1
@@ -383,7 +383,7 @@ catalogs:
       version: 18.0.0
     zod:
       specifier: ^4.3.6
-      version: 4.3.6
+      version: 4.4.3
 
 overrides:
   '@eslint/plugin-kit@<0.3.4': '>=0.3.4'
@@ -540,7 +540,7 @@ importers:
     dependencies:
       '@digdir/designsystemet-css':
         specifier: 'catalog:'
-        version: 1.13.3
+        version: 1.14.0
       '@udir-design/theme':
         specifier: workspace:*
         version: link:../theme
@@ -550,31 +550,31 @@ importers:
         version: link:../icons
       autoprefixer:
         specifier: 'catalog:'
-        version: 10.5.0(postcss@8.5.10)
+        version: 10.5.0(postcss@8.5.14)
       cssnano:
         specifier: 'catalog:'
-        version: 7.1.7(postcss@8.5.10)
+        version: 7.1.7(postcss@8.5.14)
       postcss:
         specifier: 'catalog:'
-        version: 8.5.10
+        version: 8.5.14
       postcss-cli:
         specifier: 'catalog:'
-        version: 11.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)
+        version: 11.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)
       postcss-easy-import:
         specifier: 'catalog:'
-        version: 4.0.0(postcss@8.5.10)
+        version: 4.0.0(postcss@8.5.14)
       postcss-load-config:
         specifier: 'catalog:'
-        version: 6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3)
       postcss-nesting:
         specifier: 'catalog:'
-        version: 14.0.0(postcss@8.5.10)
+        version: 14.0.0(postcss@8.5.14)
 
   '@udir-design/icons':
     dependencies:
       '@navikt/aksel-icons':
         specifier: 'catalog:'
-        version: 8.10.1(@types/react@19.2.14)(react@19.2.5)
+        version: 8.10.5(@types/react@19.2.14)(react@19.2.5)
     devDependencies:
       camelcase:
         specifier: 'catalog:'
@@ -593,13 +593,13 @@ importers:
     dependencies:
       '@digdir/designsystemet-react':
         specifier: 'catalog:'
-        version: 1.13.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 1.14.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@digdir/designsystemet-types':
         specifier: 'catalog:'
-        version: 1.13.3
+        version: 1.14.0
       '@digdir/designsystemet-web':
         specifier: 'catalog:'
-        version: 1.13.3
+        version: 1.14.0
       '@radix-ui/react-slot':
         specifier: 'catalog:'
         version: 1.2.4(@types/react@19.2.14)(react@19.2.5)
@@ -786,7 +786,7 @@ importers:
         version: 4.1.5(@types/node@24.12.2)(@vitest/browser-playwright@4.1.5)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@28.1.0)(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: 'catalog:'
-        version: 4.3.6
+        version: 4.4.3
 
   '@udir-design/symbols':
     devDependencies:
@@ -840,7 +840,7 @@ importers:
     dependencies:
       '@digdir/designsystemet-types':
         specifier: 'catalog:'
-        version: 1.13.3
+        version: 1.14.0
     devDependencies:
       '@internal/build-tools':
         specifier: workspace:*
@@ -860,7 +860,7 @@ importers:
     devDependencies:
       '@digdir/designsystemet':
         specifier: 'catalog:'
-        version: 1.13.3(tslib@2.8.1)
+        version: 1.14.0(tslib@2.8.1)
       '@tokens-studio/sd-transforms':
         specifier: 'catalog:'
         version: 2.0.3(style-dictionary@5.4.0(tslib@2.8.1))
@@ -972,7 +972,7 @@ importers:
     dependencies:
       '@digdir/designsystemet-css':
         specifier: 'catalog:'
-        version: 1.13.3
+        version: 1.14.0
       '@udir-design/css':
         specifier: workspace:*
         version: link:../../@udir-design/css
@@ -1809,23 +1809,23 @@ packages:
     resolution: {integrity: sha512-QPKO4ao2+iniYAYnPZwHKK67EgDG2GAdye9OCy11xsmApHGwzpH3AcSdPjGyPO3tC2/K8mF7JjWX3A/FTRnskg==}
     engines: {node: '>=18'}
 
-  '@digdir/designsystemet-css@1.13.3':
-    resolution: {integrity: sha512-ZtuygHy9xm6DVBi59pGKdbiR7vPNcwHx6e4E3xRgxL0nT6262vbYpaU+woiMS0a+krPpvkJ6K6CBmNcIqsV8IQ==}
+  '@digdir/designsystemet-css@1.14.0':
+    resolution: {integrity: sha512-qAIpcrFgO80p5TrVWcRUC8xO1ZAEp1j39kQ+WLyBuM/BBsgLXBZVIUaju3ZI1rsQFNyY/QZ9CKQslnoOVAeCkQ==}
 
-  '@digdir/designsystemet-react@1.13.3':
-    resolution: {integrity: sha512-RwCrXiKxvFMLJAwtpiRl26PHecRlwXFu1155vJE8oVuxY1nFW/5xqUbBtuX3MsSBoy6SN2byxN22hoJhJC4q/Q==}
+  '@digdir/designsystemet-react@1.14.0':
+    resolution: {integrity: sha512-m4lYxbWv0bY5ayg0L+DueSrrhk2W+A0ovs443MteABwcx6pLDYPQMVl0FGZ/Wtn2gB92ZivvWuVhUxdom13dKg==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
 
-  '@digdir/designsystemet-types@1.13.3':
-    resolution: {integrity: sha512-yGhZoQmHhRmUGw8isyS2k3xgtI8yB+7s2wWnstdemVpls+SSZmDs3g1d3+Cj16PNNOnevDUDS6oxd+txF1zGBQ==}
+  '@digdir/designsystemet-types@1.14.0':
+    resolution: {integrity: sha512-d/JZhwebAgclFsE7ax0Z8mWotEk3GE4e9+iC8Cq8EN5BQ+bOptwFrVipSrL+NAt8/7AX9WzrnAScPuxCb4vvgQ==}
 
-  '@digdir/designsystemet-web@1.13.3':
-    resolution: {integrity: sha512-lzyMa7uIdbd5t5C74GffZIahzQyoidJCD/eiUQXustVvI/2JxNP36rTyM6QRZcsfNMr3I5s0hewGBsGhq/ab2w==}
+  '@digdir/designsystemet-web@1.14.0':
+    resolution: {integrity: sha512-dmUnV/0wzTOSPnSGqQwjYyneuO+/QqfugAr2SP1N1m/VzfMal3Y5hD+AkDWWzWhJ7EJrhGtYwG5JVRM8iYuVeQ==}
 
-  '@digdir/designsystemet@1.13.3':
-    resolution: {integrity: sha512-Clr56SrOku6VaiUmAKkXM/e5Xvqrkp6eFdlLYto//rWjkbQnlLHkKu842H4ae9x0HSxPHXmXtuq6SH0zoq3FXA==}
+  '@digdir/designsystemet@1.14.0':
+    resolution: {integrity: sha512-y+CWrrjzlEBbu0DmcdhwC5167rz+l5qUIb0l4dLMkxIrkQKXSC0dt/aoxATFsHhVTehbKuYUrGZdCkZTW+/bSA==}
     engines: {node: '>=20.20.2'}
     hasBin: true
 
@@ -2462,8 +2462,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@navikt/aksel-icons@8.10.1':
-    resolution: {integrity: sha512-nIOl9nG59kK/2hPyiZWdeTGXFj4LO41F6Y6D+Jsj+p9N2dEZEGrpyZ54BGdTXMu1+REVSsZiYmd2fip8h1EFNw==}
+  '@navikt/aksel-icons@8.10.5':
+    resolution: {integrity: sha512-XDmygarYMyGhGxE5x5uVDCxPPW5dty2A0yVvdT+I6VyRjvDDY/jtAw0NU/HV5itAm7prCwO19IKf1DvjuzU31g==}
     peerDependencies:
       '@types/react': ^18.3.11 || ^19.0.0
       react: ^18.3.1 || ^19.0.0
@@ -3737,11 +3737,11 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
-  '@u-elements/u-combobox@1.0.7':
-    resolution: {integrity: sha512-rueG+Wof9ycmbjIW2omS4bLite5BkH87SWfkBrvSjrR1GWn4wgpjnUQ1lORDRalYcPYlgFWy2uGFEqqKPx3Yqw==}
+  '@u-elements/u-combobox@2.0.4':
+    resolution: {integrity: sha512-+X4w54dgySFJWer2n5Q5wYm48vSYW2kiM0fibjFINU8hXeejf+A4qYy4s56g9StHyH3b2Ar/2ZEWgZALGE2zLA==}
 
-  '@u-elements/u-datalist@1.1.0':
-    resolution: {integrity: sha512-t8H3OddziXmq0YBuXodVWnvRi56WW4sfbJEIO1fx4i39sZ0s/0xjHBsoAsTZkb9mXJEtpgrsH8IkDYP0ZSgSXQ==}
+  '@u-elements/u-datalist@2.0.1':
+    resolution: {integrity: sha512-xfbSiTZApvbqCt6W3LUtoyAArxOYq17Em9mYyjStiq5/XpshTVsN1JkqSqo+OjVOwDieggyAQsRwgloZgtHB7Q==}
 
   '@u-elements/u-details@1.0.0':
     resolution: {integrity: sha512-CA0w0VTH/vWWouFWEw7XIws3RUCBm2dh7ity+sbDXgpc6yz5NkoMpeDTdB/DHpI+/YInULz0XLOTrw8b7KX3Qg==}
@@ -3749,8 +3749,8 @@ packages:
   '@u-elements/u-progress@0.0.7':
     resolution: {integrity: sha512-T2Q6jwWL60we4qiZCOPqnhEfoI2lOaUP3EmYYvnVpZ+iA8HVuqT+kgdQgACiVymfGWgIzapTcP6xaM02AvPa/A==}
 
-  '@u-elements/u-tabs@1.0.1':
-    resolution: {integrity: sha512-3qAWrFtHCI7+8K2TR1LtcDTPihjANn0lGcMA7d+OZiQxMO00hWns9nKR/4OHmXc8LWLB6MWKG9e6Yg7Vs/MkjQ==}
+  '@u-elements/u-tabs@1.0.3':
+    resolution: {integrity: sha512-Jqd3YuwpWHZVrPx8qiLN4njsdQ/KZY6PbHsskC42mrnxkuR4LnnmWBoRPgcKrn7P74rRtm0MnPp0PMDZYbSorg==}
 
   '@udir-design/react@file:@udir-design/react':
     resolution: {directory: '@udir-design/react', type: directory}
@@ -6902,8 +6902,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   precinct@12.3.1:
@@ -8145,8 +8145,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -9262,17 +9262,17 @@ snapshots:
       gonzales-pe: 4.3.0
       node-source-walk: 7.0.1
 
-  '@digdir/designsystemet-css@1.13.3':
+  '@digdir/designsystemet-css@1.14.0':
     dependencies:
-      '@digdir/designsystemet-types': 1.13.3
+      '@digdir/designsystemet-types': 1.14.0
 
-  '@digdir/designsystemet-react@1.13.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@digdir/designsystemet-react@1.14.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@digdir/designsystemet-types': 1.13.3
-      '@digdir/designsystemet-web': 1.13.3
+      '@digdir/designsystemet-types': 1.14.0
+      '@digdir/designsystemet-web': 1.14.0
       '@floating-ui/dom': 1.7.6
       '@floating-ui/react': 0.26.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@navikt/aksel-icons': 8.10.1(@types/react@19.2.14)(react@19.2.5)
+      '@navikt/aksel-icons': 8.10.5(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@tanstack/react-virtual': 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       clsx: 2.1.1
@@ -9281,20 +9281,20 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@digdir/designsystemet-types@1.13.3': {}
+  '@digdir/designsystemet-types@1.14.0': {}
 
-  '@digdir/designsystemet-web@1.13.3':
+  '@digdir/designsystemet-web@1.14.0':
     dependencies:
       '@floating-ui/dom': 1.7.6
-      '@u-elements/u-combobox': 1.0.7
-      '@u-elements/u-datalist': 1.1.0
+      '@u-elements/u-combobox': 2.0.4
+      '@u-elements/u-datalist': 2.0.1
       '@u-elements/u-details': 1.0.0
-      '@u-elements/u-tabs': 1.0.1
+      '@u-elements/u-tabs': 1.0.3
 
-  '@digdir/designsystemet@1.13.3(tslib@2.8.1)':
+  '@digdir/designsystemet@1.14.0(tslib@2.8.1)':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
-      '@digdir/designsystemet-types': 1.13.3
+      '@digdir/designsystemet-types': 1.14.0
       '@tokens-studio/sd-transforms': 2.0.3(style-dictionary@5.4.0(tslib@2.8.1))
       chroma-js: 3.2.0
       colorjs.io: 0.6.1
@@ -9303,11 +9303,11 @@ snapshots:
       hsluv: 1.0.1
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.10
+      postcss: 8.5.14
       ramda: 0.32.0
       style-dictionary: 5.4.0(tslib@2.8.1)
-      zod: 4.3.6
-      zod-validation-error: 5.0.0(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 5.0.0(zod@4.4.3)
     transitivePeerDependencies:
       - tslib
 
@@ -9861,7 +9861,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@navikt/aksel-icons@8.10.1(@types/react@19.2.14)(react@19.2.5)':
+  '@navikt/aksel-icons@8.10.5(@types/react@19.2.14)(react@19.2.5)':
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.5
@@ -11090,21 +11090,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@u-elements/u-combobox@1.0.7': {}
+  '@u-elements/u-combobox@2.0.4': {}
 
-  '@u-elements/u-datalist@1.1.0': {}
+  '@u-elements/u-datalist@2.0.1': {}
 
   '@u-elements/u-details@1.0.0': {}
 
   '@u-elements/u-progress@0.0.7': {}
 
-  '@u-elements/u-tabs@1.0.1': {}
+  '@u-elements/u-tabs@1.0.3': {}
 
   '@udir-design/react@file:@udir-design/react(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@digdir/designsystemet-react': 1.13.3(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@digdir/designsystemet-types': 1.13.3
-      '@digdir/designsystemet-web': 1.13.3
+      '@digdir/designsystemet-react': 1.14.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@digdir/designsystemet-types': 1.14.0
+      '@digdir/designsystemet-web': 1.14.0
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
       '@u-elements/u-details': 1.0.0
       '@u-elements/u-progress': 0.0.7
@@ -11339,7 +11339,7 @@ snapshots:
       '@vue/shared': 3.5.33
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.33':
@@ -11572,13 +11572,13 @@ snapshots:
 
   attr-accept@2.2.5: {}
 
-  autoprefixer@10.5.0(postcss@8.5.10):
+  autoprefixer@10.5.0(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001790
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -12004,9 +12004,9 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-declaration-sorter@7.4.0(postcss@8.5.10):
+  css-declaration-sorter@7.4.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
 
   css-select@5.2.2:
     dependencies:
@@ -12037,49 +12037,49 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@7.0.15(postcss@8.5.10):
+  cssnano-preset-default@7.0.15(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      css-declaration-sorter: 7.4.0(postcss@8.5.10)
-      cssnano-utils: 5.0.2(postcss@8.5.10)
-      postcss: 8.5.10
-      postcss-calc: 10.1.1(postcss@8.5.10)
-      postcss-colormin: 7.0.9(postcss@8.5.10)
-      postcss-convert-values: 7.0.11(postcss@8.5.10)
-      postcss-discard-comments: 7.0.7(postcss@8.5.10)
-      postcss-discard-duplicates: 7.0.3(postcss@8.5.10)
-      postcss-discard-empty: 7.0.2(postcss@8.5.10)
-      postcss-discard-overridden: 7.0.2(postcss@8.5.10)
-      postcss-merge-longhand: 7.0.6(postcss@8.5.10)
-      postcss-merge-rules: 7.0.10(postcss@8.5.10)
-      postcss-minify-font-values: 7.0.2(postcss@8.5.10)
-      postcss-minify-gradients: 7.0.4(postcss@8.5.10)
-      postcss-minify-params: 7.0.8(postcss@8.5.10)
-      postcss-minify-selectors: 7.1.0(postcss@8.5.10)
-      postcss-normalize-charset: 7.0.2(postcss@8.5.10)
-      postcss-normalize-display-values: 7.0.2(postcss@8.5.10)
-      postcss-normalize-positions: 7.0.3(postcss@8.5.10)
-      postcss-normalize-repeat-style: 7.0.3(postcss@8.5.10)
-      postcss-normalize-string: 7.0.2(postcss@8.5.10)
-      postcss-normalize-timing-functions: 7.0.2(postcss@8.5.10)
-      postcss-normalize-unicode: 7.0.8(postcss@8.5.10)
-      postcss-normalize-url: 7.0.2(postcss@8.5.10)
-      postcss-normalize-whitespace: 7.0.2(postcss@8.5.10)
-      postcss-ordered-values: 7.0.3(postcss@8.5.10)
-      postcss-reduce-initial: 7.0.8(postcss@8.5.10)
-      postcss-reduce-transforms: 7.0.2(postcss@8.5.10)
-      postcss-svgo: 7.1.2(postcss@8.5.10)
-      postcss-unique-selectors: 7.0.6(postcss@8.5.10)
+      css-declaration-sorter: 7.4.0(postcss@8.5.14)
+      cssnano-utils: 5.0.2(postcss@8.5.14)
+      postcss: 8.5.14
+      postcss-calc: 10.1.1(postcss@8.5.14)
+      postcss-colormin: 7.0.9(postcss@8.5.14)
+      postcss-convert-values: 7.0.11(postcss@8.5.14)
+      postcss-discard-comments: 7.0.7(postcss@8.5.14)
+      postcss-discard-duplicates: 7.0.3(postcss@8.5.14)
+      postcss-discard-empty: 7.0.2(postcss@8.5.14)
+      postcss-discard-overridden: 7.0.2(postcss@8.5.14)
+      postcss-merge-longhand: 7.0.6(postcss@8.5.14)
+      postcss-merge-rules: 7.0.10(postcss@8.5.14)
+      postcss-minify-font-values: 7.0.2(postcss@8.5.14)
+      postcss-minify-gradients: 7.0.4(postcss@8.5.14)
+      postcss-minify-params: 7.0.8(postcss@8.5.14)
+      postcss-minify-selectors: 7.1.0(postcss@8.5.14)
+      postcss-normalize-charset: 7.0.2(postcss@8.5.14)
+      postcss-normalize-display-values: 7.0.2(postcss@8.5.14)
+      postcss-normalize-positions: 7.0.3(postcss@8.5.14)
+      postcss-normalize-repeat-style: 7.0.3(postcss@8.5.14)
+      postcss-normalize-string: 7.0.2(postcss@8.5.14)
+      postcss-normalize-timing-functions: 7.0.2(postcss@8.5.14)
+      postcss-normalize-unicode: 7.0.8(postcss@8.5.14)
+      postcss-normalize-url: 7.0.2(postcss@8.5.14)
+      postcss-normalize-whitespace: 7.0.2(postcss@8.5.14)
+      postcss-ordered-values: 7.0.3(postcss@8.5.14)
+      postcss-reduce-initial: 7.0.8(postcss@8.5.14)
+      postcss-reduce-transforms: 7.0.2(postcss@8.5.14)
+      postcss-svgo: 7.1.2(postcss@8.5.14)
+      postcss-unique-selectors: 7.0.6(postcss@8.5.14)
 
-  cssnano-utils@5.0.2(postcss@8.5.10):
+  cssnano-utils@5.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
 
-  cssnano@7.1.7(postcss@8.5.10):
+  cssnano@7.1.7(postcss@8.5.14):
     dependencies:
-      cssnano-preset-default: 7.0.15(postcss@8.5.10)
+      cssnano-preset-default: 7.0.15(postcss@8.5.14)
       lilconfig: 3.1.3
-      postcss: 8.5.10
+      postcss: 8.5.14
 
   csso@5.0.5:
     dependencies:
@@ -12216,11 +12216,11 @@ snapshots:
     dependencies:
       node-source-walk: 7.0.1
 
-  detective-postcss@7.0.1(postcss@8.5.10):
+  detective-postcss@7.0.1(postcss@8.5.14):
     dependencies:
       is-url: 1.2.4
-      postcss: 8.5.10
-      postcss-values-parser: 6.0.2(postcss@8.5.10)
+      postcss: 8.5.14
+      postcss-values-parser: 6.0.2(postcss@8.5.14)
 
   detective-sass@6.0.1:
     dependencies:
@@ -12659,8 +12659,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 9.39.4(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -14523,21 +14523,21 @@ snapshots:
     dependencies:
       postcss-value-parser: 3.3.1
 
-  postcss-calc@10.1.1(postcss@8.5.10):
+  postcss-calc@10.1.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0):
+  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.4
       picocolors: 1.1.1
-      postcss: 8.5.10
-      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)
-      postcss-reporter: 7.1.0(postcss@8.5.10)
+      postcss: 8.5.14
+      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)
+      postcss-reporter: 7.1.0(postcss@8.5.14)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.1.0
@@ -14547,187 +14547,187 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-colormin@7.0.9(postcss@8.5.10):
+  postcss-colormin@7.0.9(postcss@8.5.14):
     dependencies:
       '@colordx/core': 5.2.0
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@7.0.11(postcss@8.5.10):
+  postcss-convert-values@7.0.11(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@7.0.7(postcss@8.5.10):
+  postcss-discard-comments@7.0.7(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-discard-duplicates@7.0.3(postcss@8.5.10):
+  postcss-discard-duplicates@7.0.3(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
 
-  postcss-discard-empty@7.0.2(postcss@8.5.10):
+  postcss-discard-empty@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
 
-  postcss-discard-overridden@7.0.2(postcss@8.5.10):
+  postcss-discard-overridden@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
 
-  postcss-easy-import@4.0.0(postcss@8.5.10):
+  postcss-easy-import@4.0.0(postcss@8.5.14):
     dependencies:
       globby: 6.1.0
       is-glob: 4.0.3
       lodash: 4.18.1
       object-assign: 4.1.1
       pify: 3.0.0
-      postcss: 8.5.10
-      postcss-import: 14.1.0(postcss@8.5.10)
+      postcss: 8.5.14
+      postcss-import: 14.1.0(postcss@8.5.14)
       resolve: 1.22.12
 
-  postcss-import@14.1.0(postcss@8.5.10):
+  postcss-import@14.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0):
+  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.10
+      postcss: 8.5.14
       tsx: 4.21.0
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.10
+      postcss: 8.5.14
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss-merge-longhand@7.0.6(postcss@8.5.10):
+  postcss-merge-longhand@7.0.6(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
-      stylehacks: 7.0.10(postcss@8.5.10)
+      stylehacks: 7.0.10(postcss@8.5.14)
 
-  postcss-merge-rules@7.0.10(postcss@8.5.10):
+  postcss-merge-rules@7.0.10(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      cssnano-utils: 5.0.2(postcss@8.5.10)
-      postcss: 8.5.10
+      cssnano-utils: 5.0.2(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-minify-font-values@7.0.2(postcss@8.5.10):
+  postcss-minify-font-values@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@7.0.4(postcss@8.5.10):
+  postcss-minify-gradients@7.0.4(postcss@8.5.14):
     dependencies:
       '@colordx/core': 5.2.0
-      cssnano-utils: 5.0.2(postcss@8.5.10)
-      postcss: 8.5.10
+      cssnano-utils: 5.0.2(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@7.0.8(postcss@8.5.10):
+  postcss-minify-params@7.0.8(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 5.0.2(postcss@8.5.10)
-      postcss: 8.5.10
+      cssnano-utils: 5.0.2(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@7.1.0(postcss@8.5.10):
+  postcss-minify-selectors@7.1.0(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
       cssesc: 3.0.0
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-nesting@14.0.0(postcss@8.5.10):
+  postcss-nesting@14.0.0(postcss@8.5.14):
     dependencies:
       '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
       '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-normalize-charset@7.0.2(postcss@8.5.10):
+  postcss-normalize-charset@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
 
-  postcss-normalize-display-values@7.0.2(postcss@8.5.10):
+  postcss-normalize-display-values@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@7.0.3(postcss@8.5.10):
+  postcss-normalize-positions@7.0.3(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@7.0.3(postcss@8.5.10):
+  postcss-normalize-repeat-style@7.0.3(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@7.0.2(postcss@8.5.10):
+  postcss-normalize-string@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@7.0.2(postcss@8.5.10):
+  postcss-normalize-timing-functions@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@7.0.8(postcss@8.5.10):
+  postcss-normalize-unicode@7.0.8(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@7.0.2(postcss@8.5.10):
+  postcss-normalize-url@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@7.0.2(postcss@8.5.10):
+  postcss-normalize-whitespace@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@7.0.3(postcss@8.5.10):
+  postcss-ordered-values@7.0.3(postcss@8.5.14):
     dependencies:
-      cssnano-utils: 5.0.2(postcss@8.5.10)
-      postcss: 8.5.10
+      cssnano-utils: 5.0.2(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@7.0.8(postcss@8.5.10):
+  postcss-reduce-initial@7.0.8(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.10
+      postcss: 8.5.14
 
-  postcss-reduce-transforms@7.0.2(postcss@8.5.10):
+  postcss-reduce-transforms@7.0.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-reporter@7.1.0(postcss@8.5.10):
+  postcss-reporter@7.1.0(postcss@8.5.14):
     dependencies:
       picocolors: 1.1.1
-      postcss: 8.5.10
+      postcss: 8.5.14
       thenby: 1.4.1
 
   postcss-selector-parser@7.1.1:
@@ -14735,26 +14735,26 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@7.1.2(postcss@8.5.10):
+  postcss-svgo@7.1.2(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       svgo: 4.0.1
 
-  postcss-unique-selectors@7.0.6(postcss@8.5.10):
+  postcss-unique-selectors@7.0.6(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-value-parser@3.3.1: {}
 
   postcss-value-parser@4.2.0: {}
 
-  postcss-values-parser@6.0.2(postcss@8.5.10):
+  postcss-values-parser@6.0.2(postcss@8.5.14):
     dependencies:
       color-name: 1.1.4
       is-url-superb: 4.0.0
-      postcss: 8.5.10
+      postcss: 8.5.14
       quote-unquote: 1.0.0
 
   postcss@8.4.31:
@@ -14763,7 +14763,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.10:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -14776,7 +14776,7 @@ snapshots:
       detective-amd: 6.0.2
       detective-cjs: 6.1.1
       detective-es6: 5.0.2
-      detective-postcss: 7.0.1(postcss@8.5.10)
+      detective-postcss: 7.0.1(postcss@8.5.14)
       detective-sass: 6.0.1
       detective-scss: 5.0.1
       detective-stylus: 5.0.1
@@ -14784,7 +14784,7 @@ snapshots:
       detective-vue2: 2.3.0(typescript@5.9.3)
       module-definition: 6.0.2
       node-source-walk: 7.0.1
-      postcss: 8.5.10
+      postcss: 8.5.14
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -15540,10 +15540,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
-  stylehacks@7.0.10(postcss@8.5.10):
+  stylehacks@7.0.10(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   stylus-lookup@6.1.1:
@@ -16074,7 +16074,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.14
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -16263,14 +16263,14 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod-validation-error@5.0.0(zod@4.3.6):
+  zod-validation-error@5.0.0(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -215,5 +215,3 @@ trustPolicyExclude:
   # due to being a dependency of @nx/js
   - invokers-polyfill@0.6.1
   - detect-port@1.6.1
-
-verifyDepsBeforeRun: prompt

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,11 +22,11 @@ catalog:
   '@commitlint/cli': ^20.5.0
   '@commitlint/config-conventional': ^20.5.0
   '@commitlint/types': ^20.5.0
-  '@digdir/designsystemet': 1.13.3
-  '@digdir/designsystemet-css': 1.13.3
-  '@digdir/designsystemet-react': 1.13.3
-  '@digdir/designsystemet-types': 1.13.3
-  '@digdir/designsystemet-web': 1.13.3
+  '@digdir/designsystemet': 1.14.0
+  '@digdir/designsystemet-css': 1.14.0
+  '@digdir/designsystemet-react': 1.14.0
+  '@digdir/designsystemet-types': 1.14.0
+  '@digdir/designsystemet-web': 1.14.0
   '@eslint/compat': ^2.0.5
   '@eslint/eslintrc': ^3.3.5
   '@eslint/js': ^9.39.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -202,6 +202,9 @@ packageExtensions:
 patchedDependencies:
   remark-heading-id@1.0.1: patches/remark-heading-id@1.0.1.patch
 
+syncInjectedDepsAfterScripts:
+  - inject
+
 trustPolicy: no-downgrade
 
 trustPolicyExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -202,9 +202,6 @@ packageExtensions:
 patchedDependencies:
   remark-heading-id@1.0.1: patches/remark-heading-id@1.0.1.patch
 
-syncInjectedDepsAfterScripts:
-  - build
-
 trustPolicy: no-downgrade
 
 trustPolicyExclude:


### PR DESCRIPTION
Oppgraderer til versjon 1.4.0 av Designsystemet og legger til dokumentasjon for outline-variant av Checkbox, Radio og Switch.

OBS: Inneheld også kode som midlertidig fikser logikken i `useCheckboxGroup` og `useRadioGroup` i påvente av at [denne PRen](https://github.com/digdir/designsystemet/pull/4864) blir tatt inn i Designsystemet.