### PR TITLE
chore: remove redundant stable import

### DIFF
--- a/@udir-design/react/src/alpha.ts
+++ b/@udir-design/react/src/alpha.ts
@@ -2,7 +2,6 @@
  * This is the entry point for the /alpha sub-module.
  * It exports the alpha-stage components, plus everything in beta (& stable).
  */
-export * from './stable';
 export * from './beta';
 export * from './components/alpha';
 export * from './utilities/hooks/alpha';


### PR DESCRIPTION
## Hva er gjort?

Fjernet overflødig import av stable i beta, siden denne allerede kommer via beta-importen.

## Sjekkliste

- [X] Commitmeldingene gir mening i kontekst av changelog