### PR TITLE
Fix/prose selectors

### DIFF
--- a/@udir-design/react/demo-pages/article-demo/ArticleDemo.tsx
+++ b/@udir-design/react/demo-pages/article-demo/ArticleDemo.tsx
@@ -71,12 +71,11 @@ export const ArticleDemo = () => {
         ref={containerRef}
       >
         <Prose>
+          <Heading data-size="lg" level={1}>
+            Tilpasset opplæring
+          </Heading>
+          <ContentSection section={sectionHeader} />
           <div className={classes.headingWrapper}>
-            <Heading data-size="lg" level={1}>
-              Tilpasset opplæring
-            </Heading>
-            <ContentSection section={sectionHeader} />
-
             <Divider style={{ margin: 'var(--ds-size-4) 0' }} />
             <div className={classes.dividerWrapper}>
               <Paragraph data-size="sm">

--- a/@udir-design/react/src/components/typography/prose/Prose.stories.tsx
+++ b/@udir-design/react/src/components/typography/prose/Prose.stories.tsx
@@ -1,8 +1,12 @@
+import { MultiplyIcon } from '@udir-design/icons';
 import preview from '.storybook/preview';
 import { Alert } from 'src/components/alert';
+import { Button } from 'src/components/button/Button';
 import { Details } from 'src/components/details/Details';
+import { Dialog } from 'src/components/dialog/Dialog';
 import { Divider } from 'src/components/divider/Divider';
 import { List } from 'src/components/list/List';
+import { Popover } from 'src/components/popover/Popover';
 import { Table } from 'src/components/table';
 import { TableOfContents } from 'src/components/tableOfContents/TableOfContents';
 import { useTableOfContents } from 'src/utilities/hooks/useTableOfContents/useTableOfContents';
@@ -280,6 +284,71 @@ export const Headings = meta.story({
           </Paragraph>
         </Prose>
       </div>
+    );
+  },
+});
+
+export const WithDialog = meta.story({
+  render: () => {
+    return (
+      <Prose style={{ maxWidth: '50rem' }}>
+        <Dialog.TriggerContext>
+          <Dialog.Trigger>Åpne Dialog</Dialog.Trigger>
+          <Dialog
+            closedby="any"
+            style={{
+              zIndex: 10,
+            }}
+            open
+          >
+            <Heading
+              style={{
+                marginBottom: 'var(--ds-size-2)',
+              }}
+            >
+              Dialog header
+            </Heading>
+            <Paragraph
+              style={{
+                marginBottom: 'var(--ds-size-2)',
+              }}
+            >
+              Lorem ipsum dolor sit, amet consectetur adipisicing elit.
+              Blanditiis doloremque obcaecati assumenda odio ducimus sunt et.
+            </Paragraph>
+            <Paragraph data-size="sm">Dialog footer</Paragraph>
+          </Dialog>
+        </Dialog.TriggerContext>
+      </Prose>
+    );
+  },
+});
+
+export const WithPopover = meta.story({
+  render: () => {
+    return (
+      <Prose style={{ maxWidth: '50rem' }}>
+        <Popover.TriggerContext>
+          <Popover.Trigger variant="tertiary">
+            Fjern <MultiplyIcon aria-hidden />
+          </Popover.Trigger>
+          <Popover open>
+            Er du sikker på at du vil fjerne raden? Handlingen kan ikke angres.
+            <div
+              style={{
+                display: 'flex',
+                gap: 'var(--ds-size-2)',
+                marginTop: 'var(--ds-size-2)',
+              }}
+            >
+              <Button data-size="sm">Ja, fjern</Button>
+              <Button data-size="sm" variant="tertiary">
+                Avbryt
+              </Button>
+            </div>
+          </Popover>
+        </Popover.TriggerContext>
+      </Prose>
     );
   },
 });

--- a/@udir-design/react/src/components/typography/prose/__snapshots__/Prose.stories.tsx.snap
+++ b/@udir-design/react/src/components/typography/prose/__snapshots__/Prose.stories.tsx.snap
@@ -358,3 +358,103 @@ exports[`Preview 1`] = `
   </div>
 </div>
 `;
