### PR TITLE
ci: reduce Chromatic usage

### DIFF
--- a/.github/workflows/chromatic-on-label.yml
+++ b/.github/workflows/chromatic-on-label.yml
@@ -1,0 +1,26 @@
+# Runs Chromatic when the 'chromatic' label is added to a PR.
+# This avoids re-running the full CI pipeline (build, lint, commitlint) since
+# the code hasn't changed — only the label was added.
+#
+# Temporary measure to conserve Chromatic snapshot credits.
+# Remove this workflow (and the label gate in ci.yml) when no longer needed.
+
+name: 'Chromatic (on label)'
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  actions: read
+  contents: read
+  checks: write
+
+jobs:
+  chromatic:
+    if: |
+      github.event.label.name == 'chromatic' &&
+      !github.event.pull_request.draft
+    uses: ./.github/workflows/chromatic.yml
+    secrets:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,79 @@
+# Reusable workflow for running Chromatic visual regression tests.
+# Called from ci.yml and chromatic-on-label.yml.
+
+name: Chromatic
+
+on:
+  workflow_call:
+    secrets:
+      CHROMATIC_PROJECT_TOKEN:
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+  checks: write
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    env:
+      CHROMATIC_WORKING_DIR: '@udir-design/react'
+      CHROMATIC_STORYBOOK_BUILD_DIR: ./storybook-static
+      CHROMATIC_EXIT_ZERO_ON_CHANGES: true
+      CHROMATIC_EXIT_ONCE_UPLOADED: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/pnpm-setup
+
+      - name: Build storybook
+        run: pnpm turbo run build:docs --filter=@udir-design/react
+
+      - name: Check runtime dependency changes
+        id: diff_runtime_deps
+        run: |
+          pnpm tsx ./@internal/ci/bin/diff-runtime-deps.ts --base "${TURBO_SCM_BASE:-main}" \
+            && echo "deps_changed=false" >> "$GITHUB_OUTPUT" \
+            || echo "deps_changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Storybook to Chromatic (TurboSnap)
+        if: steps.diff_runtime_deps.outputs.deps_changed != 'true'
+        uses: chromaui/action@fd9f0848927ca40d7157227eb3a7f771827652bc # v16.7.0
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: ${{ env.CHROMATIC_WORKING_DIR }}
+          storybookBuildDir: ${{ env.CHROMATIC_STORYBOOK_BUILD_DIR }}
+          exitZeroOnChanges: ${{ env.CHROMATIC_EXIT_ZERO_ON_CHANGES }}
+          exitOnceUploaded: ${{ env.CHROMATIC_EXIT_ONCE_UPLOADED }}
+          onlyChanged: true
+          externals: 'design-tokens/src/**'
+          untraced: |
+            @udir-design/react/.storybook/docs/**
+            @udir-design/react/.storybook/manager.tsx
+            @udir-design/react/.storybook/manager.css
+            @udir-design/react/.storybook/manager-head.html
+            @udir-design/react/.storybook/addons/**
+            @udir-design/react/.storybook/types/**
+            @udir-design/react/.storybook/data/**
+            @udir-design/react/.storybook/utils/argTypesEnhancer.ts
+            @udir-design/react/.storybook/utils/sourceCodeUrl.ts
+            @udir-design/react/.storybook/utils/sourceTransformers.ts
+            @udir-design/react/.storybook/utils/makeStoryTransformer.ts
+            @udir-design/react/.storybook/story-snapshot-serializer.ts
+            @udir-design/react/.storybook/preview-test.ts
+            @udir-design/react/.storybook/decorators/WithInertInitialRender.tsx
+            @udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
+
+      - name: Publish Storybook to Chromatic (full build)
+        if: steps.diff_runtime_deps.outputs.deps_changed == 'true'
+        uses: chromaui/action@fd9f0848927ca40d7157227eb3a7f771827652bc # v16.7.0
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: ${{ env.CHROMATIC_WORKING_DIR }}
+          storybookBuildDir: ${{ env.CHROMATIC_STORYBOOK_BUILD_DIR }}
+          exitZeroOnChanges: ${{ env.CHROMATIC_EXIT_ZERO_ON_CHANGES }}
+          exitOnceUploaded: ${{ env.CHROMATIC_EXIT_ONCE_UPLOADED }}
+          onlyChanged: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,22 @@ jobs:
           exitOnceUploaded: ${{ env.CHROMATIC_EXIT_ONCE_UPLOADED }}
           onlyChanged: true
           externals: 'design-tokens/src/**'
-          untraced: '@udir-design/react/.storybook/docs/**'
+          untraced: |
+            @udir-design/react/.storybook/docs/**
+            @udir-design/react/.storybook/manager.tsx
+            @udir-design/react/.storybook/manager.css
+            @udir-design/react/.storybook/manager-head.html
+            @udir-design/react/.storybook/addons/**
+            @udir-design/react/.storybook/types/**
+            @udir-design/react/.storybook/data/**
+            @udir-design/react/.storybook/utils/argTypesEnhancer.ts
+            @udir-design/react/.storybook/utils/sourceCodeUrl.ts
+            @udir-design/react/.storybook/utils/sourceTransformers.ts
+            @udir-design/react/.storybook/utils/makeStoryTransformer.ts
+            @udir-design/react/.storybook/story-snapshot-serializer.ts
+            @udir-design/react/.storybook/preview-test.ts
+            @udir-design/react/.storybook/decorators/WithInertInitialRender.tsx
+            @udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
 
       - name: Publish Storybook to Chromatic (full build)
         if: steps.diff_runtime_deps.outputs.deps_changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,69 +88,15 @@ jobs:
         run: pnpm turbo run test:storybook --filter=@udir-design/react
 
   chromatic:
-    runs-on: ubuntu-latest
     needs: [main]
-    if: needs.main.outputs.run_ui_tests == 'true'
-    env:
-      CHROMATIC_WORKING_DIR: '@udir-design/react'
-      CHROMATIC_STORYBOOK_BUILD_DIR: ./storybook-static
-      CHROMATIC_EXIT_ZERO_ON_CHANGES: true
-      CHROMATIC_EXIT_ONCE_UPLOADED: true
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/pnpm-setup
-
-      - name: Build storybook
-        run: pnpm turbo run build:docs --filter=@udir-design/react
-
-      - name: Check runtime dependency changes
-        id: diff_runtime_deps
-        run: |
-          pnpm tsx ./@internal/ci/bin/diff-runtime-deps.ts --base "${TURBO_SCM_BASE:-main}" \
-            && echo "deps_changed=false" >> "$GITHUB_OUTPUT" \
-            || echo "deps_changed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Publish Storybook to Chromatic (TurboSnap)
-        if: steps.diff_runtime_deps.outputs.deps_changed != 'true'
-        uses: chromaui/action@fd9f0848927ca40d7157227eb3a7f771827652bc # v16.7.0
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: ${{ env.CHROMATIC_WORKING_DIR }}
-          storybookBuildDir: ${{ env.CHROMATIC_STORYBOOK_BUILD_DIR }}
-          exitZeroOnChanges: ${{ env.CHROMATIC_EXIT_ZERO_ON_CHANGES }}
-          exitOnceUploaded: ${{ env.CHROMATIC_EXIT_ONCE_UPLOADED }}
-          onlyChanged: true
-          externals: 'design-tokens/src/**'
-          untraced: |
-            @udir-design/react/.storybook/docs/**
-            @udir-design/react/.storybook/manager.tsx
-            @udir-design/react/.storybook/manager.css
-            @udir-design/react/.storybook/manager-head.html
-            @udir-design/react/.storybook/addons/**
-            @udir-design/react/.storybook/types/**
-            @udir-design/react/.storybook/data/**
-            @udir-design/react/.storybook/utils/argTypesEnhancer.ts
-            @udir-design/react/.storybook/utils/sourceCodeUrl.ts
-            @udir-design/react/.storybook/utils/sourceTransformers.ts
-            @udir-design/react/.storybook/utils/makeStoryTransformer.ts
-            @udir-design/react/.storybook/story-snapshot-serializer.ts
-            @udir-design/react/.storybook/preview-test.ts
-            @udir-design/react/.storybook/decorators/WithInertInitialRender.tsx
-            @udir-design/react/.storybook/decorators/withScrollHashBehavior.tsx
-
-      - name: Publish Storybook to Chromatic (full build)
-        if: steps.diff_runtime_deps.outputs.deps_changed == 'true'
-        uses: chromaui/action@fd9f0848927ca40d7157227eb3a7f771827652bc # v16.7.0
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: ${{ env.CHROMATIC_WORKING_DIR }}
-          storybookBuildDir: ${{ env.CHROMATIC_STORYBOOK_BUILD_DIR }}
-          exitZeroOnChanges: ${{ env.CHROMATIC_EXIT_ZERO_ON_CHANGES }}
-          exitOnceUploaded: ${{ env.CHROMATIC_EXIT_ONCE_UPLOADED }}
-          onlyChanged: false
+    # On PRs, require the 'chromatic' label to run (conserves snapshot credits).
+    # On pushes to protected branches, always run. Remove label gate when no longer needed.
+    if: |
+      needs.main.outputs.run_ui_tests == 'true' &&
+      (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'chromatic'))
+    uses: ./.github/workflows/chromatic.yml
+    secrets:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
 
   release:
     needs: [main, storybook-tests, chromatic]

--- a/@internal/ci/bin/ci-decisions.test.ts
+++ b/@internal/ci/bin/ci-decisions.test.ts
@@ -51,27 +51,25 @@ function isCleanWorkingTree(): boolean {
 }
 
 describe('should-run-ui-tests', () => {
-  it('returns "true" on push events regardless of affected state', () => {
+  it('returns "false" on push events when react is not affected', () => {
     const result = runScript('should-run-ui-tests.ts', {
       IS_PR_READY: 'false',
       IS_PUSH: 'true',
       TURBO_SCM_BASE: 'HEAD',
     });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('true');
+    expect(result.stdout).toBe('false');
   });
 
-  it('simulates push-to-main in CI: IS_PUSH bypasses affected check', () => {
-    // In CI on push, TURBO_SCM_BASE is set to github.event.before (the previous
-    // commit on the branch). Turbo correctly diffs the new commits. But IS_PUSH=true
-    // means UI tests run unconditionally regardless of the affected result.
+  it('returns "true" on push events when react is affected', () => {
     const result = runScript('should-run-ui-tests.ts', {
       IS_PR_READY: 'false',
       IS_PUSH: 'true',
-      TURBO_SCM_BASE: 'HEAD~1', // Simulates github.event.before (previous commit)
+      TURBO_SCM_BASE: 'HEAD~1',
     });
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toBe('true');
+    // Result depends on whether the last commit affected @udir-design/react
+    expect(['true', 'false']).toContain(result.stdout);
   });
 
   it('returns "false" for draft PRs even if react is affected', () => {

--- a/@internal/ci/bin/ci-decisions.test.ts
+++ b/@internal/ci/bin/ci-decisions.test.ts
@@ -118,7 +118,7 @@ describe('should-run-ui-tests', () => {
       TURBO_SCM_BASE: 'HEAD',
     });
     expect(result.stderr).toContain('Conclusion');
-    expect(result.stderr).toContain('should we run UI tests');
+    expect(result.stderr).toContain('build:storybook affected');
   });
 
   it('outputs no trailing newline on stdout', () => {

--- a/@internal/ci/bin/should-run-ui-tests.ts
+++ b/@internal/ci/bin/should-run-ui-tests.ts
@@ -4,7 +4,7 @@
  * Determines whether UI tests (Storybook tests + Chromatic) should run.
  *
  * Decision logic:
- *   (IS_PR_READY || IS_PUSH) && @udir-design/react is affected
+ *   (IS_PR_READY || IS_PUSH) && @udir-design/react#build:storybook is affected
  *
  * Reads from environment variables:
  *   IS_PR_READY - "true" if the PR is open and not a draft
@@ -24,23 +24,26 @@ function log(msg: string) {
 const IS_PR_READY = process.env['IS_PR_READY'] === 'true';
 const IS_PUSH = process.env['IS_PUSH'] === 'true';
 
-function isReactAffected(): boolean {
+function isReactStorybookAffected(): boolean {
   try {
     const output = execSync(
-      'pnpm turbo ls --affected --filter="@udir-design/react" --output json',
+      'pnpm turbo run build:storybook --filter="@udir-design/react" --affected --dry-run=json',
       { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] },
     );
     const result = JSON.parse(output);
-    return result.packages.count > 0;
+    return result.tasks.some(
+      (t: { taskId: string }) =>
+        t.taskId === '@udir-design/react#build:storybook',
+    );
   } catch {
     return false;
   }
 }
 
-const reactAffected = isReactAffected();
+const reactAffected = isReactStorybookAffected();
 
 log(`Is this a PR which is ready for review? ${IS_PR_READY}`);
-log(`Is @udir-design/react affected? ${reactAffected}`);
+log(`Is @udir-design/react#build:storybook affected? ${reactAffected}`);
 log(`Is this a push to a protected branch? ${IS_PUSH}`);
 
 const shouldRun = (IS_PR_READY || IS_PUSH) && reactAffected;

--- a/@internal/ci/bin/should-run-ui-tests.ts
+++ b/@internal/ci/bin/should-run-ui-tests.ts
@@ -4,7 +4,7 @@
  * Determines whether UI tests (Storybook tests + Chromatic) should run.
  *
  * Decision logic:
- *   (IS_PR_READY && @udir-design/react is affected) || IS_PUSH
+ *   (IS_PR_READY || IS_PUSH) && @udir-design/react is affected
  *
  * Reads from environment variables:
  *   IS_PR_READY - "true" if the PR is open and not a draft
@@ -43,7 +43,7 @@ log(`Is this a PR which is ready for review? ${IS_PR_READY}`);
 log(`Is @udir-design/react affected? ${reactAffected}`);
 log(`Is this a push to a protected branch? ${IS_PUSH}`);
 
-const shouldRun = (IS_PR_READY && reactAffected) || IS_PUSH;
+const shouldRun = (IS_PR_READY || IS_PUSH) && reactAffected;
 
 log(`Conclusion: should we run UI tests? ${shouldRun}`);
 process.stdout.write(String(shouldRun));

--- a/@udir-design/react/.storybook/docs/fixIconDisplayNames.ts
+++ b/@udir-design/react/.storybook/docs/fixIconDisplayNames.ts
@@ -1,0 +1,12 @@
+/**
+ * Fix icons being displayed as "React.ForwardRef" in Storybook code examples.
+ *
+ * This is a side-effect-only module — import it for its side effects.
+ * It lives in an untraced directory so that changes to @udir-design/icons
+ * don't cause TurboSnap to re-snapshot every story.
+ */
+import * as icons from '@udir-design/icons';
+
+for (const iconName of Object.keys(icons) as (keyof typeof icons)[]) {
+  icons[iconName].displayName = iconName;
+}

