### PR TITLE
ci: report skipped status for `chromatic / chromatic` check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: UI Review
           conclusion: skipped
+      - name: Skip 'chromatic / chromatic' check
+        if: steps.job_condition.outputs.run_ui_tests == 'false'
+        uses: LouisBrunner/checks-action@937cbbcde3259005b50746dc91cde29098aac2ff # v3.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: chromatic / chromatic
+          conclusion: skipped
 
       - name: Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'


### PR DESCRIPTION
When UI tests are unnecessary, the `chromatic` job in `ci.yml` is
skipped entirely. Because it calls a reusable workflow, the inner job
`chromatic / chromatic` never reports a status — leaving the required
check pending indefinitely.

Use `checks-action` to report a skipped status, matching the existing
pattern for `Storybook Publish`, `UI Tests`, and `UI Review`.
