### PR TITLE
chore(useCheckboxGroup): remove beta tag

### DIFF
--- a/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
+++ b/@udir-design/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.stories.tsx
@@ -22,7 +22,7 @@ const meta = preview.meta<
 >({
   title: 'Utilities/useCheckboxGroup',
   component: fakeUseCheckboxGroup,
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: { originator: 'digdir' },
   },


### PR DESCRIPTION
## Hva er gjort?
Fjerner beta-tag på `useCheckboxGroup`, som blei gløymd i PR som flytta denne frå beta til stabil