+
+exports[`With Dialog 1`] = `
+<div style="<removed>">
+  <button
+    data-variant="primary"
+    type="button"
+    aria-haspopup="dialog"
+  >
+    Åpne Dialog
+  </button>
+  <dialog
+    data-placement="center"
+    data-modal="true"
+    id="<removed>"
+    closedby="any"
+    open
+    style="<removed>"
+  >
+    <button
+      data-icon="true"
+      commandfor="_r_6_"
+      data-variant="tertiary"
+      type="button"
+      aria-label="Lukk dialogvindu"
+      data-color="neutral"
+      command="close"
+    >
+    </button>
+    <h2 style="<removed>">
+      Dialog header
+    </h2>
+    <p
+      data-variant="default"
+      style="<removed>"
+    >
+      Lorem ipsum dolor sit, amet consectetur adipisicing elit. Blanditiis doloremque obcaecati assumenda odio ducimus sunt et.
+    </p>
+    <p
+      data-variant="default"
+      data-size="sm"
+    >
+      Dialog footer
+    </p>
+  </dialog>
+</div>
+`;
+
+exports[`With Popover 1`] = `
+<div style="<removed>">
+  <button
+    data-variant="tertiary"
+    type="button"
+    popovertarget="_r_7_"
+  >
+    Fjern
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="1em"
+      height="1em"
+      fill="none"
+      viewbox="0 0 24 24"
+      focusable="false"
+      role="img"
+      aria-hidden="true"
+    >
+      <path
+        fill="currentColor"
+        d="M18.03 7.03a.75.75 0 0 0-1.06-1.06L12 10.94 7.03 5.97a.75.75 0 0 0-1.06 1.06L10.94 12l-4.97 4.97a.75.75 0 1 0 1.06 1.06L12 13.06l4.97 4.97a.75.75 0 1 0 1.06-1.06L13.06 12z"
+      >
+      </path>
+    </svg>
+  </button>
+  <div
+    id="<removed>"
+    popover="manual"
+    data-placement="top"
+    data-variant="default"
+    data-floating="bottom"
+    style="<removed>"
+  >
+    Er du sikker på at du vil fjerne raden? Handlingen kan ikke angres.
+    <div style="<removed>">
+      <button
+        data-variant="primary"
+        type="button"
+        data-size="sm"
+      >
+        Ja, fjern
+      </button>
+      <button
+        data-variant="tertiary"
+        type="button"
+        data-size="sm"
+      >
+        Avbryt
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/@udir-design/react/src/components/typography/prose/prose.css
+++ b/@udir-design/react/src/components/typography/prose/prose.css
@@ -9,31 +9,31 @@
     margin-block-end: var(--ds-size-4);
     margin-block-start: var(--ds-size-8);
 
-    &[data-size='2xl'] {
+    &:where([data-size='2xl']) {
       margin-block-start: var(--ds-size-12);
     }
 
-    &[data-size='xl'] {
+    &:where([data-size='xl']) {
       margin-block-start: var(--ds-size-11);
     }
 
-    &[data-size='lg'] {
+    &:where([data-size='lg']) {
       margin-block-start: var(--ds-size-10);
     }
 
-    &[data-size='md'] {
+    &:where([data-size='md']) {
       margin-block-start: var(--ds-size-9);
     }
 
-    &[data-size='sm'] {
+    &:where([data-size='sm']) {
       margin-block-start: var(--ds-size-8);
     }
 
-    &[data-size='xs'] {
+    &:where([data-size='xs']) {
       margin-block-start: var(--ds-size-7);
     }
 
-    &[data-size='2xs'] {
+    &:where([data-size='2xs']) {
       margin-block-start: var(--ds-size-6);
     }
   }

--- a/@udir-design/react/src/components/typography/prose/prose.css
+++ b/@udir-design/react/src/components/typography/prose/prose.css
@@ -3,8 +3,10 @@
     margin-block-end: var(--ds-size-5);
   }
 
-  & .ds-heading {
+  > .ds-heading,
+  > section > .ds-heading {
     margin-block-end: var(--ds-size-4);
+    margin-block-start: var(--ds-size-8);
 
     &[data-size='2xl'] {
       margin-block-start: var(--ds-size-12);
@@ -33,9 +35,9 @@
     &[data-size='2xs'] {
       margin-block-start: var(--ds-size-6);
     }
-
-    &:first-child {
+  }
+  > .ds-heading:first-child,
+  section:first-child > .ds-heading:first-child {
       margin-block-start: 0;
-    }
   }
 }

--- a/@udir-design/react/src/components/typography/prose/prose.css
+++ b/@udir-design/react/src/components/typography/prose/prose.css
@@ -1,5 +1,6 @@
 .uds-prose {
-  & > * {
+  > *:not(.ds-dialog),
+  section > *:not(.ds-dialog) {
     margin-block-end: var(--ds-size-5);
   }
 
@@ -38,6 +39,6 @@
   }
   > .ds-heading:first-child,
   section:first-child > .ds-heading:first-child {
-      margin-block-start: 0;
+    margin-block-start: 0;
   }
 }

--- a/@udir-design/react/src/demo/__snapshots__/ArticleDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/ArticleDemo.stories.tsx.snap
@@ -125,13 +125,13 @@ exports[`Article Story 1`] = `
         tabindex="-1"
       >
         <div>
+          <h1 data-size="lg">
+            Tilpasset opplæring
+          </h1>
+          <p data-variant="default">
+            Skolen skal tilpasse opplæringen for alle elever, lærlinger, lærekandidater og voksne. Tilpasset opplæring innebærer at elevene skal få et tilfredsstillende utbytte av opplæringen uavhengig av forutsetninger, og at alle skal få utnyttet og utviklet evnene sine.
+          </p>
           <div>
-            <h1 data-size="lg">
-              Tilpasset opplæring
-            </h1>
-            <p data-variant="default">
-              Skolen skal tilpasse opplæringen for alle elever, lærlinger, lærekandidater og voksne. Tilpasset opplæring innebærer at elevene skal få et tilfredsstillende utbytte av opplæringen uavhengig av forutsetninger, og at alle skal få utnyttet og utviklet evnene sine.
-            </p>
             <hr
               aria-hidden="true"
               style="<removed>"


### PR DESCRIPTION
- Scope spacing rules to direct children only
> Prose spacing selectors are now scoped to direct children
and `> section` children instead of matching all descendants.
Consumers relying on deeply nested elements
inheriting prose spacing will need to restructure their markup.
- Exclude Dialog elements from margin rules