### PR TITLE
build: remove @joshwooding/vite-plugin-react-docgen-typescript override

### DIFF
--- a/@udir-design/react/.storybook/main.ts
+++ b/@udir-design/react/.storybook/main.ts
@@ -119,7 +119,7 @@ export default defineMain({
         );
         return isPropFromAllowedLocation;
       },
-      tsconfigPath: 'tsconfig.lib.json',
+      tsconfigPath: 'tsconfig.docgen.json',
       // Required for unions like Size, Color etc from @digdir to generate options in Storybook controls
       shouldExtractLiteralValuesFromEnum: true,
       // Removes "undefined" as an option in Storybook controls for optional properties

--- a/@udir-design/react/tsconfig.docgen.json
+++ b/@udir-design/react/tsconfig.docgen.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.lib.json",
+  // Ensure docgen has the full context (including anything in **/docs/)
+  "exclude": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,7 +386,6 @@ catalogs:
       version: 4.4.3
 
 overrides:
-  '@joshwooding/vite-plugin-react-docgen-typescript@>=0.7.0': 0.6.4
   axios@>=1.0.0 <1.15.0: '>=1.15.0'
   postcss@<8.5.10: ^8.5.10
   semver@<7: ^7
@@ -2370,11 +2369,11 @@ packages:
     resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4':
-    resolution: {integrity: sha512-6PyZBYKnnVNqOSB0YFly+62R7dmov8segT27A+RVTBVd4iAE6kbW9QBJGlyR2yG4D4ohzhZSTIu7BK1UTtmFFA==}
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9627,7 +9626,7 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.49
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@6.0.3)(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
@@ -10480,7 +10479,7 @@ snapshots:
 
   '@storybook/react-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@6.0.3)(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
       '@storybook/builder-vite': 10.4.1(esbuild@0.28.0)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@7.3.3(@types/node@24.12.4)(jiti@2.6.1)(sass@1.100.0)(tsx@4.22.3)(yaml@2.9.0))
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -168,9 +168,6 @@ minimumReleaseAgeExclude:
   - '@u-elements/*'
 
 overrides:
-  # vite-plugin-react-docgen-typescript@>=0.7.0 removes many props from args tables in Storybook.
-  # Storybook now lists a higher version as a dependency, but we are prevented from upgrading
-  '@joshwooding/vite-plugin-react-docgen-typescript@>=0.7.0': 0.6.4
   axios@>=1.0.0 <1.15.0: '>=1.15.0'
   postcss@<8.5.10: ^8.5.10
   semver@<7: ^7


### PR DESCRIPTION
Upgrading `@joshwooding/vite-plugin-react-docgen-typescript` from 0.6.4 to 0.7.0 changed how it generated the typescript information. Where it previously checked all tsx files, it now needs the files to be included in the tsconfig file, which we had configured to tsconfig.lib.json. Because that tsconfig file specifically excludes `**/docs/**/*.tsx` our `docs/Fake*` pattern for enhancing information in the args table no longer worked, as these files were not included. Thus react-docgen-typescript couldn't generate any docs for the components that use this pattern, like Card.

The fix uses a new tsconfig.docgen.json which extends from tsconfig.lib.json, but removes exclusions. This ensures all the files are included in docgen, and there is no difference from the props tables as they were before upgrading to 0.7.0.