### PR TITLE
test: add unit tests for useFormNavigation

### DIFF
--- a/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
+++ b/@udir-design/react/demo-pages/form-demo/ErrorSummaryContent.tsx
@@ -1,6 +1,7 @@
 import type { DSErrorSummaryElement } from '@digdir/designsystemet-web';
 import type { FieldError, FieldErrors } from 'react-hook-form';
 import { ErrorSummary } from 'src/components/errorSummary';
+import type { UseFormNavigationReturn } from 'src/hooks/useFormNavigation';
 import type { FieldId, FormValues, PageFields, PageId } from './FormDemo';
 import { findPageForField } from './FormDemo';
 
@@ -10,7 +11,7 @@ type Props = {
   errors: FieldErrors<FormValues>;
   errorSummaryRef: React.RefObject<DSErrorSummaryElement | null>;
   pageFields: PageFields;
-  setId: React.Dispatch<React.SetStateAction<PageId | null>>;
+  setId: UseFormNavigationReturn<PageId>['setId'];
 };
 
 const getMessage = (

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.stories.tsx
@@ -48,7 +48,9 @@ const meta = preview.meta({
 export const Preview = meta.story({
   args: {},
   render(args) {
-    const { getStepProps, getGroupProps } = useFormNavigation({
+    const { getStepProps, getGroupProps } = useFormNavigation<
+      'step' | 'step-1' | 'step-2'
+    >({
       value: 'step',
     });
     return (
@@ -104,7 +106,9 @@ export const Preview = meta.story({
 export const Grouping = meta.story({
   args: {},
   render(args) {
-    const { getStepProps, getGroupProps } = useFormNavigation({
+    const { getStepProps, getGroupProps } = useFormNavigation<
+      'step1' | 'step2'
+    >({
       value: 'step1',
     });
     return (
@@ -128,7 +132,9 @@ export const Grouping = meta.story({
 export const LongStepNames = meta.story({
   args: {},
   render(args) {
-    const { getStepProps, getGroupProps } = useFormNavigation({
+    const { getStepProps, getGroupProps } = useFormNavigation<
+      'step1' | 'step2' | 'step3' | 'step4'
+    >({
       value: 'step1',
     });
     return (
@@ -432,7 +438,7 @@ export const SimpleNavigation = meta.story({
       prev,
       hasNext,
       hasPrev,
-    } = useFormNavigation({
+    } = useFormNavigation<'step1' | 'step2' | 'submit'>({
       value: 'step1',
     });
 

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.mdx
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.mdx
@@ -17,8 +17,8 @@ I respons får du objektet:
 ```ts
 {
   /* Aktivt steg */
-  id: TId | null, // Aktivt steg-ID (eller null hvis ingen aktiv)
-  setId: Dispatch<SetStateAction<TId | null>>, // Overstyr aktivt steg-ID
+  id: TId, // Aktivt steg-ID
+  setId: (next: TId | ((prev: TId) => TId)) => void, // Overstyr aktivt steg-ID
 
   /* Håndtering av tilstand */
   markCompleted: (id: TId) => void, // Marker et steg som fullført
@@ -104,8 +104,7 @@ return (
 Validering av skjema håndteres utenfor hooken, slik at du kan tilpasse valideringslogikken etter behov. Når brukeren prøver å gå videre til neste steg, kan du validere det nåværende steget og bruke `markInvalid` eller `markCompleted` basert på resultatet. Dette kan gjøres i `onChange` som du sender til hooken.
 
 ```tsx
-const onStepChange = (nextId: StepId, prevId: StepId | null) => {
-  if (!prevId) return;
+const onStepChange = (nextId: StepId, prevId: StepId) => {
   const isValid = validateStep(prevId);
   if (isValid) {
     markCompleted(prevId);

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -376,6 +376,19 @@ describe('getStepProps', () => {
     ).toBe('completed');
   });
 
+  it('passes through extra HTML attributes', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    const props = result.current.getStepProps({
+      stepId: 'step1',
+      'aria-label': 'First step',
+      className: 'custom',
+    });
+    expect(props['aria-label']).toBe('First step');
+    expect(props.className).toBe('custom');
+  });
+
   it('onClick handler calls provided onClick callback', () => {
     const onClickCallback = vi.fn();
     const { result } = renderHook(() =>

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -89,6 +89,26 @@ describe('next, prev', () => {
     expect(result.current.id).toBeNull();
   });
 
+  it('next calls onChange with next and prev step id', async () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order], onChange }),
+    );
+    await act(async () => result.current.next());
+    expect(onChange).toHaveBeenCalledWith('step2', 'step1');
+  });
+
+  it('next calls onChange with null as prev when active step id is null', async () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order], onChange }),
+    );
+    act(() => result.current.setId(null));
+    onChange.mockClear();
+    await act(async () => result.current.next());
+    expect(onChange).toHaveBeenCalledWith('step1', null);
+  });
+
   it('next returns false when called on the last step', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ value: 'step3', order: [...order] }),
@@ -105,6 +125,15 @@ describe('next, prev', () => {
     const moved = await act(async () => result.current.prev());
     expect(moved).toBe(true);
     expect(result.current.id).toBe('step1');
+  });
+
+  it('prev calls onChange with next and prev step id', async () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step2', order: [...order], onChange }),
+    );
+    await act(async () => result.current.prev());
+    expect(onChange).toHaveBeenCalledWith('step1', 'step2');
   });
 
   it('prev returns false when active step id is null', async () => {

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -1,0 +1,374 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useFormNavigation } from './useFormNavigation';
+
+const order = ['step1', 'step2', 'step3'] as const;
+
+describe('initial state', () => {
+  it('returns no active step id when no value or order is given', () => {
+    const { result } = renderHook(() => useFormNavigation());
+    expect(result.current.id).toBeNull();
+  });
+
+  it('uses value as initial active step id', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step2', order: [...order] }),
+    );
+    expect(result.current.id).toBe('step2');
+  });
+
+  it('returns the first step when no value is given', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.id).toBe('step1');
+  });
+});
+
+describe('setId', () => {
+  it('updates the active step id', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.setId('step2'));
+    expect(result.current.id).toBe('step2');
+  });
+
+  it('calls onChange with arguments next and prev', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order], onChange }),
+    );
+    act(() => result.current.setId('step2'));
+    expect(onChange).toHaveBeenCalledWith('step2', 'step1');
+  });
+
+  it('accepts an function as next', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.setId(() => 'step3'));
+    expect(result.current.id).toBe('step3');
+  });
+
+  it('does not call onChange when step id is set to the same value', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order], onChange }),
+    );
+    act(() => result.current.setId('step1'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('next, prev', () => {
+  it('next moves to the next step and returns true', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    let moved: boolean;
+    act(() => {
+      moved = result.current.next();
+    });
+    expect(moved!).toBe(true);
+    expect(result.current.id).toBe('step2');
+  });
+
+  it('next moves to first step when active step id is null and steps are available', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.setId(null));
+    expect(result.current.id).toBeNull();
+    let moved: boolean;
+    act(() => {
+      moved = result.current.next();
+    });
+    expect(moved!).toBe(true);
+    expect(result.current.id).toBe('step1');
+  });
+
+  it('next returns false when active step id is null and no steps available', () => {
+    const { result } = renderHook(() => useFormNavigation({ order: [] }));
+    let moved: boolean;
+    act(() => {
+      moved = result.current.next();
+    });
+    expect(moved!).toBe(false);
+    expect(result.current.id).toBeNull();
+  });
+
+  it('next returns false when called on the last step', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step3', order: [...order] }),
+    );
+    let moved: boolean;
+    act(() => {
+      moved = result.current.next();
+    });
+    expect(moved!).toBe(false);
+    expect(result.current.id).toBe('step3');
+  });
+
+  it('prev moves to the previous step and returns true', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step2', order: [...order] }),
+    );
+    let moved: boolean;
+    act(() => {
+      moved = result.current.prev();
+    });
+    expect(moved!).toBe(true);
+    expect(result.current.id).toBe('step1');
+  });
+
+  it('prev returns false when active step id is null', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.setId(null));
+    expect(result.current.id).toBeNull();
+    let moved: boolean;
+    act(() => {
+      moved = result.current.prev();
+    });
+    expect(moved!).toBe(false);
+    expect(result.current.id).toBeNull();
+  });
+
+  it('prev returns false when called on the first step', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    let moved: boolean;
+    act(() => {
+      moved = result.current.prev();
+    });
+    expect(moved!).toBe(false);
+    expect(result.current.id).toBe('step1');
+  });
+});
+
+describe('hasNext, hasPrev', () => {
+  it('hasNext is true when not on last step', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.hasNext()).toBe(true);
+  });
+
+  it('hasNext is false on last step', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step3', order: [...order] }),
+    );
+    expect(result.current.hasNext()).toBe(false);
+  });
+
+  it('hasPrev is false on first step', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.hasPrev()).toBe(false);
+  });
+
+  it('hasPrev is true when not on first step', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step2', order: [...order] }),
+    );
+    expect(result.current.hasPrev()).toBe(true);
+  });
+
+  it('hasPrev is false when activeId is null', () => {
+    const { result } = renderHook(() => useFormNavigation());
+    expect(result.current.hasPrev()).toBe(false);
+  });
+
+  it('hasNext is true when activeId is null and steps are available', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.setId(null));
+    expect(result.current.hasNext()).toBe(true);
+  });
+});
+
+describe('markCompleted, markInvalid, resetStep, reset', () => {
+  it('markCompleted sets step state to completed', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.markCompleted('step2'));
+    expect(result.current.getStepProps('step2').state).toBe('completed');
+  });
+
+  it('markInvalid sets step state to invalid', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.markInvalid('step2'));
+    expect(result.current.getStepProps('step2').state).toBe('invalid');
+  });
+
+  it('resetStep sets step state to idle', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => result.current.markCompleted('step2'));
+    expect(result.current.getStepProps('step2').state).toBe('completed');
+    act(() => result.current.resetStep('step2'));
+    expect(result.current.getStepProps('step2').state).toBe('idle');
+  });
+
+  it('reset sets all states to idle', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => {
+      result.current.markCompleted('step2');
+      result.current.markInvalid('step3');
+    });
+    act(() => result.current.reset());
+    expect(result.current.getStepProps('step2').state).toBe('idle');
+    expect(result.current.getStepProps('step3').state).toBe('idle');
+  });
+});
+
+describe('getStepProps', () => {
+  it('active step has state "active"', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.getStepProps('step1').state).toBe('active');
+  });
+
+  it('inactive step defaults to state "idle"', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.getStepProps('step2').state).toBe('idle');
+  });
+
+  it('throws error if no step id is provided', () => {
+    const { result } = renderHook(() => useFormNavigation());
+    expect(() => result.current.getStepProps({})).toThrow();
+  });
+
+  it('state override takes precedence', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(
+      result.current.getStepProps({ stepId: 'step1', state: 'completed' })
+        .state,
+    ).toBe('completed');
+  });
+
+  it('onClick handler calls provided onClick callback', () => {
+    const onClickCallback = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    const props = result.current.getStepProps({
+      stepId: 'step2',
+      onClick: onClickCallback,
+    });
+
+    const mockEvent = {
+      defaultPrevented: false,
+    } as React.MouseEvent<HTMLButtonElement>;
+    act(() => {
+      props.onClick?.(mockEvent);
+    });
+
+    expect(onClickCallback).toHaveBeenCalledWith(mockEvent);
+    expect(result.current.id).toBe('step2');
+  });
+
+  it('onClick handler respects defaultPrevented', () => {
+    const onClickCallback = vi.fn();
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    const props = result.current.getStepProps({
+      stepId: 'step2',
+      onClick: onClickCallback,
+    });
+
+    const mockEvent = {
+      defaultPrevented: true,
+    } as React.MouseEvent<HTMLButtonElement>;
+    act(() => {
+      props.onClick?.(mockEvent);
+    });
+
+    expect(onClickCallback).toHaveBeenCalledWith(mockEvent);
+    // Should not change active id due to defaultPrevented
+    expect(result.current.id).toBe('step1');
+  });
+});
+
+describe('getGroupProps', () => {
+  it('returns idle when no steps have a state', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.getGroupProps(['step1', 'step2']).state).toBe('idle');
+  });
+
+  it('returns idle for empty group', () => {
+    const { result } = renderHook(() => useFormNavigation());
+    expect(result.current.getGroupProps([]).state).toBe('idle');
+  });
+
+  it('returns completed when all steps are completed', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => {
+      result.current.markCompleted('step1');
+      result.current.markCompleted('step2');
+    });
+    expect(result.current.getGroupProps(['step1', 'step2']).state).toBe(
+      'completed',
+    );
+  });
+
+  it('returns completed only when all steps are completed', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'step3', order: [...order] }),
+    );
+    act(() => {
+      result.current.markCompleted('step1');
+      result.current.markCompleted('step2');
+      result.current.markCompleted('step3');
+    });
+    expect(
+      result.current.getGroupProps(['step1', 'step2', 'step3']).state,
+    ).toBe('completed');
+    // Test that partial completion doesn't return 'completed'
+    const { result: result2 } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => {
+      result2.current.markCompleted('step1');
+      result2.current.markCompleted('step2');
+      // step3 is not marked as completed
+    });
+    expect(
+      result2.current.getGroupProps(['step1', 'step2', 'step3']).state,
+    ).toBe('idle');
+  });
+
+  it('returns invalid when any step is invalid', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    act(() => {
+      result.current.markCompleted('step1');
+      result.current.markInvalid('step2');
+    });
+    expect(result.current.getGroupProps(['step1', 'step2']).state).toBe(
+      'invalid',
+    );
+  });
+});

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -497,4 +497,13 @@ describe('getGroupProps', () => {
       'invalid',
     );
   });
