### PR TITLE
nextjs: smoketest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_ui_tests: ${{ steps.job_condition.outputs.run_ui_tests }}
+      run_nextjs_smoke: ${{ steps.job_condition.outputs.run_nextjs_smoke }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,9 +34,11 @@ jobs:
       - name: Print affected packages
         run: pnpm turbo ls --affected
 
-      - name: Determine whether storybook-tests & chromatic need to run
+      - name: Determine which conditional jobs need to run
         id: job_condition
-        run: echo "run_ui_tests=$(./@internal/ci/bin/should-run-ui-tests.ts)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "run_ui_tests=$(./@internal/ci/bin/should-run-ui-tests.ts)" >> "$GITHUB_OUTPUT"
+          echo "run_nextjs_smoke=$(./@internal/ci/bin/should-run-nextjs-smoke.ts)" >> "$GITHUB_OUTPUT"
         env:
           IS_PR_READY: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
           IS_PUSH: ${{ github.event_name == 'push' }}
@@ -67,6 +70,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: chromatic / chromatic
+          conclusion: skipped
+      - name: Skip 'Next.js Smoke Test' check
+        if: steps.job_condition.outputs.run_nextjs_smoke == 'false'
+        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Next.js Smoke Test
           conclusion: skipped
 
       - name: Validate current commit (last commit) with commitlint
@@ -105,8 +115,20 @@ jobs:
     secrets:
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
+  nextjs-smoke-test:
+    runs-on: ubuntu-latest
+    needs: main
+    if: needs.main.outputs.run_nextjs_smoke == 'true'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/pnpm-setup
+      - name: Run Next.js smoke test
+        run: pnpm turbo run test:e2e --filter=test-app-nextjs
+
   release:
-    needs: [main, storybook-tests, chromatic]
+    needs: [main, storybook-tests, chromatic, nextjs-smoke-test]
     if: |
       always() && !failure() && !cancelled() &&
       (github.event_name == 'push' || github.event_name == 'pull_request') &&

--- a/@internal/ci/bin/should-run-nextjs-smoke.ts
+++ b/@internal/ci/bin/should-run-nextjs-smoke.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env -S pnpm tsx
+
+/**
+ * Determines whether the Next.js smoke test should run.
+ *
+ * Decision logic:
+ *   (IS_PR_READY || IS_PUSH) && test-app-nextjs#build is affected
+ *
+ * Reads from environment variables:
+ *   IS_PR_READY - "true" if the PR is open and not a draft
+ *   IS_PUSH     - "true" if the event is a push to a protected branch
+ *
+ * Outputs "true" or "false" to stdout (no trailing newline).
+ * Also prints diagnostic info to stderr for CI logging.
+ */
+
+import { execSync } from 'node:child_process';
+
+/** Write to stderr so diagnostics appear in CI logs without affecting captured stdout. */
+function log(msg: string) {
+  process.stderr.write(msg + '\n');
+}
+
+const IS_PR_READY = process.env['IS_PR_READY'] === 'true';
+const IS_PUSH = process.env['IS_PUSH'] === 'true';
+
+function isNextjsAffected(): boolean {
+  try {
+    const output = execSync(
+      'pnpm turbo run build --filter="test-app-nextjs" --affected --dry-run=json',
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] },
+    );
+    const result = JSON.parse(output);
+    return result.tasks.some(
+      (t: { taskId: string }) => t.taskId === 'test-app-nextjs#build',
+    );
+  } catch {
+    return false;
+  }
+}
+
+const nextjsAffected = isNextjsAffected();
+
+log(`Is this a PR which is ready for review? ${IS_PR_READY}`);
+log(`Is test-app-nextjs#build affected? ${nextjsAffected}`);
+log(`Is this a push to a protected branch? ${IS_PUSH}`);
+
+const shouldRun = (IS_PR_READY || IS_PUSH) && nextjsAffected;
+
+log(`Conclusion: should we run Next.js smoke test? ${shouldRun}`);
+process.stdout.write(String(shouldRun));

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ I dette repositoriet lever den delen av designsystemet som implementeres i kode:
 - [Hva tester vi?](#hva-tester-vi)
   - [Individuelle komponenter](#individuelle-komponenter)
   - [Demosider](#demosider)
+  - [Smoketest (Next.js)](#smoketest-nextjs)
   - [Felles for komponenter og demosider](#felles-for-komponenter-og-demosider)
   - [Tester for komponenter i ulike livsfaser](#tester-for-komponenter-i-ulike-livsfaser)
 - [Informasjon for utviklere som skal bidra](#informasjon-for-utviklere-som-skal-bidra)
@@ -104,6 +105,10 @@ I de tilfellene vi implementerer egen oppførsel for komponenter eller hjelpefun
 ## Demosider
 
 Vi tester hver komponent i en større kontekst av andre komponenter. Dette kaller vi **komposisjonstester**. Her kan vi også teste interaksjoner på tvers av komponenter.
+
+## Smoketest (Next.js)
+
+Vi smoketester Next.js-testapplikasjonen i produksjonsmodus og besøker alle demosidene. Testen verifiserer at hver side rendres uten feil, og fanger opp problemer som ikke oppdages av komponent- eller komposisjonstester — for eksempel biblioteker som krasjer under server-side rendering (SSR).
 
 ## Felles for komponenter og demosider
 
@@ -427,6 +432,16 @@ Hvert eksempel i Storybook får automatisk en snapshottest, en visuell test, og 
 ```bash
 pnpm test:storybook:update
 ```
+
+#### Smoketest (Next.js)
+
+Smoketesten bruker [Playwright](https://playwright.dev/) til å bygge og starte Next.js-appen (`test-apps/nextjs`) og besøke alle demosider i Chromium.
+
+```bash
+pnpm nx test:e2e test-app-nextjs
+```
+
+I CI kjøres denne automatisk på pull requests som påvirker `test-app-nextjs` eller dens avhengigheter (`@udir-design/react`, `@udir-design/theme`, `@udir-design/icons`, `@udir-design/symbols`).
 
 #### Systemtest
 

--- a/test-apps/nextjs/.gitignore
+++ b/test-apps/nextjs/.gitignore
@@ -1,0 +1,2 @@
+# Playwright
+test-results/

--- a/test-apps/nextjs/e2e/smoke.spec.ts
+++ b/test-apps/nextjs/e2e/smoke.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'playwright/test';
+
+// Keep this list in sync with the routes in src/app/
+const routes = ['/', '/article', '/dashboard', '/form', '/page', '/table'];
+
+for (const route of routes) {
+  test(`smoke: ${route} renders without errors`, async ({ page }) => {
+    const response = await page.goto(route);
+
+    expect(response?.status()).toBe(200);
+
+    const main = page.locator('main#main-content');
+    await expect(main).toBeVisible();
+    await expect(main).not.toBeEmpty();
+
+    // Ensure no Next.js error overlay is present
+    await expect(page.locator('#__next_error__')).toHaveCount(0);
+    await expect(page.locator('nextjs-portal')).toHaveCount(0);
+  });
+}

--- a/test-apps/nextjs/package.json
+++ b/test-apps/nextjs/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings 0",
-    "typecheck": "tsgo --build"
+    "typecheck": "tsgo --build",
+    "pretest:e2e": "pnpm exec playwright install --with-deps chromium",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@next/eslint-plugin-next": "catalog:",

--- a/test-apps/nextjs/playwright.config.ts
+++ b/test-apps/nextjs/playwright.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'playwright/test';
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
-  retries: 1,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: 'http://localhost:3000',
   },

--- a/test-apps/nextjs/playwright.config.ts
+++ b/test-apps/nextjs/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  webServer: {
+    command: 'pnpm next start',
+    port: 3000,
+    reuseExistingServer: false,
+  },
+});

--- a/test-apps/nextjs/turbo.json
+++ b/test-apps/nextjs/turbo.json
@@ -8,6 +8,9 @@
     "dev": {
       "persistent": true,
       "dependsOn": ["^build", "^inject"]
+    },
+    "test:e2e": {
+      "dependsOn": ["build"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,9 @@
     "lint": {
       "inputs": ["$TURBO_DEFAULT$"]
     },
-    "inject": {},
+    "inject": {
+      "cache": false
+    },
     "test": {
       "dependsOn": ["build"],
       "inputs": ["$TURBO_DEFAULT$"]


### PR DESCRIPTION
Setter opp smoketest med playwright for nextjs-appen. Testene kan kjøres lokalt med `pnpm nx test:e2e test-app-nextjs`. 

- I ci vil appen kjøres opp (hvis appen crasher så får man beskjed om det)
- Testene sjekker enkelt at det ikke er noen errors 
- Man vil ikke kunne gå videre i actions eller pr uten at alt kjører 