### PR TITLE
 docs: remove need for setting specific args in preview story to get a nice args table

### DIFF
--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import addonA11y from '@storybook/addon-a11y';
 import addonDocs from '@storybook/addon-docs';
 import { definePreview } from '@storybook/react-vite';
 import * as R from 'ramda';
-import { type PreviewAddon } from 'storybook/internal/csf';
+import type { PreviewAddon } from 'storybook/internal/csf';
 import { INITIAL_VIEWPORTS, type ViewportMap } from 'storybook/viewport';
 import storybookAddonPseudoStates from 'storybook-addon-pseudo-states';
 import * as icons from '@udir-design/icons';
@@ -16,6 +16,7 @@ import type {
   ComponentOriginParameters,
   CustomStylesParameters,
 } from './types';
+import { argTypesEnhancer } from './utils/argTypesEnhancer';
 import { CustomStylesDecorator } from './utils/customStylesDecorator';
 
 // Fix icons being displayed as React.ForwardRef in Storybook code examples
@@ -42,6 +43,8 @@ const chromaticViewports = {
 
 export default definePreview({
   tags: ['a11y-test'],
+
+  argTypesEnhancers: [argTypesEnhancer],
 
   parameters: {
     options: {

--- a/@udir-design/react/.storybook/utils/argTypesEnhancer.ts
+++ b/@udir-design/react/.storybook/utils/argTypesEnhancer.ts
@@ -1,0 +1,68 @@
+import * as R from 'ramda';
+import type {
+  StoryContextForEnhancers,
+  StrictInputType,
+} from 'storybook/internal/types';
+
+/** Fix various issues with arg types in the documentation */
+export function argTypesEnhancer({ argTypes }: StoryContextForEnhancers) {
+  return R.map((x): StrictInputType => {
+    if (x.control === false) {
+      return x;
+    }
+
+    if (x.type?.name === 'other') {
+      if (x.type.value === 'ReactNode') {
+        // Fix issues when trying to edit prop of type ReactNode in args table, as {}
+        // (the default value when `control === 'object'`) sometimes makes stories crash.
+        return withControlType(x, 'text');
+      } else if (x.type.value === 'string | number') {
+        // Text control is better than object for `string | number`
+        return withControlType(x, 'text');
+      } else if (x.type.value === 'Booleanish') {
+        // Set "Booleanish" args (`boolean | "true" | "false"`) to just use a boolean toggle
+        return withControlType(x, 'boolean');
+      } else if (
+        x.type.value.includes('EventHandler') ||
+        x.type.value.includes(' => ')
+      ) {
+        // Make event handlers and other functions non-editable
+        return {
+          ...x,
+          control: { disable: true },
+        };
+      }
+    }
+    return x;
+  }, argTypes);
+}
+
+type ControlType =
+  | 'number'
+  | 'boolean'
+  | 'object'
+  | 'check'
+  | 'inline-check'
+  | 'radio'
+  | 'inline-radio'
+  | 'select'
+  | 'multi-select'
+  | 'range'
+  | 'file'
+  | 'color'
+  | 'date'
+  | 'text';
+
+function withControlType(
+  inputType: StrictInputType,
+  controlType: ControlType,
+): StrictInputType {
+  return {
+    ...inputType,
+    control: {
+      type: controlType,
+      disable:
+        typeof inputType.control === 'object' && inputType.control.disable,
+    },
+  };
+}

--- a/@udir-design/react/.storybook/utils/customStylesDecorator.tsx
+++ b/@udir-design/react/.storybook/utils/customStylesDecorator.tsx
@@ -56,8 +56,6 @@ export const CustomStylesDecorator: Decorator = (Story, ctx) => {
       ctx.canvasElement.querySelectorAll('[data-storybook-decorator]'),
     ).at(-1);
     if (innerDecorator) {
-      console.log('Found inner decorator');
-      console.log(innerDecorator);
       const existingStyle = innerDecorator.getAttribute('style') ?? '';
       innerDecorator.setAttribute(
         'style',

--- a/@udir-design/react/src/components/avatar/Avatar.stories.tsx
+++ b/@udir-design/react/src/components/avatar/Avatar.stories.tsx
@@ -34,7 +34,6 @@ const profileImage =
 export const Preview = meta.story({
   args: {
     'aria-label': 'Ola Nordmann',
-    children: '',
   },
 });
 

--- a/@udir-design/react/src/components/button/Button.stories.tsx
+++ b/@udir-design/react/src/components/button/Button.stories.tsx
@@ -38,9 +38,7 @@ const meta = preview.meta({
 
 export const Preview = meta.story({
   args: {
-    disabled: false,
     variant: 'primary',
-    icon: false,
     onClick: fn(),
     children: 'Knapp',
   },

--- a/@udir-design/react/src/components/button/Button.tsx
+++ b/@udir-design/react/src/components/button/Button.tsx
@@ -5,11 +5,21 @@ import {
 import type {
   ComponentRef,
   ForwardRefExoticComponent,
+  ReactNode,
   RefAttributes,
 } from 'react';
 import './button.css';
 
 type ButtonProps = Omit<DigdirButtonProps, 'data-color'> & {
+  onClick?: DigdirButtonProps['onClick'];
+  /**
+   * The content of the button
+   */
+  children?: ReactNode;
+  /**
+   * Disable the button. Usually not recommended.
+   */
+  disabled?: DigdirButtonProps['disabled'];
   /**
    * Change the color scheme of the button
    */

--- a/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.stories.tsx
@@ -13,15 +13,15 @@ const meta = preview.meta({
       details: 'Vi har fjernet mulighet for fargevalg.',
     },
   },
+  argTypes: {
+    onChange: { table: { disable: true } },
+  },
 });
 
 export const Preview = meta.story({
   args: {
     label: 'Checkbox label',
     description: 'Description',
-    disabled: false,
-    readOnly: false,
-    value: 'value',
     onChange: fn(),
     id: 'checkbox-preview',
   },
@@ -123,8 +123,6 @@ export const Focused = meta.story({
   args: {
     label: 'Checkbox label',
     description: 'Description',
-    disabled: false,
-    readOnly: false,
     value: 'value',
     onChange: fn(),
     id: 'checkbox-preview',

--- a/@udir-design/react/src/components/checkbox/Checkbox.tsx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.tsx
@@ -8,7 +8,12 @@ import type {
   RefAttributes,
 } from 'react';
 
-type CheckboxProps = Omit<DigdirCheckboxProps, 'data-color'>;
+type CheckboxProps = Omit<DigdirCheckboxProps, 'data-color' | 'value'> & {
+  /**
+   * Value of the `input` element
+   */
+  value?: string | number; // original type is `string | number | readonly string[]`
+};
 
 const Checkbox = DigdirCheckbox as ForwardRefExoticComponent<
   CheckboxProps & RefAttributes<ComponentRef<typeof DigdirCheckbox>>

--- a/@udir-design/react/src/components/checkbox/__snapshots__/Checkbox.stories.tsx.snap
+++ b/@udir-design/react/src/components/checkbox/__snapshots__/Checkbox.stories.tsx.snap
@@ -89,7 +89,6 @@ exports[`Outline 1`] = `
   <input
     id="<removed>"
     type="checkbox"
-    value="value"
     aria-describedby="<removed>"
   >
   <label
@@ -112,7 +111,6 @@ exports[`Preview 1`] = `
   <input
     id="<removed>"
     type="checkbox"
-    value="value"
     aria-describedby="<removed>"
   >
   <label

--- a/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
+++ b/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
@@ -100,8 +100,8 @@ exports[`Dialog Non Modal 1`] = `
   data-placement="center"
   data-modal="false"
   id="<removed>"
-  style="<removed>"
   open
+  style="<removed>"
 >
   <button
     data-icon="true"
@@ -213,8 +213,8 @@ exports[`Dialog With Max Width 1`] = `
   data-placement="center"
   data-modal="true"
   id="<removed>"
-  style="<removed>"
   open
+  style="<removed>"
 >
   <button
     data-icon="true"
@@ -295,8 +295,8 @@ exports[`Dialog With Suggestion 1`] = `
   data-placement="center"
   data-modal="true"
   id="<removed>"
-  style="<removed>"
   open
+  style="<removed>"
 >
   <button
     data-icon="true"
@@ -566,8 +566,8 @@ exports[`Drawer 1`] = `
     data-modal="true"
     id="<removed>"
     closedby="any"
-    style="<removed>"
     open
+    style="<removed>"
   >
     <button
       data-icon="true"
@@ -605,8 +605,8 @@ exports[`Preview 1`] = `
     data-modal="true"
     id="<removed>"
     closedby="any"
-    style="<removed>"
     open
+    style="<removed>"
   >
     <button
       data-icon="true"

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -32,7 +32,7 @@ export const Preview = meta.story({
       <Field.Description>
         E-posten din brukes til å logge inn og motta varsler
       </Field.Description>
-      <Input id="preview" defaultValue="ola nordmann@udir.no" aria-invalid />
+      <Input id="preview" defaultValue="ola nordmann@udir.no" />
       <ValidationMessage>Du må oppgi en gyldig e-postadresse</ValidationMessage>
     </Field>
   ),

--- a/@udir-design/react/src/components/field/__snapshots__/Field.stories.tsx.snap
+++ b/@udir-design/react/src/components/field/__snapshots__/Field.stories.tsx.snap
@@ -121,10 +121,10 @@ exports[`Preview 1`] = `
   </div>
   <input
     id="<removed>"
-    aria-invalid="true"
     type="text"
     value="ola nordmann@udir.no"
     aria-describedby="<removed>"
+    aria-invalid="true"
   >
   <p
     data-field="validation"

--- a/@udir-design/react/src/components/input/Input.stories.tsx
+++ b/@udir-design/react/src/components/input/Input.stories.tsx
@@ -21,6 +21,9 @@ const meta = preview.meta({
       options: ['checkbox', 'switch'],
       if: { arg: 'type', eq: 'checkbox' },
     },
+    'aria-invalid': {
+      control: 'boolean',
+    },
   },
   parameters: {
     componentOrigin: {
@@ -33,9 +36,6 @@ const meta = preview.meta({
 
 export const Preview = meta.story({
   args: {
-    'aria-invalid': false,
-    disabled: false,
-    readOnly: false,
     type: 'text',
     name: 'inputs',
     'aria-label': 'input',
@@ -189,7 +189,7 @@ export const Text = meta.story({
     const states = [
       { label: 'Default', props: {} },
       { label: 'Disabled', props: { disabled: true } },
-      { label: 'Invalid', props: { 'aria-invalid': true } },
+      { label: 'Invalid', props: {} },
       { label: 'Read-only', props: { readOnly: true } },
     ];
 

--- a/@udir-design/react/src/components/input/Input.tsx
+++ b/@udir-design/react/src/components/input/Input.tsx
@@ -9,7 +9,10 @@ import type {
 } from 'react';
 import './input.css';
 
-type InputProps = Omit<DigdirInputProps, 'data-color'>;
+type InputProps = Omit<DigdirInputProps, 'data-color'> & {
+  'aria-invalid'?: DigdirInputProps['aria-invalid'];
+  'aria-label'?: DigdirInputProps['aria-label'];
+};
 
 const Input = DigdirInput as ForwardRefExoticComponent<
   InputProps & RefAttributes<ComponentRef<typeof DigdirInput>>

--- a/@udir-design/react/src/components/input/__snapshots__/Input.stories.tsx.snap
+++ b/@udir-design/react/src/components/input/__snapshots__/Input.stories.tsx.snap
@@ -639,7 +639,6 @@ exports[`Input Types 1`] = `
 
 exports[`Preview 1`] = `
 <input
-  aria-invalid="false"
   aria-label="input"
   type="text"
   name="inputs"
@@ -1388,13 +1387,13 @@ exports[`Text 1`] = `
         Invalid
       </label>
       <input
-        aria-invalid="true"
         data-size="sm"
         type="text"
         value="Value"
         name="sm-invalid"
         id="<removed>"
         aria-describedby="<removed>"
+        aria-invalid="true"
       >
       <p
         data-field="validation"
@@ -1469,13 +1468,13 @@ exports[`Text 1`] = `
         Invalid
       </label>
       <input
-        aria-invalid="true"
         data-size="md"
         type="text"
         value="Value"
         name="md-invalid"
         id="<removed>"
         aria-describedby="<removed>"
+        aria-invalid="true"
       >
       <p
         data-field="validation"
@@ -1550,13 +1549,13 @@ exports[`Text 1`] = `
         Invalid
       </label>
       <input
-        aria-invalid="true"
         data-size="lg"
         type="text"
         value="Value"
         name="lg-invalid"
         id="<removed>"
         aria-describedby="<removed>"
+        aria-invalid="true"
       >
       <p
         data-field="validation"

--- a/@udir-design/react/src/components/radio/Radio.stories.tsx
+++ b/@udir-design/react/src/components/radio/Radio.stories.tsx
@@ -13,14 +13,16 @@ const meta = preview.meta({
       details: 'Vi har fjernet mulighet for fargevalg.',
     },
   },
+  argTypes: {
+    onChange: { table: { disable: true } },
+    onClick: { table: { disable: true } },
+  },
 });
 
 export const Preview = meta.story({
   args: {
     label: 'Radio',
     description: 'Description',
-    disabled: false,
-    readOnly: false,
     value: 'value',
     onChange: fn(),
     onClick: fn(),
@@ -109,8 +111,6 @@ export const Focused = meta.story({
   args: {
     label: 'Radio',
     description: 'Description',
-    disabled: false,
-    readOnly: false,
     value: 'value',
     onChange: fn(),
     onClick: fn(),

--- a/@udir-design/react/src/components/radio/Radio.tsx
+++ b/@udir-design/react/src/components/radio/Radio.tsx
@@ -8,7 +8,15 @@ import type {
   RefAttributes,
 } from 'react';
 
-type RadioProps = Omit<DigdirRadioProps, 'data-color' | 'data-indeterminate'>;
+type RadioProps = Omit<
+  DigdirRadioProps,
+  'data-color' | 'data-indeterminate' | 'value'
+> & {
+  /**
+   * Value of the `input` element
+   */
+  value?: string | number; // original type is `string | number | readonly string[]`
+};
 
 const Radio = DigdirRadio as ForwardRefExoticComponent<
   RadioProps & RefAttributes<ComponentRef<typeof DigdirRadio>>

--- a/@udir-design/react/src/components/select/Select.mdx
+++ b/@udir-design/react/src/components/select/Select.mdx
@@ -43,7 +43,7 @@ import { Select, Field } from '@udir-design/react';
 
 ### Vise feilmelding
 
-Bruk `aria-invalid` på `Select` og `ValidationMessage` for å vise feilmeldinger.
+Bruk `ValidationMessage` for å vise feilmeldinger.
 
 <Canvas of={SelectStories.WithError} />
 

--- a/@udir-design/react/src/components/select/Select.stories.tsx
+++ b/@udir-design/react/src/components/select/Select.stories.tsx
@@ -29,10 +29,7 @@ const meta = preview.meta({
 
 export const Preview = meta.story({
   args: {
-    'aria-invalid': false,
     width: 'full',
-    disabled: false,
-    readOnly: false,
   },
   render: (args) => (
     <Field>
@@ -87,9 +84,7 @@ export const Preview = meta.story({
 });
 
 export const WithError = meta.story({
-  args: {
-    'aria-invalid': true,
-  },
+  args: {},
   render: (args) => (
     <Field>
       <Label>Fylke</Label>
@@ -221,7 +216,7 @@ export const Disabled = meta.story({
 
 export const ReadOnly = meta.story({
   args: {
-    readOnly: true,
+    'aria-readonly': true,
   },
   render: Preview.input.render,
 });

--- a/@udir-design/react/src/components/select/__snapshots__/Select.stories.tsx.snap
+++ b/@udir-design/react/src/components/select/__snapshots__/Select.stories.tsx.snap
@@ -153,9 +153,7 @@ exports[`Preview 1`] = `
     Fylke
   </label>
   <select
-    aria-readonly="false"
     data-width="full"
-    aria-invalid="false"
     id="<removed>"
   >
     <option
@@ -289,9 +287,9 @@ exports[`With Error 1`] = `
     Fylke
   </label>
   <select
-    aria-invalid="true"
     id="<removed>"
     aria-describedby="<removed>"
+    aria-invalid="true"
   >
     <option value>
       Velg et fylke …

--- a/@udir-design/react/src/components/select/docs/FakeSelect.tsx
+++ b/@udir-design/react/src/components/select/docs/FakeSelect.tsx
@@ -6,8 +6,7 @@ import type { SelectProps } from '../Select';
  * Storybook controls for Select directly :(
  */
 export const Select: FunctionComponent<
-  SelectProps & {
-    'aria-invalid'?: SelectProps['aria-invalid'];
+  Omit<SelectProps, 'readOnly'> & {
     'aria-readonly'?: SelectProps['aria-readonly'];
   }
 > = () => null;

--- a/@udir-design/react/src/components/textarea/Textarea.stories.tsx
+++ b/@udir-design/react/src/components/textarea/Textarea.stories.tsx
@@ -5,9 +5,10 @@ import { Button } from '../button/Button';
 import { Field } from '../field/Field';
 import { Label } from '../typography/label/Label';
 import { Textarea } from './Textarea';
+import { Textarea as FakeTextarea } from './docs/FakeTextarea';
 
 const meta = preview.meta({
-  component: Textarea,
+  component: FakeTextarea,
   tags: ['beta', 'digdir'],
   parameters: {
     componentOrigin: {
@@ -25,8 +26,6 @@ const meta = preview.meta({
 
 export const Preview = meta.story({
   args: {
-    disabled: false,
-    readOnly: false,
     rows: 3,
     cols: 20,
     id: 'my-textarea',

--- a/@udir-design/react/src/components/textarea/docs/FakeTextarea.tsx
+++ b/@udir-design/react/src/components/textarea/docs/FakeTextarea.tsx
@@ -1,0 +1,11 @@
+import type { FunctionComponent } from 'react';
+import type { TextareaProps } from '../Textarea';
+
+export const Textarea: FunctionComponent<
+  TextareaProps & {
+    disabled?: TextareaProps['disabled'];
+    readOnly?: TextareaProps['readOnly'];
+    rows?: TextareaProps['rows'];
+    cols?: TextareaProps['cols'];
+  }
+> = () => null;

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -55,11 +55,6 @@ const meta = preview.meta({
 export const Preview = meta.story({
   args: {
     label: 'Label',
-    disabled: false,
-    readOnly: false,
-    multiline: false,
-    description: '',
-    error: '',
     counter: 0,
     id: 'textfield-preview',
   },
@@ -180,7 +175,6 @@ export const Format = meta.story({
 export const Controlled = meta.story({
   args: {
     label: 'Fullt navn',
-    multiline: false,
     id: 'textfield-controlled',
   },
   parameters: {

--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
@@ -31,15 +31,10 @@ const meta = preview.meta<
 export const Default = meta.story({
   args: {
     name: 'my-group',
-    disabled: false,
-    readOnly: false,
-    required: false,
     value: ['epost'],
-    error: '',
   },
   render(args) {
     const { getCheckboxProps, validationMessageProps } = useCheckboxGroup({
-      value: ['epost'],
       ...args,
     });
 
@@ -57,14 +52,10 @@ export const Default = meta.story({
 const GroupBase = {
   args: {
     name: 'my-group',
-    disabled: false,
-    readOnly: false,
-    required: false,
-    error: '',
+    value: ['epost'],
   } as UseCheckboxGroupProps,
   render(args: UseCheckboxGroupProps) {
     const { getCheckboxProps, validationMessageProps } = useCheckboxGroup({
-      value: ['epost'],
       ...args,
     });
 

--- a/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useRadioGroup/useRadioGroup.stories.tsx
@@ -33,8 +33,6 @@ const ageGroups = [
 export const Default = meta.story({
   args: {
     name: 'my-group',
-    readOnly: false,
-    disabled: false,
     value: '10-20',
   },
   render(args) {
@@ -114,8 +112,6 @@ export const Controlled = meta.story({
 const GroupBase = {
   args: {
     name: 'my-group',
-    readOnly: false,
-    disabled: false,
     value: 'sjokolade',
   },
   render(args: UseRadioGroupProps) {


### PR DESCRIPTION
## Kva er gjort?

- Legger til ein `argsTypeEnhancer` i Storybook-oppsettet som endrar presentasjon av props i args-tabell for enkelte typar:
  - `ReactNode` blir no redigert som om det var type `string`, ikkje `object`
  - `string | number"  blir no redigert som om det var type `string`, ikkje `object`
  - `Booleanish` blir no redigert som om det var type `boolean`, ikkje `object`
  - Skrur av redirering for `EventHandler` og inline funksjonstypar

- Har gått gjennom stories for å fjerne enkelte default-verdiar som kun var satt for å endre korleis props blei redigert i args-tabellen.
- Ref forrige punkt, default-verdiane fekk i enkelte tilfeller feil type til å dukke opp i args-tabellen, fordi prop-typen frå før var skjult når den kom frå React sine innebygga typar. For å fikse dette har eg henta inn relevante props i komponent-typen (eller i fake-komponenten der det ga meir meining) slik at disse no dukker opp med riktig type i tabellen der det trengs
- Nokon stader har eg skjult props frå stories  som ellers kun dukka opp fordi vi brukte dei til testing 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