+
+  it('returns idle when group includes the active step without explicit state', () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    // step1 is active, step2 is completed — group is not fully completed
+    act(() => result.current.markCompleted('step2'));
+    expect(result.current.getGroupProps(['step1', 'step2']).state).toBe('idle');
+  });
 });

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -155,6 +155,33 @@ describe('next, prev', () => {
     expect(moved).toBe(false);
     expect(result.current.id).toBe('step1');
   });
+
+  it('navigates through all steps and stops at boundaries', async () => {
+    const { result } = renderHook(() =>
+      useFormNavigation({ order: [...order] }),
+    );
+    expect(result.current.id).toBe('step1');
+
+    await act(async () => result.current.next());
+    expect(result.current.id).toBe('step2');
+
+    await act(async () => result.current.next());
+    expect(result.current.id).toBe('step3');
+
+    const blocked = await act(async () => result.current.next());
+    expect(blocked).toBe(false);
+    expect(result.current.id).toBe('step3');
+
+    await act(async () => result.current.prev());
+    expect(result.current.id).toBe('step2');
+
+    await act(async () => result.current.prev());
+    expect(result.current.id).toBe('step1');
+
+    const blockedBack = await act(async () => result.current.prev());
+    expect(blockedBack).toBe(false);
+    expect(result.current.id).toBe('step1');
+  });
 });
 
 describe('navigation using implicit render order', () => {

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -25,6 +25,50 @@ describe('initial state', () => {
   });
 });
 
