### PR TITLE
fix(useCheckboxGroup, useRadioGroup): be more strict about which shared props to pass through

### DIFF
--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
@@ -3,15 +3,9 @@ import {
   useCheckboxGroup as useCheckboxGroupDigdir,
 } from '@digdir/designsystemet-react';
 import type { CheckboxProps } from '../../../components/checkbox/Checkbox';
-import type { MergeRight } from '../../type-utils';
 
-type UseCheckboxGroupProps = MergeRight<
-  Omit<
-    CheckboxProps,
-    'aria-label' | 'aria-labelledby' | 'data-size' | 'data-indeterminate'
-  >,
-  UseCheckboxGroupPropsDigdir
->;
+type UseCheckboxGroupProps = UseCheckboxGroupPropsDigdir &
+  Pick<CheckboxProps, 'variant'>;
 
 type UseCheckboxGroupReturn = ReturnType<typeof useCheckboxGroupDigdir>;
 const useCheckboxGroup = (

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
@@ -3,12 +3,9 @@ import {
   useRadioGroup as useRadioGroupDigdir,
 } from '@digdir/designsystemet-react';
 import type { RadioProps } from '../../../components/radio/Radio';
-import type { MergeRight } from '../../type-utils';
 
-type UseRadioGroupProps = MergeRight<
-  Omit<RadioProps, 'aria-label' | 'aria-labelledby' | 'data-size'>,
-  UseRadioGroupPropsDigdir
->;
+type UseRadioGroupProps = UseRadioGroupPropsDigdir &
+  Pick<RadioProps, 'variant'>;
 
 type UseRadioGroupReturn = ReturnType<typeof useRadioGroupDigdir>;
 const useRadioGroup = (props?: UseRadioGroupProps): UseRadioGroupReturn => {

--- a/@udir-design/react/src/utilities/type-utils.ts
+++ b/@udir-design/react/src/utilities/type-utils.ts
@@ -1,5 +1,0 @@
-/**
- * Create a new type with the properties of the first type merged with the properties of the second type.
- * If a key exists in both types, the property from the *second* type will be used.
- */
-export type MergeRight<T1, T2> = Omit<T1, keyof T2> & T2;


### PR DESCRIPTION
Some props would clearly be a mistake to share, e.g. `id`. To reduce the chance of misuse, we only allow a few useful shared props, like `variant`.

NOTE: Denne fikser noko som ikkje enno har blitt publisert, men eg beheld den som "fix" slik at det dukker opp i endringsloggen. Dette fordi vi faktisk må endre teksten i endringsloggen til det denne fikser, sidan det som står der ikkje stemmer lenger 🙃 