--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -3,11 +3,9 @@ import './docs/customTheme.scss';
 import addonA11y from '@storybook/addon-a11y';
 import addonDocs from '@storybook/addon-docs';
 import { definePreview } from '@storybook/react-vite';
-import * as R from 'ramda';
 import type { PreviewAddon } from 'storybook/internal/csf';
 import { INITIAL_VIEWPORTS, type ViewportMap } from 'storybook/viewport';
 import storybookAddonPseudoStates from 'storybook-addon-pseudo-states';
-import * as icons from '@udir-design/icons';
 import { sourceCodeToolbarAddon } from './addons/sourceCodeToolbar';
 import { docsParameters } from './docs/parameters';
 import { testLifecycleHooks } from './preview-test';
@@ -18,11 +16,7 @@ import type {
 } from './types';
 import { argTypesEnhancer } from './utils/argTypesEnhancer';
 import { CustomStylesDecorator } from './utils/customStylesDecorator';
-
-// Fix icons being displayed as React.ForwardRef in Storybook code examples
-for (const iconName of R.keys(icons)) {
-  icons[iconName].displayName = iconName;
-}
+import './docs/fixIconDisplayNames';
 
 // See the complete list of available devices in INITIAL_VIEWPORTS here:
 // https://storybook.js.org/docs/essentials/viewport#use-a-detailed-set-of-devices


### PR DESCRIPTION
## Kva er gjort?

Vi nærmar oss kvota på 35000 snapshots for juni. Denne PR-en reduserer unødvendig forbruk ved å:

- Hoppe over Chromatic på push til `main` når `@udir-design/react` ikkje er påverka
- Utvide `untraced`-config slik at fleire `.storybook/`-filer ikkje triggar full re-snapshot
- Flytte `@udir-design/icons`-importen ut av `preview.tsx` til ei utraca fil
- Vente med å køyre Chromatic på PRs til vi legg til eit `chromatic`-label, som midlertidig tiltak under overgangen frå beta til stabil. Vi krever framleis at dei må ha kjørt før merge.