+describe('value not in order', () => {
+  it('warns when value is not in order', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    renderHook(() =>
+      useFormNavigation({ value: 'unknown', order: [...order] }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"unknown" is not included in order'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('navigation is stuck when value is not in order', async () => {
+    // Suppress expected warning from test output
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'unknown', order: [...order] }),
+    );
+    expect(result.current.id).toBe('unknown');
+    expect(result.current.hasNext()).toBe(false);
+    expect(result.current.hasPrev()).toBe(false);
+
+    const movedNext = await act(async () => result.current.next());
+    expect(movedNext).toBe(false);
+
+    const movedPrev = await act(async () => result.current.prev());
+    expect(movedPrev).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it('can recover from unknown value via setId', () => {
+    // Suppress expected warning from test output
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { result } = renderHook(() =>
+      useFormNavigation({ value: 'unknown', order: [...order] }),
+    );
+    act(() => result.current.setId('step2'));
+    expect(result.current.id).toBe('step2');
+    expect(result.current.hasNext()).toBe(true);
+    expect(result.current.hasPrev()).toBe(true);
+    vi.restoreAllMocks();
+  });
+});
+
 describe('setId', () => {
   it('updates the active step id', () => {
     const { result } = renderHook(() =>

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -62,89 +62,68 @@ describe('setId', () => {
 });
 
 describe('next, prev', () => {
-  it('next moves to the next step and returns true', () => {
+  it('next moves to the next step and returns true', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ order: [...order] }),
     );
-    let moved: boolean;
-    act(() => {
-      moved = result.current.next();
-    });
-    expect(moved!).toBe(true);
+    const moved = await act(async () => result.current.next());
+    expect(moved).toBe(true);
     expect(result.current.id).toBe('step2');
   });
 
-  it('next moves to first step when active step id is null and steps are available', () => {
+  it('next moves to first step when active step id is null and steps are available', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ order: [...order] }),
     );
     act(() => result.current.setId(null));
     expect(result.current.id).toBeNull();
-    let moved: boolean;
-    act(() => {
-      moved = result.current.next();
-    });
-    expect(moved!).toBe(true);
+    const moved = await act(async () => result.current.next());
+    expect(moved).toBe(true);
     expect(result.current.id).toBe('step1');
   });
 
-  it('next returns false when active step id is null and no steps available', () => {
+  it('next returns false when active step id is null and no steps available', async () => {
     const { result } = renderHook(() => useFormNavigation({ order: [] }));
-    let moved: boolean;
-    act(() => {
-      moved = result.current.next();
-    });
-    expect(moved!).toBe(false);
+    const moved = await act(async () => result.current.next());
+    expect(moved).toBe(false);
     expect(result.current.id).toBeNull();
   });
 
-  it('next returns false when called on the last step', () => {
+  it('next returns false when called on the last step', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ value: 'step3', order: [...order] }),
     );
-    let moved: boolean;
-    act(() => {
-      moved = result.current.next();
-    });
-    expect(moved!).toBe(false);
+    const moved = await act(async () => result.current.next());
+    expect(moved).toBe(false);
     expect(result.current.id).toBe('step3');
   });
 
-  it('prev moves to the previous step and returns true', () => {
+  it('prev moves to the previous step and returns true', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ value: 'step2', order: [...order] }),
     );
-    let moved: boolean;
-    act(() => {
-      moved = result.current.prev();
-    });
-    expect(moved!).toBe(true);
+    const moved = await act(async () => result.current.prev());
+    expect(moved).toBe(true);
     expect(result.current.id).toBe('step1');
   });
 
-  it('prev returns false when active step id is null', () => {
+  it('prev returns false when active step id is null', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ order: [...order] }),
     );
     act(() => result.current.setId(null));
     expect(result.current.id).toBeNull();
-    let moved: boolean;
-    act(() => {
-      moved = result.current.prev();
-    });
-    expect(moved!).toBe(false);
+    const moved = await act(async () => result.current.prev());
+    expect(moved).toBe(false);
     expect(result.current.id).toBeNull();
   });
 
-  it('prev returns false when called on the first step', () => {
+  it('prev returns false when called on the first step', async () => {
     const { result } = renderHook(() =>
       useFormNavigation({ order: [...order] }),
     );
-    let moved: boolean;
-    act(() => {
-      moved = result.current.prev();
-    });
-    expect(moved!).toBe(false);
+    const moved = await act(async () => result.current.prev());
+    expect(moved).toBe(false);
     expect(result.current.id).toBe('step1');
   });
 });

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -157,6 +157,40 @@ describe('next, prev', () => {
   });
 });
 
+describe('navigation using implicit render order', () => {
+  it('next and prev use order derived from getStepProps calls', async () => {
+    type StepId = 'charlie' | 'alpha' | 'bravo';
+    const { result } = renderHook(() =>
+      useFormNavigation<StepId>({ value: 'charlie' }),
+    );
+    // Register steps in non-alphabetical order
+    result.current.getStepProps('charlie');
+    result.current.getStepProps('alpha');
+    result.current.getStepProps('bravo');
+
+    const moved = await act(async () => result.current.next());
+    expect(moved).toBe(true);
+    expect(result.current.id).toBe('alpha');
+
+    const movedBack = await act(async () => result.current.prev());
+    expect(movedBack).toBe(true);
+    expect(result.current.id).toBe('charlie');
+  });
+
+  it('hasNext and hasPrev use order derived from getStepProps calls', () => {
+    type StepId = 'charlie' | 'alpha' | 'bravo';
+    const { result } = renderHook(() =>
+      useFormNavigation<StepId>({ value: 'alpha' }),
+    );
+    result.current.getStepProps('charlie');
+    result.current.getStepProps('alpha');
+    result.current.getStepProps('bravo');
+
+    expect(result.current.hasPrev()).toBe(true);
+    expect(result.current.hasNext()).toBe(true);
+  });
+});
+
 describe('hasNext, hasPrev', () => {
   it('hasNext is true when not on last step', () => {
     const { result } = renderHook(() =>

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.spec.ts
@@ -5,11 +5,6 @@ import { useFormNavigation } from './useFormNavigation';
 const order = ['step1', 'step2', 'step3'] as const;
 
 describe('initial state', () => {
-  it('returns no active step id when no value or order is given', () => {
-    const { result } = renderHook(() => useFormNavigation());
-    expect(result.current.id).toBeNull();
-  });
-
   it('uses value as initial active step id', () => {
     const { result } = renderHook(() =>
       useFormNavigation({ value: 'step2', order: [...order] }),
@@ -115,24 +110,6 @@ describe('next, prev', () => {
     expect(result.current.id).toBe('step2');
   });
 
-  it('next moves to first step when active step id is null and steps are available', async () => {
-    const { result } = renderHook(() =>
-      useFormNavigation({ order: [...order] }),
-    );
-    act(() => result.current.setId(null));
-    expect(result.current.id).toBeNull();
-    const moved = await act(async () => result.current.next());
-    expect(moved).toBe(true);
-    expect(result.current.id).toBe('step1');
-  });
-
-  it('next returns false when active step id is null and no steps available', async () => {
-    const { result } = renderHook(() => useFormNavigation({ order: [] }));
-    const moved = await act(async () => result.current.next());
-    expect(moved).toBe(false);
-    expect(result.current.id).toBeNull();
-  });
-
   it('next calls onChange with next and prev step id', async () => {
     const onChange = vi.fn();
     const { result } = renderHook(() =>
@@ -140,17 +117,6 @@ describe('next, prev', () => {
     );
     await act(async () => result.current.next());
     expect(onChange).toHaveBeenCalledWith('step2', 'step1');
-  });
-
-  it('next calls onChange with null as prev when active step id is null', async () => {
-    const onChange = vi.fn();
-    const { result } = renderHook(() =>
-      useFormNavigation({ order: [...order], onChange }),
-    );
-    act(() => result.current.setId(null));
-    onChange.mockClear();
-    await act(async () => result.current.next());
-    expect(onChange).toHaveBeenCalledWith('step1', null);
   });
 
   it('next returns false when called on the last step', async () => {
@@ -178,17 +144,6 @@ describe('next, prev', () => {
     );
     await act(async () => result.current.prev());
     expect(onChange).toHaveBeenCalledWith('step1', 'step2');
-  });
-
-  it('prev returns false when active step id is null', async () => {
-    const { result } = renderHook(() =>
-      useFormNavigation({ order: [...order] }),
-    );
-    act(() => result.current.setId(null));
-    expect(result.current.id).toBeNull();
-    const moved = await act(async () => result.current.prev());
-    expect(moved).toBe(false);
-    expect(result.current.id).toBeNull();
   });
 
   it('prev returns false when called on the first step', async () => {
@@ -290,19 +245,6 @@ describe('hasNext, hasPrev', () => {
     );
     expect(result.current.hasPrev()).toBe(true);
   });
-
-  it('hasPrev is false when activeId is null', () => {
-    const { result } = renderHook(() => useFormNavigation());
-    expect(result.current.hasPrev()).toBe(false);
-  });
-
-  it('hasNext is true when activeId is null and steps are available', () => {
-    const { result } = renderHook(() =>
-      useFormNavigation({ order: [...order] }),
-    );
-    act(() => result.current.setId(null));
-    expect(result.current.hasNext()).toBe(true);
-  });
 });
 
 describe('markCompleted, markInvalid, resetStep, reset', () => {
@@ -362,7 +304,7 @@ describe('getStepProps', () => {
   });
 
   it('throws error if no step id is provided', () => {
-    const { result } = renderHook(() => useFormNavigation());
+    const { result } = renderHook(() => useFormNavigation({ value: 'step1' }));
     expect(() => result.current.getStepProps({})).toThrow();
   });
 
@@ -442,7 +384,7 @@ describe('getGroupProps', () => {
   });
 
   it('returns idle for empty group', () => {
-    const { result } = renderHook(() => useFormNavigation());
+    const { result } = renderHook(() => useFormNavigation({ value: 'step1' }));
     expect(result.current.getGroupProps([]).state).toBe('idle');
   });
 

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.ts
@@ -1,29 +1,28 @@
-import type {
-  Dispatch,
-  ForwardedRef,
-  HTMLAttributes,
-  MouseEventHandler,
-  SetStateAction,
-} from 'react';
+import type { ForwardedRef, HTMLAttributes, MouseEventHandler } from 'react';
 import { useCallback, useRef, useState } from 'react';
 
 export type FormNavigationState = 'idle' | 'active' | 'completed' | 'invalid';
 
-export type UseFormNavigationProps<TId extends string = string> = {
-  /**
-   * Initial active step ID
-   */
-  value?: TId | null;
+type UseFormNavigationPropsBase<TId extends string = string> = {
   /**
    * Called when the active step changes
    */
-  onChange?: (nextId: TId, prevId: TId | null) => void;
-  /**
-   * Define the order of the steps. If not provided, the order
-   * will be determined by the order of `getStepProps` calls.
-   */
-  order?: TId[];
+  onChange?: (nextId: TId, prevId: TId) => void;
 };
+
+export type UseFormNavigationProps<TId extends string = string> =
+  | (UseFormNavigationPropsBase<TId> & {
+      /** Initial active step ID */
+      value: TId;
+      /** Define the order of the steps. If not provided, the order will be determined by the order of `getStepProps` calls. */
+      order?: TId[];
+    })
+  | (UseFormNavigationPropsBase<TId> & {
+      /** Initial active step ID. Defaults to the first step in `order`. */
+      value?: TId;
+      /** Define the order of the steps. */
+      order: [TId, ...TId[]];
+    });
 
 export type GetFormNavigationStepProps<TId extends string = string> = Omit<
   HTMLAttributes<HTMLButtonElement>,
@@ -45,11 +44,11 @@ export type UseFormNavigationReturn<TId extends string = string> = {
   /**
    * Active step ID
    */
-  id: TId | null;
+  id: TId;
   /**
    * Set active step ID
    */
-  setId: Dispatch<SetStateAction<TId | null>>;
+  setId: (next: TId | ((prev: TId) => TId)) => void;
   /**
    * Mark step as completed
    */
@@ -104,11 +103,6 @@ export type UseFormNavigationReturn<TId extends string = string> = {
   };
 };
 
-// Overloads for generic type inference
-export function useFormNavigation(
-  props?: UseFormNavigationProps<string>,
-): UseFormNavigationReturn<string>;
-
 export function useFormNavigation<TId extends string>(
   props: UseFormNavigationProps<TId>,
 ): UseFormNavigationReturn<TId>;
@@ -116,23 +110,23 @@ export function useFormNavigation<TId extends string>(
 /**
  * useFormNavigation – lightweight management for FormNavigation + FormNavigation.Step
  */
-export function useFormNavigation<TId extends string = string>({
-  value: initialId = null,
+export function useFormNavigation<TId extends string>({
+  value: initialId,
   onChange,
   order,
-}: UseFormNavigationProps<TId> = {}): UseFormNavigationReturn<TId> {
-  const [activeId, setActiveId] = useState<TId | null>(
-    initialId ?? (order?.[0] as TId | undefined) ?? null,
+}: UseFormNavigationProps<TId>): UseFormNavigationReturn<TId> {
+  const [activeId, setActiveId] = useState<TId>(
+    initialId ?? (order as TId[])[0],
   );
   const [stepStates, setStepStates] = useState<
     Record<TId, Exclude<FormNavigationState, 'active'>>
   >({} as Record<TId, Exclude<FormNavigationState, 'active'>>);
 
   if (
-    initialId != null &&
+    initialId !== undefined &&
     order &&
     order.length > 0 &&
-    !order.includes(initialId as TId)
+    !order.includes(initialId)
   ) {
     console.warn(
       `useFormNavigation: value "${String(initialId)}" is not included in order. Navigation will be stuck until a valid step is set via setId.`,
@@ -144,7 +138,7 @@ export function useFormNavigation<TId extends string = string>({
   const setId: UseFormNavigationReturn<TId>['setId'] = (next) => {
     setActiveId((prev) => {
       const nextValue = typeof next === 'function' ? next(prev) : next;
-      if (nextValue !== prev) onChange?.(nextValue as TId, prev);
+      if (nextValue !== prev) onChange?.(nextValue, prev);
       return nextValue;
     });
   };
@@ -221,36 +215,26 @@ export function useFormNavigation<TId extends string = string>({
   ) as TId[];
 
   const prev = () => {
-    if (!activeId) return false;
-    const i = effectiveOrder.indexOf(activeId as TId);
+    const i = effectiveOrder.indexOf(activeId);
     if (i <= 0) return false;
     setId(effectiveOrder[i - 1]);
     return true;
   };
 
   const next = () => {
-    if (!activeId) {
-      if (effectiveOrder.length > 0) {
-        setId(effectiveOrder[0]);
-        return true;
-      }
-      return false;
-    }
-    const i = effectiveOrder.indexOf(activeId as TId);
+    const i = effectiveOrder.indexOf(activeId);
     if (i === -1 || i >= effectiveOrder.length - 1) return false;
     setId(effectiveOrder[i + 1]);
     return true;
   };
 
   const hasPrev = () => {
-    if (!activeId) return false;
-    const index = effectiveOrder.indexOf(activeId as TId);
+    const index = effectiveOrder.indexOf(activeId);
     return index > 0;
   };
 
   const hasNext = () => {
-    if (!activeId) return effectiveOrder.length > 0;
-    const index = effectiveOrder.indexOf(activeId as TId);
+    const index = effectiveOrder.indexOf(activeId);
     return index > -1 && index < effectiveOrder.length - 1;
   };
 

--- a/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.ts
+++ b/@udir-design/react/src/hooks/useFormNavigation/useFormNavigation.ts
@@ -128,6 +128,17 @@ export function useFormNavigation<TId extends string = string>({
     Record<TId, Exclude<FormNavigationState, 'active'>>
   >({} as Record<TId, Exclude<FormNavigationState, 'active'>>);
 
+  if (
+    initialId != null &&
+    order &&
+    order.length > 0 &&
+    !order.includes(initialId as TId)
+  ) {
+    console.warn(
+      `useFormNavigation: value "${String(initialId)}" is not included in order. Navigation will be stuck until a valid step is set via setId.`,
+    );
+  }
+
   const renderOrderRef = useRef<TId[]>([]);
 
   const setId: UseFormNavigationReturn<TId>['setId'] = (next) => {


### PR DESCRIPTION
## Hva er gjort?

Lagt til unit tester for `useFormNavigation`

### Endring i API

Testene avdekket mulighet for runtime-feil fordi vi tillot at "nåværende steg" var `null`. Endret APIet med en BREAKING CHANGE for å sørge for at dette ikke kan skje.

## Sjekkliste

- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Dokumentasjon er oppdatert 