### PR TITLE
feat: promote 10 components from beta to stable (batch 3)

### DIFF
--- a/@udir-design/react/demo-pages/article-demo/ArticleDemo.module.css
+++ b/@udir-design/react/demo-pages/article-demo/ArticleDemo.module.css
@@ -23,6 +23,12 @@
   gap: var(--ds-size-13);
 }
 
+.breadcrumbs {
+  max-width: 80rem;
+  margin: 0 auto;
+  width: 100%;
+}
+
 .contentWrapper {
   max-width: 50rem;
   margin: 0 auto;

--- a/@udir-design/react/demo-pages/article-demo/ArticleDemo.tsx
+++ b/@udir-design/react/demo-pages/article-demo/ArticleDemo.tsx
@@ -34,7 +34,7 @@ export const ArticleDemo = () => {
       aria-label="Tilpasset opplæring"
       className={cl(classes.article, classes.contentSpacing)}
     >
-      <Breadcrumbs aria-label="Du er her:">
+      <Breadcrumbs aria-label="Du er her:" className={classes.breadcrumbs}>
         <Breadcrumbs.Link
           href="https://www.udir.no/laring-og-trivsel/lareplanverket/stotte/"
           aria-label="Tilbake til Støtte til arbeid med læreplanverket"

--- a/@udir-design/react/src/components/badge/Badge.mdx
+++ b/@udir-design/react/src/components/badge/Badge.mdx
@@ -60,8 +60,9 @@ Det er vanleg å bruke raud farge, altså `data-color="danger"` på `Badge` som 
 
 <Canvas of={BadgeStories.Floating} />
 
-Ikkje alle ikon har lik form, og då må du kanskje endre kor `Badge` skal plasserast. Dersom du ikkje får `Badge` til å liggje der du ynskjer, kan du bruke css-variablar for å overstyre plasseringa.
-Dette fungerer og når du brukar `overlap="circle"`.
+Ikkje alle ikon har lik form, og då må du kanskje endre kor `Badge` skal plasserast. Dersom du ikkje får `Badge` til å liggje der du ynskjer, kan du bruke css-variablar for å overstyre plasseringa. Dette fungerer og når du brukar `overlap="circle"`.
+
+Det finst ikkje automatisk støtte for å spegle plassering av `badge` ved bruk av `dir="rtl"`. Du må sjølv overstyre plasseringa med css-variablar avhengig av kva for eit språk som er vald.
 
 <Canvas of={BadgeStories.CustomPlacement} />
 

--- a/@udir-design/react/src/components/badge/Badge.mdx
+++ b/@udir-design/react/src/components/badge/Badge.mdx
@@ -10,7 +10,7 @@ import * as BadgeStories from './Badge.stories';
 **Passar til å**
 
 - vise antal nye meldingar, varsel eller oppgåver med tal
-- vise statusindikatorar i form av ein sirkel, som til dømes viser om ein person er opptatt, borte eller aktiv
+- vise statusindikatorar i form av ein sirkel, som til dømes viser om ein person er oppteken, borte eller aktiv
 
 **Passar ikkje til å**
 
@@ -39,13 +39,13 @@ import { Badge } from '@udir-design/react';
 
 ### Fargar
 
-`Badge` finst i neutral, i tillegg til varselfargane. Du kan endre fargen med `data-color`. Du kan òg setje `variant` direkte for å endre bakgrunnsfargen til `tinted` variant, som er noko lysare.
+`Badge` finst i neutral, i tillegg til varselfargane. Du kan endre fargen med `data-color`. Du kan òg setje `variant` til `tinted`, denne varianten har ei bakgrunnsfarge som er noko lysare.
 
 Fordi raud er godt etablert som farge for å indikere notifikasjonar, vik den tilrådde bruken her noko frå standard semantikk for varselfargar. For notifikasjonar plasserte på ikon eller avatarar blir fargen `danger` tilrådd. Ved bruk inline er hovudregelen å nytte `neutral`. I enkelte tilfelle kan det vere aktuelt å nytte dei andre varselfargane.
 
 <Canvas of={BadgeStories.ColorVariants} />
 
-### Vise staus
+### Vise status
 
 Dersom du ikkje sender inn `count`, blir berre ein sirkel vist. Dette kan brukast for å vise status.
 
@@ -61,7 +61,7 @@ Det er vanleg å bruke raud farge, altså `data-color="danger"` på `Badge` som 
 <Canvas of={BadgeStories.Floating} />
 
 Ikkje alle ikon har lik form, og då må du kanskje endre kor `Badge` skal plasserast. Dersom du ikkje får `Badge` til å liggje der du ynskjer, kan du bruke css-variablar for å overstyre plasseringa.
-Dette fungerer og når du bruker `overlap="circle"`.
+Dette fungerer og når du brukar `overlap="circle"`.
 
 <Canvas of={BadgeStories.CustomPlacement} />
 
@@ -71,7 +71,7 @@ Du kan òg bruke komponenten inline.
 
 <Canvas of={BadgeStories.InTabs} />
 
-Under ser du et eksempel på bruk av varselfargene til `Badge` inline.
+Under ser du eit eksempel på bruk av varselfargane til `Badge` inline.
 
 <Canvas of={BadgeStories.SystemAlerts} />
 
@@ -83,7 +83,7 @@ Bruk `Badge` for å trekkje merksemd mot statusar, varslar eller tal.
 
 Denne komponenten er ikkje meint for tekst. Om du treng å vise ord eller korte frasar, bør du heller bruke [`Tag`](/docs/components-tag--docs)-komponenten.
 
-## Tilgjengeligheit
+## Tilgjengelegheit
 
 [Badge gir ingen informasjon til skjermlesarar](https://github.com/digdir/designsystemet/issues/3560).
 Sørg derfor for at elementet som `Badge` er plassert over, inneheld den same informasjonen ved å bruke `aria-label`.

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -22,7 +22,7 @@ const meta = preview.meta({
   subcomponents: {
     'Badge.Position': BadgePosition,
   },
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -26,8 +26,7 @@ const meta = preview.meta({
   parameters: {
     componentOrigin: {
       originator: 'digdir',
-      details:
-        'Vi har begrenset fargevalg til varselfarger og Udirs hovedfarger.',
+      details: 'Vi har begrenset fargevalg til varselfarger og neutral.',
     },
     customStyles: {
       display: 'flex',

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -275,8 +275,8 @@ export const SystemAlerts = meta.story({
             <Badge count={2} maxCount={9} data-color="danger" {...args} />
           </Details.Summary>
           <Details.Content className="example-details-content">
-            {Array.from({ length: 2 }, (_) => (
-              <Varsel importance="danger" />
+            {Array.from({ length: 2 }, (_, i) => (
+              <Varsel key={i} importance="danger" />
             ))}
           </Details.Content>
         </Details>
@@ -286,8 +286,8 @@ export const SystemAlerts = meta.story({
             <Badge count={6} maxCount={9} data-color="warning" {...args} />
           </Details.Summary>
           <Details.Content className="example-details-content">
-            {Array.from({ length: 6 }, (_) => (
-              <Varsel importance="warning" />
+            {Array.from({ length: 6 }, (_, i) => (
+              <Varsel key={i} importance="warning" />
             ))}
           </Details.Content>
         </Details>
@@ -297,8 +297,8 @@ export const SystemAlerts = meta.story({
             <Badge count={11} maxCount={9} data-color="info" {...args} />
           </Details.Summary>
           <Details.Content className="example-details-content">
-            {Array.from({ length: 11 }, (_) => (
-              <Varsel importance="info" />
+            {Array.from({ length: 11 }, (_, i) => (
+              <Varsel key={i} importance="info" />
             ))}
           </Details.Content>
         </Details>

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -119,10 +119,10 @@ export const CustomPlacement = meta.story({
 export const Status = meta.story({
   args: { 'data-color': 'danger' },
   render: (args) => (
-      <Badge.Position data-size="lg">
-        <Badge {...args} />
-        <FloppydiskFillIcon title="Lagre" />
-      </Badge.Position>
+    <Badge.Position data-size="lg">
+      <Badge {...args} />
+      <FloppydiskFillIcon title="Lagre" />
+    </Badge.Position>
   ),
 });
 
@@ -268,12 +268,11 @@ export const SystemAlerts = meta.story({
 }`}
       </style>
       <div className="example-main">
-        <Heading className="example-heading">
-          Systemvarsler
-        </Heading>
+        <Heading className="example-heading">Systemvarsler</Heading>
         <Details>
           <Details.Summary>
-            Kritisk <Badge count={2} maxCount={9} data-color="danger" {...args}/>
+            Kritisk{' '}
+            <Badge count={2} maxCount={9} data-color="danger" {...args} />
           </Details.Summary>
           <Details.Content className="example-details-content">
             {Array.from({ length: 2 }, (_) => (
@@ -283,7 +282,8 @@ export const SystemAlerts = meta.story({
         </Details>
         <Details>
           <Details.Summary>
-            Advarsler <Badge count={6} maxCount={9} data-color="warning" {...args}/>
+            Advarsler{' '}
+            <Badge count={6} maxCount={9} data-color="warning" {...args} />
           </Details.Summary>
           <Details.Content className="example-details-content">
             {Array.from({ length: 6 }, (_) => (
@@ -293,12 +293,13 @@ export const SystemAlerts = meta.story({
         </Details>
         <Details>
           <Details.Summary>
-            Andre hendelser <Badge count={11} maxCount={9} data-color="info" {...args}/>
+            Andre hendelser{' '}
+            <Badge count={11} maxCount={9} data-color="info" {...args} />
           </Details.Summary>
           <Details.Content className="example-details-content">
-              {Array.from({ length: 11 }, (_) => (
-                <Varsel importance="info" />
-              ))}
+            {Array.from({ length: 11 }, (_) => (
+              <Varsel importance="info" />
+            ))}
           </Details.Content>
         </Details>
       </div>

--- a/@udir-design/react/src/components/badge/Badge.stories.tsx
+++ b/@udir-design/react/src/components/badge/Badge.stories.tsx
@@ -54,6 +54,14 @@ export const Floating = meta.story({
   },
   render: (args) => (
     <>
+      <style>
+        {`
+.example-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+}`}
+      </style>
       <Badge.Position placement="top-right">
         <Badge {...args} />
         <EnvelopeClosedFillIcon title="Meldinger" />
@@ -72,47 +80,19 @@ export const Floating = meta.story({
       </Badge.Position>
       <Badge.Position placement="top-right" overlap="circle">
         <Badge {...args} />
-        <Avatar
-          style={{
-            width: '2rem',
-            height: '2rem',
-            borderRadius: '50%',
-          }}
-          aria-label={'Avatar 1'}
-        />
+        <Avatar className="example-avatar" aria-label={'Avatar 1'} />
       </Badge.Position>
       <Badge.Position placement="top-left" overlap="circle">
         <Badge {...args} />
-        <Avatar
-          style={{
-            width: '2rem',
-            height: '2rem',
-            borderRadius: '50%',
-          }}
-          aria-label={'Avatar 1'}
-        />
+        <Avatar className="example-avatar" aria-label={'Avatar 1'} />
       </Badge.Position>
       <Badge.Position placement="bottom-right" overlap="circle">
         <Badge {...args} />
-        <Avatar
-          style={{
-            width: '2rem',
-            height: '2rem',
-            borderRadius: '50%',
-          }}
-          aria-label={'Avatar 1'}
-        />
+        <Avatar className="example-avatar" aria-label={'Avatar 1'} />
       </Badge.Position>
       <Badge.Position placement="bottom-left" overlap="circle">
         <Badge {...args} />
-        <Avatar
-          style={{
-            width: '2rem',
-            height: '2rem',
-            borderRadius: '50%',
-          }}
-          aria-label={'Avatar 1'}
-        />
+        <Avatar className="example-avatar" aria-label={'Avatar 1'} />
       </Badge.Position>
     </>
   ),
@@ -139,12 +119,10 @@ export const CustomPlacement = meta.story({
 export const Status = meta.story({
   args: { 'data-color': 'danger' },
   render: (args) => (
-    <div>
       <Badge.Position data-size="lg">
         <Badge {...args} />
         <FloppydiskFillIcon title="Lagre" />
       </Badge.Position>
-    </div>
   ),
 });
 
@@ -252,7 +230,7 @@ const ColorsMap: {
 };
 
 export const ColorVariants = meta.story({
-  render: () => (
+  render: (args) => (
     <div
       style={{
         display: 'grid',
@@ -264,69 +242,67 @@ export const ColorVariants = meta.story({
       }}
     >
       {Object.entries(ColorsMap).map(([key, value]) => (
-        <Badge key={key} {...value} count={15} maxCount={9} />
+        <Badge key={key} {...value} count={15} maxCount={9} {...args} />
       ))}
     </div>
   ),
 });
 
 export const SystemAlerts = meta.story({
-  render: () => (
-    <div style={{ display: 'flex', flexDirection: 'column', width: '30rem' }}>
-      <Heading style={{ marginBlockEnd: 'var(--ds-size-4' }}>
-        Systemvarsler
-      </Heading>
-      <Details>
-        <Details.Summary>
-          Kritisk <Badge count={2} maxCount={9} data-color="danger" />
-        </Details.Summary>
-        <Details.Content
-          style={{
-            gap: 'var(--ds-size-4)',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          {Array.from({ length: 2 }, (_, index) => (
-            <Varsel key={index} importance="danger" />
-          ))}
-        </Details.Content>
-      </Details>
-      <Details>
-        <Details.Summary>
-          Advarsler <Badge count={6} maxCount={9} data-color="warning" />
-        </Details.Summary>
-        <Details.Content
-          style={{
-            gap: 'var(--ds-size-4)',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          {Array.from({ length: 6 }, (_, index) => (
-            <Varsel key={index} importance="warning" />
-          ))}
-        </Details.Content>
-      </Details>
-      <Details>
-        <Details.Summary>
-          Andre hendelser <Badge count={11} maxCount={9} data-color="info" />
-        </Details.Summary>
-        <Details.Content>
-          <Details.Content
-            style={{
-              gap: 'var(--ds-size-4)',
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            {Array.from({ length: 11 }, (_, index) => (
-              <Varsel key={index} importance="info" />
+  render: (args) => (
+    <>
+      <style>
+        {`
+.example-main {
+  display: flex;
+  flex-direction: column;
+  width: 30rem;
+}
+.example-heading {
+  margin-block-end: var(--ds-size-4);
+}
+.example-details-content {
+  gap: var(--ds-size-4);
+  display: flex;
+  flex-direction: column;
+}`}
+      </style>
+      <div className="example-main">
+        <Heading className="example-heading">
+          Systemvarsler
+        </Heading>
+        <Details>
+          <Details.Summary>
+            Kritisk <Badge count={2} maxCount={9} data-color="danger" {...args}/>
+          </Details.Summary>
+          <Details.Content className="example-details-content">
+            {Array.from({ length: 2 }, (_) => (
+              <Varsel importance="danger" />
             ))}
           </Details.Content>
-        </Details.Content>
-      </Details>
-    </div>
+        </Details>
+        <Details>
+          <Details.Summary>
+            Advarsler <Badge count={6} maxCount={9} data-color="warning" {...args}/>
+          </Details.Summary>
+          <Details.Content className="example-details-content">
+            {Array.from({ length: 6 }, (_) => (
+              <Varsel importance="warning" />
+            ))}
+          </Details.Content>
+        </Details>
+        <Details>
+          <Details.Summary>
+            Andre hendelser <Badge count={11} maxCount={9} data-color="info" {...args}/>
+          </Details.Summary>
+          <Details.Content className="example-details-content">
+              {Array.from({ length: 11 }, (_) => (
+                <Varsel importance="info" />
+              ))}
+          </Details.Content>
+        </Details>
+      </div>
+    </>
   ),
 });
 

--- a/@udir-design/react/src/components/badge/__snapshots__/Badge.stories.tsx.snap
+++ b/@udir-design/react/src/components/badge/__snapshots__/Badge.stories.tsx.snap
@@ -101,6 +101,13 @@ exports[`Custom Placement 1`] = `
 `;
 
 exports[`Floating 1`] = `
+<style>
+  .example-avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+}
+</style>
 <span
   data-overlap="rectangle"
   data-placement="top-right"
@@ -238,7 +245,6 @@ exports[`Floating 1`] = `
     data-variant="circle"
     role="img"
     aria-label="Avatar 1"
-    style="<removed>"
   >
   </span>
 </span>
@@ -255,7 +261,6 @@ exports[`Floating 1`] = `
     data-variant="circle"
     role="img"
     aria-label="Avatar 1"
-    style="<removed>"
   >
   </span>
 </span>
@@ -272,7 +277,6 @@ exports[`Floating 1`] = `
     data-variant="circle"
     role="img"
     aria-label="Avatar 1"
-    style="<removed>"
   >
   </span>
 </span>
@@ -289,7 +293,6 @@ exports[`Floating 1`] = `
     data-variant="circle"
     role="img"
     aria-label="Avatar 1"
-    style="<removed>"
   >
   </span>
 </span>
@@ -468,45 +471,58 @@ exports[`Preview 1`] = `
 `;
 
 exports[`Status 1`] = `
-<div>
+<span
+  data-overlap="rectangle"
+  data-placement="top-right"
+  data-size="lg"
+>
   <span
-    data-overlap="rectangle"
-    data-placement="top-right"
-    data-size="lg"
+    data-variant="base"
+    data-color="danger"
   >
-    <span
-      data-variant="base"
-      data-color="danger"
-    >
-    </span>
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
-      fill="none"
-      viewbox="0 0 24 24"
-      focusable="false"
-      role="img"
-      aria-labelledby="<removed>"
-    >
-      <title id="<removed>">
-        Lagre
-      </title>
-      <path
-        fill="currentColor"
-        fill-rule="evenodd"
-        d="M4 3.25h2.75a.5.5 0 0 1 .5.5V7c0 .414.336.75.75.75h8a.75.75 0 0 0 .75-.75V3.75a.5.5 0 0 1 .5-.5H18a.75.75 0 0 1 .53.22l2 2c.141.14.22.331.22.53v14a.75.75 0 0 1-.75.75h-1.75a.5.5 0 0 1-.5-.5V11a.75.75 0 0 0-.75-.75H7a.75.75 0 0 0-.75.75v9.25a.5.5 0 0 1-.5.5H4a.75.75 0 0 1-.75-.75V4A.75.75 0 0 1 4 3.25m12.25 17a.5.5 0 0 1-.5.5h-7.5a.5.5 0 0 1-.5-.5v-8a.5.5 0 0 1 .5-.5h7.5a.5.5 0 0 1 .5.5zm-7.5-16.5a.5.5 0 0 1 .5-.5h5.5a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.5.5h-5.5a.5.5 0 0 1-.5-.5zM9.25 14a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75m.75 2.25a.75.75 0 0 0 0 1.5h3a.75.75 0 0 0 0-1.5z"
-        clip-rule="evenodd"
-      >
-      </path>
-    </svg>
   </span>
-</div>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    fill="none"
+    viewbox="0 0 24 24"
+    focusable="false"
+    role="img"
+    aria-labelledby="<removed>"
+  >
+    <title id="<removed>">
+      Lagre
+    </title>
+    <path
+      fill="currentColor"
+      fill-rule="evenodd"
+      d="M4 3.25h2.75a.5.5 0 0 1 .5.5V7c0 .414.336.75.75.75h8a.75.75 0 0 0 .75-.75V3.75a.5.5 0 0 1 .5-.5H18a.75.75 0 0 1 .53.22l2 2c.141.14.22.331.22.53v14a.75.75 0 0 1-.75.75h-1.75a.5.5 0 0 1-.5-.5V11a.75.75 0 0 0-.75-.75H7a.75.75 0 0 0-.75.75v9.25a.5.5 0 0 1-.5.5H4a.75.75 0 0 1-.75-.75V4A.75.75 0 0 1 4 3.25m12.25 17a.5.5 0 0 1-.5.5h-7.5a.5.5 0 0 1-.5-.5v-8a.5.5 0 0 1 .5-.5h7.5a.5.5 0 0 1 .5.5zm-7.5-16.5a.5.5 0 0 1 .5-.5h5.5a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-.5.5h-5.5a.5.5 0 0 1-.5-.5zM9.25 14a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75m.75 2.25a.75.75 0 0 0 0 1.5h3a.75.75 0 0 0 0-1.5z"
+      clip-rule="evenodd"
+    >
+    </path>
+  </svg>
+</span>
 `;
 
 exports[`System Alerts 1`] = `
-<div style="<removed>">
-  <h2 style="<removed>">
+<style>
+  .example-main {
+  display: flex;
+  flex-direction: column;
+  width: 30rem;
+}
+.example-heading {
+  margin-block-end: var(--ds-size-4);
+}
+.example-details-content {
+  gap: var(--ds-size-4);
+  display: flex;
+  flex-direction: column;
+}
+</style>
+<div>
+  <h2>
     Systemvarsler
   </h2>
   <details data-variant="default">
@@ -519,7 +535,7 @@ exports[`System Alerts 1`] = `
       >
       </span>
     </summary>
-    <div style="<removed>">
+    <div>
       <div data-variant="default">
         <div style="<removed>">
           <h3 data-size="xs">
@@ -566,7 +582,7 @@ exports[`System Alerts 1`] = `
       >
       </span>
     </summary>
-    <div style="<removed>">
+    <div>
       <div data-variant="default">
         <div style="<removed>">
           <h3 data-size="xs">
@@ -682,117 +698,115 @@ exports[`System Alerts 1`] = `
       </span>
     </summary>
     <div>
-      <div style="<removed>">
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
-        <div data-variant="default">
-          <div style="<removed>">
-            <h3 data-size="xs">
-              Varsel
-            </h3>
-          </div>
-          <p data-variant="default">
-            Dette er et varsel.
-          </p>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
+      </div>
+      <div data-variant="default">
+        <div style="<removed>">
+          <h3 data-size="xs">
+            Varsel
+          </h3>
         </div>
+        <p data-variant="default">
+          Dette er et varsel.
+        </p>
       </div>
     </div>
   </details>

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -13,7 +13,6 @@ export * from './errorSummary/ErrorSummary';
 export * from './formNavigation';
 export * from './header';
 export * from './pagination/Pagination';
-export * from './progressBar/ProgressBar';
 export * from './readMore/ReadMore';
 export * from './select/Select';
 export * from './skeleton/Skeleton';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -18,7 +18,6 @@ export * from './readMore/ReadMore';
 export * from './select/Select';
 export * from './skeleton/Skeleton';
 export * from './tableOfContents/TableOfContents';
-export * from './tabs/Tabs';
 export * from './textarea/Textarea';
 export * from './table';
 export * from './textfield/Textfield';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -7,7 +7,6 @@ export * from './badge/Badge';
 export * from './breadcrumbs/Breadcrumbs';
 export * from './chip/Chip';
 export * from './demoBanner/DemoBanner';
-export * from './dialog/Dialog';
 export * from './dropdown/Dropdown';
 export * from './errorSummary/ErrorSummary';
 export * from './formNavigation';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -19,7 +19,6 @@ export * from './select/Select';
 export * from './skeleton/Skeleton';
 export * from './tableOfContents/TableOfContents';
 export * from './tabs/Tabs';
-export * from './textarea/Textarea';
 export * from './table';
 export * from './textfield/Textfield';
 export * from './toggleGroup';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -17,7 +17,6 @@ export * from './progressBar/ProgressBar';
 export * from './readMore/ReadMore';
 export * from './select/Select';
 export * from './skeleton/Skeleton';
-export * from './tableOfContents/TableOfContents';
 export * from './tabs/Tabs';
 export * from './textarea/Textarea';
 export * from './table';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -3,12 +3,8 @@
  */
 
 export * from './alert';
-export * from './badge/Badge';
-export * from './breadcrumbs/Breadcrumbs';
 export * from './chip/Chip';
 export * from './demoBanner/DemoBanner';
-export * from './dialog/Dialog';
-export * from './dropdown/Dropdown';
 export * from './errorSummary/ErrorSummary';
 export * from './formNavigation';
 export * from './header';
@@ -16,8 +12,6 @@ export * from './pagination/Pagination';
 export * from './readMore/ReadMore';
 export * from './select/Select';
 export * from './skeleton/Skeleton';
-export * from './tableOfContents/TableOfContents';
-export * from './tabs/Tabs';
 export * from './table';
 export * from './toggleGroup';
 export * from './typography/prose/Prose';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -8,7 +8,6 @@ export * from './breadcrumbs/Breadcrumbs';
 export * from './chip/Chip';
 export * from './demoBanner/DemoBanner';
 export * from './dialog/Dialog';
-export * from './dropdown/Dropdown';
 export * from './errorSummary/ErrorSummary';
 export * from './formNavigation';
 export * from './header';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -21,7 +21,6 @@ export * from './tableOfContents/TableOfContents';
 export * from './tabs/Tabs';
 export * from './textarea/Textarea';
 export * from './table';
-export * from './textfield/Textfield';
 export * from './toggleGroup';
 export * from './tooltip/Tooltip';
 export * from './typography/prose/Prose';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -4,7 +4,6 @@
 
 export * from './alert';
 export * from './badge/Badge';
-export * from './breadcrumbs/Breadcrumbs';
 export * from './chip/Chip';
 export * from './demoBanner/DemoBanner';
 export * from './dialog/Dialog';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -23,5 +23,4 @@ export * from './textarea/Textarea';
 export * from './table';
 export * from './textfield/Textfield';
 export * from './toggleGroup';
-export * from './tooltip/Tooltip';
 export * from './typography/prose/Prose';

--- a/@udir-design/react/src/components/beta.ts
+++ b/@udir-design/react/src/components/beta.ts
@@ -3,7 +3,6 @@
  */
 
 export * from './alert';
-export * from './badge/Badge';
 export * from './breadcrumbs/Breadcrumbs';
 export * from './chip/Chip';
 export * from './demoBanner/DemoBanner';

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -44,7 +44,7 @@ Vi bruker `Breadcrumbs` til å hjelpe brukerne å forstå hvor de er i en hierar
 
 ### Sti eller tilbake-knapp basert på skjermstørrelse
 
-Hvis du legger både en `Breadcrumbs.Link` og en `Breadcrumbs.List` direkte i `Breadcrumbs`, vil tilbake-knapp vises på skjermer smalere enn 650px, og sti vises ellers. Dette er ofte den beste løsningen fordi den gir god plass og brukervennlighet på alle skjermer.
+Hvis du legger både en `Breadcrumbs.Link` og en `Breadcrumbs.List` direkte i `Breadcrumbs`, vil en tilbake-knapp vises på skjermer smalere enn 650px, og en sti vises ellers. Dette er ofte den beste løsningen fordi den gir god plass og brukervennlighet på alle skjermer.
 
 <Canvas of={BreadcrumbsStories.Preview} />
 
@@ -56,7 +56,7 @@ Hvis du legger en `Breadcrumbs.List` direkte i `Breadcrumbs`, vil denne vises so
 
 ### Kun tilbake-knapp
 
-Hvis du legger en `Breadcrumbs.Link` direkte i `Breadcrumbs`, vil denne lenken vises som en tilbake-knapp. Det kan for eksempel benyttes for å spare plass. Det er viktig at du er konsistent i din løsning og bruker enten tilbake-knapp eller sti.
+Hvis du legger en `Breadcrumbs.Link` direkte i `Breadcrumbs`, vil denne lenken vises som en tilbake-knapp. Dette kan for eksempel benyttes for å spare plass. Det er viktig at du er konsistent i din løsning og bruker enten tilbake-knapp eller sti.
 
 <Canvas of={BreadcrumbsStories.BackOnly} />
 
@@ -84,6 +84,6 @@ Bruk korte og tydelige navn i brødsmulestien, slik at brukerne raskt forstår h
 
 Den siste lenken skal tilsvare den nåværende siden. Den ser ut som vanlig tekst, men er kodet som en lenke med aria-current="page". På den måten får skjermlesere korrekt informasjon om hvilken side brukeren er på, uten at andre brukere feilaktig oppfatter det som en klikkbar lenke.
 
-Pass på at at det ikke ligger andre interaktive elementer for nær `Breadcrumbs`, og at det ikke er noen skjulte elementer som kan forstyrre navigasjonen.
+Pass på at det ikke ligger andre interaktive elementer for nær `Breadcrumbs`, og at det ikke er noen skjulte elementer som kan forstyrre navigasjonen.
 
 Sørg for [`SkipLink`](/docs/components-skiplink--docs) hopper over `Breadcrumbs`, slik at tastaturnavigerende brukere slipper å tabbe gjennom hvert punkt før de når hovedinnholdet på siden.

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -62,13 +62,19 @@ Hvis du legger en `Breadcrumbs.Link` direkte i `Breadcrumbs`, vil denne lenken v
 
 ## Retningslinjer
 
-Følg disse retningslinjene når du bruker `Breadcrumbs`:
+Det er først når det er tre eller flere nivåer at det er behov for `Breadcrumbs`.
+Hvis det er færre enn tre nivåer, kan du bruke en [`Link`](/docs/components-link--docs) i stedet.
 
-- Det er først når det er tre eller flere nivåer at det er behov for `Breadcrumbs`.
-  Hvis det er færre enn tre nivåer, kan du bruke en [`Link`](/docs/components-link--docs) i stedet.
+### Plassering
 
 - `Breadcrumbs` skal alltid plasseres øverst på venstre del av siden.
   Den skal være under menyen og hovednavigasjonen, men over sidetittelen.
+- `Breadcrumbs` skal ha samme bredde som innholdet i [`Header`](/docs/components-header--docs). Du kan sette `max-width: 80rem` på `Breadcrumbs`, og sentrere den ved å sette `margin: 0 auto`.
+
+<Canvas
+  story={{ inline: false, height: '200px' }}
+  of={BreadcrumbsStories.PlacementWithHeader}
+/>
 
 ## Tekst i Breadcrumbs
 

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -86,4 +86,4 @@ Den siste lenken skal tilsvare den nåværende siden. Den ser ut som vanlig teks
 
 Pass på at det ikke ligger andre interaktive elementer for nær `Breadcrumbs`, og at det ikke er noen skjulte elementer som kan forstyrre navigasjonen.
 
-Sørg for [`SkipLink`](/docs/components-skiplink--docs) hopper over `Breadcrumbs`, slik at tastaturnavigerende brukere slipper å tabbe gjennom hvert punkt før de når hovedinnholdet på siden.
+Sørg for at [`SkipLink`](/docs/components-skiplink--docs) hopper over `Breadcrumbs`, slik at tastaturnavigerende brukere slipper å tabbe seg gjennom hvert punkt før de når hovedinnholdet på siden.

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import { expect, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { Header } from '../header';
 import { Breadcrumbs } from './Breadcrumbs';
 import { BreadcrumbsItem } from './docs/FakeBreadcrumbsItem';
 import { BreadcrumbsLink } from './docs/FakeBreadcrumbsLink';
@@ -150,4 +151,45 @@ export const MobileViewport = meta.story({
   globals: {
     viewport: { value: 'iphone6' },
   },
+});
+
+export const PlacementWithHeader = meta.story({
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => (
+    <>
+      <style>
+        {`
+        /* Styles defined in application-specific css */
+        .content {
+          max-width: 80rem;
+          margin: var(--ds-size-4) auto 0;
+          padding: 0 var(--ds-size-5);
+        }
+        `}
+      </style>
+      <Header applicationName="Tjenestenavn">
+        <Header.MenuButton />
+      </Header>
+      <div className="content">
+        <Breadcrumbs {...args}>
+          <Breadcrumbs.Link href="#" aria-label="Tilbake til Utdanningsløpet">
+            Utdanningsløpet
+          </Breadcrumbs.Link>
+          <Breadcrumbs.List>
+            <Breadcrumbs.Item>
+              <Breadcrumbs.Link href="#">Forside</Breadcrumbs.Link>
+            </Breadcrumbs.Item>
+            <Breadcrumbs.Item>
+              <Breadcrumbs.Link href="#">Utdanningsløpet</Breadcrumbs.Link>
+            </Breadcrumbs.Item>
+            <Breadcrumbs.Item>
+              <Breadcrumbs.Link href="#">Grunnskole</Breadcrumbs.Link>
+            </Breadcrumbs.Item>
+          </Breadcrumbs.List>
+        </Breadcrumbs>
+      </div>
+    </>
+  ),
 });

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -12,7 +12,7 @@ const meta = preview.meta({
     'Breadcrumbs.List': BreadcrumbsList,
     'Breadcrumbs.Item': BreadcrumbsItem,
   },
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -70,6 +70,11 @@ export const Preview = meta.story({
     await step('List should have expected number of items', async () => {
       await expect(canvas.getAllByRole('listitem')).toHaveLength(3);
     });
+
+    await step('Last breadcrumb should have aria-current="page"', async () => {
+      const lastLink = canvas.getByRole('link', { name: /Grunnskole/i });
+      await expect(lastLink).toHaveAttribute('aria-current', 'page');
+    });
   },
 });
 

--- a/@udir-design/react/src/components/breadcrumbs/__snapshots__/Breadcrumbs.stories.tsx.snap
+++ b/@udir-design/react/src/components/breadcrumbs/__snapshots__/Breadcrumbs.stories.tsx.snap
@@ -124,6 +124,82 @@ exports[`Mobile Viewport 1`] = `
 </ds-breadcrumbs>
 `;
 
+exports[`Placement With Header 1`] = `
+<style>
+  /* Styles defined in application-specific css */
+        .content {
+          max-width: 80rem;
+          margin: var(--ds-size-4) auto 0;
+          padding: 0 var(--ds-size-5);
+        }
+</style>
+<header
+  data-scroll-direction="up"
+  data-top="true"
+  style="<removed>"
+>
+  <div>
+    <a href="/">
+      <div style="<removed>">
+        <img
+          alt="Utdanningsdirektoratet"
+          src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-3&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-2&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+        >
+        <img
+          alt="Utdanningsdirektoratet"
+          src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-2&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-3&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
+        >
+      </div>
+      <span data-size="xs">
+        Tjenestenavn
+      </span>
+    </a>
+    <div>
+      <button
+        data-variant="tertiary"
+        type="button"
+        popovertarget="uds-header-menu"
+      >
+        Meny
+      </button>
+    </div>
+  </div>
+</header>
+<div>
+  <ds-breadcrumbs
+    role="navigation"
+    aria-label="Du er her:"
+  >
+    <a
+      href="#"
+      aria-label="Tilbake til Utdanningsløpet"
+    >
+      Utdanningsløpet
+    </a>
+    <ol>
+      <li>
+        <a href="#">
+          Forside
+        </a>
+      </li>
+      <li>
+        <a href="#">
+          Utdanningsløpet
+        </a>
+      </li>
+      <li>
+        <a
+          href="#"
+          aria-current="page"
+        >
+          Grunnskole
+        </a>
+      </li>
+    </ol>
+  </ds-breadcrumbs>
+</div>
+`;
+
 exports[`Preview 1`] = `
 <ds-breadcrumbs
   aria-label="Du er her:"

--- a/@udir-design/react/src/components/breadcrumbs/__snapshots__/Breadcrumbs.stories.tsx.snap
+++ b/@udir-design/react/src/components/breadcrumbs/__snapshots__/Breadcrumbs.stories.tsx.snap
@@ -143,10 +143,12 @@ exports[`Placement With Header 1`] = `
       <div style="<removed>">
         <img
           alt="Utdanningsdirektoratet"
+          role="img"
           src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-3&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-2&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
         >
         <img
           alt="Utdanningsdirektoratet"
+          role="img"
           src="data:image/svg+xml,%3c?xml%20version=&#x27;1.0&#x27;%20encoding=&#x27;UTF-8&#x27;?%3e%3csvg%20id=&#x27;Layer_1&#x27;%20data-name=&#x27;Layer%201&#x27;%20xmlns=&#x27;http://www.w3.org/2000/svg&#x27;%20viewBox=&#x27;0%200%2024%2024&#x27;%3e%3cdefs%3e%3cstyle%3e%20.cls-1%20{%20fill:%20%23303030;%20}%20.cls-2%20{%20fill:%20%23fff;%20}%20.cls-3%20{%20fill:%20%2376c69d;%20}%20%3c/style%3e%3c/defs%3e%3ccircle%20class=&#x27;cls-2&#x27;%20cx=&#x27;12&#x27;%20cy=&#x27;12&#x27;%20r=&#x27;12&#x27;/%3e%3cg%3e%3cpath%20class=&#x27;cls-3&#x27;%20d=&#x27;M18.26,4.55v9.25c0,2.22-1.8,4.02-4.02,4.02-.4,0-.78-.06-1.14-.16.42-.64.67-1.4.67-2.22V6.18l4.49-1.63Z&#x27;/%3e%3cpath%20class=&#x27;cls-1&#x27;%20d=&#x27;M13.11,17.65c-.72,1.08-1.95,1.8-3.35,1.8-2.22,0-4.02-1.8-4.02-4.02V6.81l4.49-1.63v8.62c0,1.82,1.21,3.36,2.88,3.85Z&#x27;/%3e%3c/g%3e%3c/svg%3e"
         >
       </div>

--- a/@udir-design/react/src/components/dialog/Dialog.mdx
+++ b/@udir-design/react/src/components/dialog/Dialog.mdx
@@ -14,7 +14,7 @@ import { SimpleAlert } from '.storybook/docs/components';
 <Canvas of={DialogStories.Preview} withToolbar />
 <Controls of={DialogStories.Preview} />
 
-Du bytter mellom modal og ikke-modal dialog ved å bruke `modal`-propen, som er satt til `true` som standard. Vi overstyrer hvordan `open` fungerer basert på verdien til `modal`.
+Du bytter mellom modal og ikke-modal dialog ved å bruke `modal`-propen, som er satt til `true` som standard. Vi overstyrer hvordan `open` fungerer basert på verdien av `modal`.
 
 En modal `dialog` har innebygd "focus trap", som betyr at brukeren ikke kan navigere med tabulator til annet innhold på siden mens dialogen er åpen.
 
@@ -37,21 +37,21 @@ import { Dialog } from '@udir-design/react';
 
 ### Kontroll over åpning og lukking
 
-Om du trenger programmatisk kontroll over åpning og lukking av `Dialog`, finnes det flere måter å gjøre dette.
+Hvis du trenger programmatisk kontroll over åpning og lukking av `Dialog`, finnes det flere måter å gjøre dette.
 
 - Du kan styre tilstanden selv med `open` på `Dialog`.
 - Du kan bruke `command` og `commandfor` på knappene som åpner og lukker `Dialog`.
-- Du kan bruke `<Dialog ref={dialogRef}>` og kalle `.show()`, `.showModal()` eller `.close()`.
+- Du kan bruke `<Dialog ref={dialogRef}>` og kalle `show()`, `showModal()` eller `close()`.
 
-Merk at knapper som åpner en dialog bør ha `aria-haspopup="dialog"`-attributtet. Dette gjør vi automatisk når du bruker `command` og `commandfor` eller `Dialog.Trigger`, men i de andre tilfellene må du sette dette selv.
+Merk at knapper som åpner en dialog bør ha `aria-haspopup="dialog"`-attributtet. Dette settes automatisk når du bruker `command` og `commandfor` eller `Dialog.Trigger`. I andre tilfeller må du sette dette selv.
 
-I tillegg kan du bruke `closedby` for å styre om brukeren kan lukke dialogen ved trykk på Esc-tasten eller klikk utenfor dialogen, og `closeButton` lar deg skjule eller endre den vanlige lukkeknappen.
+Du kan også bruke `closedby` for å styre om brukeren kan lukke dialogen ved trykk på Esc-tasten eller klikk utenfor dialogen. Med `closeButton` kan du skjule eller endre den vanlige lukkeknappen.
 
-Her går vi gjennom de ulike måtene du kan ta kontroll over åpning og lukking.
+Under går vi gjennom de ulike måtene å ta kontroll over åpning og lukking på.
 
 #### Åpne og lukke med styrt tilstand
 
-Du kan styre tilstanden ved å bruke `open` og `onClose` props på `Dialog`-elementet, som i dette eksempelet. Husk å sette `aria-haspopup="dialog"` på knappen som åpner dialogen.
+Du kan styre tilstanden ved å bruke `open` og `onClose` på `Dialog`-elementet. Husk å sette `aria-haspopup="dialog"` på knappen som åpner dialogen.
 
 <Canvas of={DialogStories.DialogWithOpenProp} />
 
@@ -66,7 +66,7 @@ Du kan styre tilstanden ved å bruke `open` og `onClose` props på `Dialog`-elem
   for å støtte eldre nettlesere.
 </SimpleAlert>
 
-Du kan bruke en knapp med `command="show-modal"` for å åpne en modal dialog, eller `command="--show-non-modal"` for en ikke-modal dialog. En knapp med `command="close"` vil lukke dialogen. Samtlige av disse knappene må også ha `commandfor="DIALOG-ID"` for å knytte de opp til riktig dialog.
+Du kan bruke en knapp med `command="show-modal"` for å åpne en modal dialog, eller `command="--show-non-modal"` for en ikke-modal dialog. En knapp med `command="close"` vil lukke dialogen. Alle disse knappene må også ha `commandfor="DIALOG-ID"` for å knyttes til riktig dialog.
 
 <Canvas of={DialogStories.WithoutDialogTriggerContextWithCommand} />
 
@@ -80,12 +80,12 @@ Her bruker vi `useRef` for å få tilgang til dialogen, og kaller `.showModal()`
 
 #### Endre standard lukkeknapp
 
-Om du ønsker å skru av lukkeknappen øverst til høyre, kan du sette `closeButton={false}` på `Dialog`-elementet.
+Hvis du ønsker å skru av lukkeknappen øverst til høyre, kan du sette `closeButton={false}` på `Dialog`-elementet.
 
-Du kan endre skjermleserteksten for lukkeknappen ved å sende en string til `closeButton`, f.eks. `closeButton="Close dialog"`. Om du ikke sender noe vil teksten være "Lukk dialogvindu".
+Du kan endre skjermleserteksten for lukkeknappen ved å sende inn en tekststreng til `closeButton`, f.eks. `closeButton="Close dialog"`. Hvis du ikke sender noe, vil teksten være "Lukk dialogvindu".
 
-Du kan også erstatte lukkeknappen helt ved å sette `closeButton={false}` på `Dialog`-elementet, og legge
-en `Button` med `command="close"` og `commandfor="DIALOG-ID"` som første barn av `Dialog`. Knappen vil da flyttes øverst til høyre i dialogen. Dersom knappen er tom vil den også få et kryss-ikon. NB: Dette fungerer kun for alternativet med `command` og `commandfor` på knappen.
+Du kan også erstatte lukkeknappen helt ved å sette `closeButton={false}` på `Dialog`-elementet og legge inn
+en `Button` med `command="close"` og `commandfor="DIALOG-ID"` som første barn av `Dialog`. Knappen flyttes da øverst til høyre i dialogen. Dersom knappen er tom, får den også et kryss-ikon. NB: Dette fungerer kun i alternativet med `command` og `commandfor` på knappen.
 
 I dette eksempelet endrer vi lukkeknappen til en knapp med tekst.
 
@@ -95,11 +95,11 @@ I dette eksempelet endrer vi lukkeknappen til en knapp med tekst.
 
 Standard oppførsel for `Dialog` er at den kan lukkes ved å trykke Esc-tasten. Dette tilsvarer å sette `closedby="closerequest"`.
 
-Dersom du også ønsker å lukke dialogen når brukeren klikker utenfor, sett `closedby="any"`. Vi legger til polyfill så `closedby="any"` også fungerer i eldre Safari.
+Dersom du også ønsker å lukke dialogen når brukeren klikker utenfor, sett `closedby="any"`. Vi legger til polyfill, slik at `closedby="any"` også fungerer i eldre Safari.
 
 Ved å sette `closedby="none"` skrur du av både Esc-tast og klikk utenfor.
 
-Du kan også kjøre egen kode når dialogen lukkes ved å bruke `onClose`. Dette er for eksempel nyttig når du skal [åpne og lukke med styrt tilstand](#åpne-og-lukke-med-styrt-tilstand).
+Du kan også kjøre egen kode når dialogen lukkes, ved å bruke `onClose`. Dette er for eksempel nyttig når du skal [åpne og lukke med styrt tilstand](#åpne-og-lukke-med-styrt-tilstand).
 
 Dette eksempelet viser `closedby="any"` og en `onClose`-funksjon, som her blir kjørt både ved klikk på lukkeknappen, ved klikk utenfor og ved trykk på Esc-tasten.
 
@@ -107,14 +107,14 @@ Dette eksempelet viser `closedby="any"` og en `onClose`-funksjon, som her blir k
 
 ### Plassering
 
-Som default åpnes en dialog midt på skjermen. Ved å sette `placement` til noe annet enn `"center"` vil `Dialog` kunne oppføre seg som en såkalt "drawer" og komme inn fra en av sidene (`"left"`, `"right"`, `"top"` eller `"bottom"`).
+Som standard åpnes en dialog midt på skjermen. Setter du `placement` til noe annet enn `"center"`, kan `Dialog` oppføre seg som en såkalt "drawer" og komme inn fra en av sidene (`"left"`, `"right"`, `"top"` eller `"bottom"`).
 
 <Canvas of={DialogStories.Drawer} />
 
 ### Med inndeling
 
-Bruk flere `Dialog.Block` hvis du vil dele opp dialogen med skillelinjer til for eksempel topp- og bunn-område.
-Merk at innhold kan ikke plasseres direkte i `Dialog` dersom du bruker `Dialog.Block`; da burde alt innholdet være inni en av dialogens `Dialog.Block`-seksjoner.
+Bruk flere `Dialog.Block` hvis du vil dele opp dialogen med skillelinjer, for eksempel i topp- og bunnområde.
+Merk at innhold ikke kan plasseres direkte i `Dialog` når du bruker `Dialog.Block`. Da må alt innhold ligge i en av dialogens `Dialog.Block`-seksjoner.
 
 <Canvas of={DialogStories.WithHeaderAndFooter} />
 
@@ -122,29 +122,29 @@ Merk at innhold kan ikke plasseres direkte i `Dialog` dersom du bruker `Dialog.B
 
 Dersom du vil at et felt i et skjema inni dialogen skal få fokus når dialogen åpnes, kan du bruke native `autofocus`-attributtet på input-elementet.
 
-Når du bruker dette med React, må du skrive det med små bokstaver som `autofocus`, ikke `autoFocus`. Fordi `autofocus` med liten `f` ikke finnes i React sine typedefinisjoner, har vi ignorert typefeilen med en `@ts-expect-error`-kommentar i eksempelet under.
+I React må dette skrives med små bokstaver som `autofocus`, ikke `autoFocus`. Siden `autofocus` (med liten `f`) ikke finnes i React sine typedefinisjoner, har vi ignorert typefeilen med en `@ts-expect-error`-kommentar i eksempelet under.
 
 <Canvas of={DialogStories.DialogWithForm} />
 
 ### Egendefinert bredde
 
-Bruk `max-width` for å sette egendefinert maks bredde på dialogen. Default er 40rem.
+Bruk `max-width` for å sette en egendefinert maksbredde på dialogen. Standard er 40rem.
 
 <Canvas of={DialogStories.DialogWithMaxWidth} />
 
 ### Innhold som går utenfor Dialogen
 
-Bruk `overflow: visible` for å la innhold gå utenfor dialogen.
+Bruk `overflow: visible` hvis du vil at innhold skal kunne gå utenfor dialogen.
 
 <Canvas of={DialogStories.DialogWithSuggestion} />
 
 ### Ikke-modal Dialog
 
-Bruk `modal={false}` for å lage en non-modal dialog. Den kan brukes til å gi støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
+Bruk `modal={false}` for å lage en ikke-modal dialog. Den kan brukes til å gi støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
 
-En ikke-modal Dialog burde som regel plasseres i forhold til innholdet. Da må du overstyre standard plassering, som vanligvis er i midten av skjermen.
+En ikke-modal Dialog bør som regel plasseres i forhold til innholdet. Det betyr at du må overstyre standardplasseringen, som vanligvis er midt på skjermen.
 
-I eksempelet under kan du se skrivetips i en dialog, samtidig som du kan fortsette å skrive inn i tekstfeltet.
+I eksempelet under vises skrivetips i en dialog, samtidig som brukeren kan fortsette å skrive i tekstfeltet.
 
 <Canvas of={DialogStories.DialogNonModal} />
 
@@ -154,7 +154,7 @@ I eksempelet under kan du se skrivetips i en dialog, samtidig som du kan fortset
 
 ### 1) Modal Dialog
 
-En modal `Dialog` er et midlertidig vindu som åpnes over resten av innholdet på nettsiden. Modal `Dialog` fanger brukerens oppmerksomhet og hindrer interaksjon med annet innhold, samtidig som konteksten til nettsiden beholdes. Bruk av modal `Dialog` bør generelt begrenses, men kan være nyttig når brukeren må ta stilling til informasjon, bekrefte en handling eller fokusere på en spesifikk oppgave – uten å navigere bort fra siden.
+En modal `Dialog` er et midlertidig vindu som åpnes over resten av innholdet på siden. Den fanger brukerens oppmerksomhet og hindrer interaksjon med annet innhold, samtidig som konteksten beholdes. Bruk av modal `Dialog` bør generelt begrenses, men kan være nyttig når brukeren må ta stilling til informasjon, bekrefte en handling eller fokusere på en spesifikk oppgave uten å navigere bort fra siden.
 
 **Passer til å**
 
@@ -165,11 +165,11 @@ En modal `Dialog` er et midlertidig vindu som åpnes over resten av innholdet p�
 **Passer ikke til å**
 
 - vise omfattende eller komplekst innhold som krever langvarig interaksjon
-- gi informasjon uten å avbryte brukerens arbeidsflyt - bruk heller [`Alert`](/docs/components-alert--docs), [`Popover`](/docs/components-popover--docs), eller "ikke-modal" `Dialog`
+- gi informasjon uten å avbryte brukerens arbeidsflyt - bruk heller [`Alert`](/docs/components-alert--docs), [`Popover`](/docs/components-popover--docs) eller ikke-modal `Dialog`
 
 ### 2) Ikke-modal Dialog
 
-En "ikke-modal" `Dialog` lar brukeren fortsatt bruke resten av siden mens dialogen er åpen. Den bør brukes med varsomhet, og passer best når du skal gi støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
+En ikke-modal `Dialog` lar brukeren fortsette å bruke resten av siden mens dialogen er åpen. Den bør brukes med varsomhet, og passer best når du vil gi støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
 
 **Passer til å**
 
@@ -180,20 +180,20 @@ En "ikke-modal" `Dialog` lar brukeren fortsatt bruke resten av siden mens dialog
 - gi kritiske valg som brukeren må ta stilling til før de kan fortsette - bruk heller modal `Dialog`
 - gi bekreftelser eller varsler som krever brukerens fulle oppmerksomhet - bruk heller modal `Dialog`
 
-På mobil kan en "ikke-modal" `Dialog` være problematisk på grunn av begrenset skjermplass. Den kan dekke viktig innhold og forstyrre brukeropplevelsen. I slike tilfeller kan det være bedre å bruke modal `Dialog` eller andre løsninger.
+På mobil kan en ikke-modal `Dialog` være problematisk på grunn av begrenset skjermplass. Den kan dekke viktig innhold og forstyrre brukeropplevelsen. I slike tilfeller kan det være bedre å bruke modal `Dialog` eller andre løsninger.
 
 ## Tekst i Dialog
 
-- Ha en kort og konsis overskrift. Overskriften skal gjøre det tydelig for brukeren at konteksten er endret.
+- Bruk en kort og konsis overskrift. Overskriften skal gjøre det tydelig for brukeren at konteksten er endret.
 - Unngå mange avsnitt med tekst.
-- Sørg for at formålet er tydelig og at all nødvendig informasjon er tilgjengelig i modalen.
+- Sørg for at formålet er tydelig, og at all nødvendig informasjon er tilgjengelig i dialogen.
 
 ## Tilgjengelighet
 
 ### Knapper som åpner dialoger
 
 En knapp som åpner en dialog bør ha `aria-haspopup="dialog"`-attributtet for en bedre skjermleseropplevelse.
-Dersom du bruker `Dialog.Trigger` eller en knapp med `command` og `commandfor` håndteres dette automatisk, men i andre tilfeller må du sette dette selv.
+Dette settes automatisk når du bruker `Dialog.Trigger` eller en knapp med `command` og `commandfor`, men i andre tilfeller må du sette dette selv.
 
 ### Ikke-modale dialoger
 
@@ -202,4 +202,4 @@ Når du bruker ikke-modale dialoger, må du passe på at elementer som får foku
 For ikke-modale dialoger betyr dette at du må:
 
 - Sikre at fokuserbare elementer aldri blir helt dekket av dialogen når brukeren tabber gjennom siden.
-- Sørge for at fokusrekkefølgen er logisk og at fokus alltid er synlig, slik at brukere som navigerer med tastatur eller skjermleser forstår hvor fokus befinner seg.
+- Sørge for at fokusrekkefølgen er logisk, og at fokus alltid er synlig, slik at brukere som navigerer med tastatur eller skjermleser forstår hvor fokus befinner seg.

--- a/@udir-design/react/src/components/dialog/Dialog.mdx
+++ b/@udir-design/react/src/components/dialog/Dialog.mdx
@@ -7,16 +7,48 @@ import { SimpleAlert } from '.storybook/docs/components';
 
 # Dialog
 
-`Dialog` lar deg lage modale og ikke-modale dialoger basert på HTML-elementet `<dialog>`. [Gå til retningslinjene](#retningslinjer) for mer informasjon om når du bør bruke modal og ikke-modal dialog.
+`Dialog` brukes til å vise innhold i et midlertidig vindu over resten av siden. Komponenten støtter både modale og ikke-modale dialoger, og er basert på HTML-elementet `<dialog>`.
+
+### 1. Modal Dialog
+
+En modal `Dialog` åpnes over resten av innholdet på siden og krever brukerens fulle oppmerksomhet. Brukeren kan ikke samhandle med resten av siden før dialogen er lukket.
+
+Bruk av modal `Dialog` bør generelt begrenses, men kan være nyttig når brukeren må ta stilling til informasjon, bekrefte en handling eller fokusere på en spesifikk oppgave uten å navigere bort fra siden.
+
+**Passer til å**
+
+- få brukeren til å fokusere på en spesifikk oppgave
+- sikre at brukeren får med seg viktig informasjon
+- gi mer informasjon uten at brukeren må forlate hovedinnholdet
+
+**Passer ikke til å**
+
+- vise omfattende eller komplekst innhold som krever langvarig interaksjon
+- gi informasjon uten å avbryte brukerens arbeidsflyt - bruk heller [`Alert`](/docs/components-alert--docs), [`Popover`](/docs/components-popover--docs) eller ikke-modal `Dialog`
+
+### 2. Ikke-modal Dialog
+
+En ikke-modal `Dialog` lar brukeren fortsette å bruke resten av siden mens dialogen er åpen. Den passer best til støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
+
+På mobil kan ikke-modale dialoger være problematiske, fordi de kan dekke viktig innhold og forstyrre brukeropplevelsen. Vurder modal `Dialog` eller en annen løsning hvis skjermplassen er begrenset.
+
+**Passer til å**
+
+- gi brukeren tilgang til informasjon eller handlinger parallelt med resten av innholdet
+
+**Passer ikke til å**
+
+- gi kritiske valg som brukeren må ta stilling til før de kan fortsette - bruk heller modal `Dialog`
+- gi bekreftelser eller varsler som krever brukerens fulle oppmerksomhet - bruk heller modal `Dialog`
 
 ## Slik bruker du Dialog
 
 <Canvas of={DialogStories.Preview} withToolbar />
 <Controls of={DialogStories.Preview} />
 
-Du bytter mellom modal og ikke-modal dialog ved å bruke `modal`-propen, som er satt til `true` som standard. Vi overstyrer hvordan `open` fungerer basert på verdien av `modal`.
+Du bytter mellom modal og ikke-modal `Dialog` ved å bruke `modal`-propen. Som standard er `modal` satt til `true`, som gir en modal dialog. Vi overstyrer hvordan `open` fungerer basert på verdien av `modal`.
 
-En modal `dialog` har innebygd "focus trap", som betyr at brukeren ikke kan navigere med tabulator til annet innhold på siden mens dialogen er åpen.
+En modal `Dialog` har innebygd "focus trap", som betyr at brukeren ikke kan navigere med tabulator til annet innhold på siden mens dialogen er åpen.
 
 ```tsx
 import { Dialog } from '@udir-design/react';
@@ -37,17 +69,17 @@ import { Dialog } from '@udir-design/react';
 
 ### Kontroll over åpning og lukking
 
-Hvis du trenger programmatisk kontroll over åpning og lukking av `Dialog`, finnes det flere måter å gjøre dette.
+Hvis du trenger programmatisk kontroll over åpning og lukking av `Dialog`, finnes det flere måter å gjøre dette på.
 
 - Du kan styre tilstanden selv med `open` på `Dialog`.
 - Du kan bruke `command` og `commandfor` på knappene som åpner og lukker `Dialog`.
 - Du kan bruke `<Dialog ref={dialogRef}>` og kalle `show()`, `showModal()` eller `close()`.
 
-Merk at knapper som åpner en dialog bør ha `aria-haspopup="dialog"`-attributtet. Dette settes automatisk når du bruker `command` og `commandfor` eller `Dialog.Trigger`. I andre tilfeller må du sette dette selv.
+Merk at knapper som åpner en `Dialog` bør ha `aria-haspopup="dialog"`-attributtet. Dette settes automatisk når du bruker `command` og `commandfor` eller `Dialog.Trigger`. I andre tilfeller må du sette dette selv.
 
 Du kan også bruke `closedby` for å styre om brukeren kan lukke dialogen ved trykk på Esc-tasten eller klikk utenfor dialogen. Med `closeButton` kan du skjule eller endre den vanlige lukkeknappen.
 
-Under går vi gjennom de ulike måtene å ta kontroll over åpning og lukking på.
+Under går vi gjennom de ulike måtene å styre åpning og lukking på.
 
 #### Åpne og lukke med styrt tilstand
 
@@ -58,15 +90,16 @@ Du kan styre tilstanden ved å bruke `open` og `onClose` på `Dialog`-elementet.
 #### Åpne og lukke med command og commandfor
 
 <SimpleAlert>
-  Attributtene
-  [`command`(developer.mozilla.org)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/command)
+  Attributtene [`command`
+  (developer.mozilla.org)](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/command)
   og `commandfor` er en relativt ny del av web-standarden som lar knapper utføre
-  handlinger på andre elementer deklarativt. Vi legger automatisk til
-  [invokers-polyfill(npmjs.com)](https://www.npmjs.com/package/invokers-polyfill/v/0.5.2)
-  for å støtte eldre nettlesere.
+  handlinger på andre elementer direkte i HTML. Vi legger derfor automatisk til
+  [invokers-polyfill
+  (npmjs.com)](https://www.npmjs.com/package/invokers-polyfill/v/0.5.2) for å
+  støtte eldre nettlesere.
 </SimpleAlert>
 
-Du kan bruke en knapp med `command="show-modal"` for å åpne en modal dialog, eller `command="--show-non-modal"` for en ikke-modal dialog. En knapp med `command="close"` vil lukke dialogen. Alle disse knappene må også ha `commandfor="DIALOG-ID"` for å knyttes til riktig dialog.
+Bruk `command` til å angi handlingen, og `commandfor` for å peke på dialogen knappen skal styre. For å åpne en dialog bruker du `command="show-modal"` for modal `Dialog` eller `command="--show-non-modal"` for ikke-modal `Dialog`. For å lukke dialogen bruker du `command="close"`. Alle knappene må ha `commandfor="DIALOG-ID"` for å knyttes til riktig `Dialog`.
 
 <Canvas of={DialogStories.WithoutDialogTriggerContextWithCommand} />
 
@@ -80,14 +113,11 @@ Her bruker vi `useRef` for å få tilgang til dialogen, og kaller `.showModal()`
 
 #### Endre standard lukkeknapp
 
-Hvis du ønsker å skru av lukkeknappen øverst til høyre, kan du sette `closeButton={false}` på `Dialog`-elementet.
+Du kan endre skjermleserteksten for lukkeknappen øverst til høyre ved å sende inn en tekststreng til `closeButton`, for eksempel `closeButton="Close dialog"`. Standardteksten er "Lukk dialogvindu" hvis du ikke sender inn noe.
 
-Du kan endre skjermleserteksten for lukkeknappen ved å sende inn en tekststreng til `closeButton`, f.eks. `closeButton="Close dialog"`. Hvis du ikke sender noe, vil teksten være "Lukk dialogvindu".
+For å fjerne lukkeknappen, sett `closeButton={false}` på `Dialog`-elementet. Hvis du ønsker å erstatte lukkeknappen helt, kan du sette `closeButton={false}` og legge inn en egen `Button` med `command="close"` og `commandfor="DIALOG-ID"` som første barn av `Dialog`. Knappen plasseres da øverst til høyre i dialogen. Dersom knappen er tom, får den også et kryss-ikon. NB: Dette fungerer kun når du bruker `command` og `commandfor` på knappen.
 
-Du kan også erstatte lukkeknappen helt ved å sette `closeButton={false}` på `Dialog`-elementet og legge inn
-en `Button` med `command="close"` og `commandfor="DIALOG-ID"` som første barn av `Dialog`. Knappen flyttes da øverst til høyre i dialogen. Dersom knappen er tom, får den også et kryss-ikon. NB: Dette fungerer kun i alternativet med `command` og `commandfor` på knappen.
-
-I dette eksempelet endrer vi lukkeknappen til en knapp med tekst.
+I eksempelet under bytter vi ut lukkeknappen med en egen knapp med tekst.
 
 <Canvas of={DialogStories.CustomCloseButton} />
 
@@ -97,11 +127,11 @@ Standard oppførsel for `Dialog` er at den kan lukkes ved å trykke Esc-tasten. 
 
 Dersom du også ønsker å lukke dialogen når brukeren klikker utenfor, sett `closedby="any"`. Vi legger til polyfill, slik at `closedby="any"` også fungerer i eldre Safari.
 
-Ved å sette `closedby="none"` skrur du av både Esc-tast og klikk utenfor.
+Setter du `closedby="none"`, deaktiveres både lukking med Esc-tast og klikk utenfor.
 
 Du kan også kjøre egen kode når dialogen lukkes, ved å bruke `onClose`. Dette er for eksempel nyttig når du skal [åpne og lukke med styrt tilstand](#åpne-og-lukke-med-styrt-tilstand).
 
-Dette eksempelet viser `closedby="any"` og en `onClose`-funksjon, som her blir kjørt både ved klikk på lukkeknappen, ved klikk utenfor og ved trykk på Esc-tasten.
+Eksempelet under viser `closedby="any"` og en `onClose`-funksjon, som kjøres både ved klikk på lukkeknappen, klikk utenfor og trykk på Esc-tasten.
 
 <Canvas of={DialogStories.BackdropClosedbyAny} />
 
@@ -113,14 +143,14 @@ Som standard åpnes en dialog midt på skjermen. Setter du `placement` til noe a
 
 ### Med inndeling
 
-Bruk flere `Dialog.Block` hvis du vil dele opp dialogen med skillelinjer, for eksempel i topp- og bunnområde.
+Bruk flere `Dialog.Block` hvis du vil dele opp dialogen med skillelinjer, for eksempel i topp- og bunnområder.
 Merk at innhold ikke kan plasseres direkte i `Dialog` når du bruker `Dialog.Block`. Da må alt innhold ligge i en av dialogens `Dialog.Block`-seksjoner.
 
 <Canvas of={DialogStories.WithHeaderAndFooter} />
 
 ### Fokus
 
-Dersom du vil at et felt i et skjema inni dialogen skal få fokus når dialogen åpnes, kan du bruke native `autofocus`-attributtet på input-elementet.
+Dersom du vil at et felt i et skjema inni dialogen skal få fokus når dialogen åpnes, kan du bruke det innebygde `autofocus`-attributtet på input-elementet.
 
 I React må dette skrives med små bokstaver som `autofocus`, ikke `autoFocus`. Siden `autofocus` (med liten `f`) ikke finnes i React sine typedefinisjoner, har vi ignorert typefeilen med en `@ts-expect-error`-kommentar i eksempelet under.
 
@@ -140,47 +170,11 @@ Bruk `overflow: visible` hvis du vil at innhold skal kunne gå utenfor dialogen.
 
 ### Ikke-modal Dialog
 
-Bruk `modal={false}` for å lage en ikke-modal dialog. Den kan brukes til å gi støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
-
-En ikke-modal Dialog bør som regel plasseres i forhold til innholdet. Det betyr at du må overstyre standardplasseringen, som vanligvis er midt på skjermen.
+En ikke-modal `Dialog` bør som regel plasseres slik at den ikke dekker viktig innhold eller elementer brukeren trenger tilgang til. Det betyr ofte at du må overstyre standardplasseringen, som vanligvis er midt på skjermen.
 
 I eksempelet under vises skrivetips i en dialog, samtidig som brukeren kan fortsette å skrive i tekstfeltet.
 
 <Canvas of={DialogStories.DialogNonModal} />
-
-## Retningslinjer
-
-`Dialog` kan brukes som både **(1) modal** og **(2) ikke-modal**.
-
-### 1) Modal Dialog
-
-En modal `Dialog` er et midlertidig vindu som åpnes over resten av innholdet på siden. Den fanger brukerens oppmerksomhet og hindrer interaksjon med annet innhold, samtidig som konteksten beholdes. Bruk av modal `Dialog` bør generelt begrenses, men kan være nyttig når brukeren må ta stilling til informasjon, bekrefte en handling eller fokusere på en spesifikk oppgave uten å navigere bort fra siden.
-
-**Passer til å**
-
-- få brukeren til å fokusere på en spesifikk oppgave
-- sikre at brukeren får med seg viktig informasjon
-- gi mer informasjon uten at brukeren må forlate hovedinnholdet
-
-**Passer ikke til å**
-
-- vise omfattende eller komplekst innhold som krever langvarig interaksjon
-- gi informasjon uten å avbryte brukerens arbeidsflyt - bruk heller [`Alert`](/docs/components-alert--docs), [`Popover`](/docs/components-popover--docs) eller ikke-modal `Dialog`
-
-### 2) Ikke-modal Dialog
-
-En ikke-modal `Dialog` lar brukeren fortsette å bruke resten av siden mens dialogen er åpen. Den bør brukes med varsomhet, og passer best når du vil gi støtteinformasjon eller ekstra funksjonalitet som ikke krever full oppmerksomhet.
-
-**Passer til å**
-
-- gi brukeren tilgang til informasjon eller handlinger parallelt med resten av innholdet
-
-**Passer ikke til å**
-
-- gi kritiske valg som brukeren må ta stilling til før de kan fortsette - bruk heller modal `Dialog`
-- gi bekreftelser eller varsler som krever brukerens fulle oppmerksomhet - bruk heller modal `Dialog`
-
-På mobil kan en ikke-modal `Dialog` være problematisk på grunn av begrenset skjermplass. Den kan dekke viktig innhold og forstyrre brukeropplevelsen. I slike tilfeller kan det være bedre å bruke modal `Dialog` eller andre løsninger.
 
 ## Tekst i Dialog
 
@@ -201,5 +195,5 @@ Når du bruker ikke-modale dialoger, må du passe på at elementer som får foku
 
 For ikke-modale dialoger betyr dette at du må:
 
-- Sikre at fokuserbare elementer aldri blir helt dekket av dialogen når brukeren tabber gjennom siden.
+- Sikre at fokuserbare elementer aldri blir helt dekket av dialogen når brukeren tabber seg gjennom siden.
 - Sørge for at fokusrekkefølgen er logisk, og at fokus alltid er synlig, slik at brukere som navigerer med tastatur eller skjermleser forstår hvor fokus befinner seg.

--- a/@udir-design/react/src/components/dialog/Dialog.mdx
+++ b/@udir-design/react/src/components/dialog/Dialog.mdx
@@ -7,7 +7,7 @@ import { SimpleAlert } from '.storybook/docs/components';
 
 # Dialog
 
-`Dialog` lar deg lage modale og ikke-modale dialoger basert på HTML-elementet `dialog`. [Gå til retningslinjene](#retningslinjer) for mer informasjon om når du bør bruke modal og ikke-modal dialog.
+`Dialog` lar deg lage modale og ikke-modale dialoger basert på HTML-elementet `<dialog>`. [Gå til retningslinjene](#retningslinjer) for mer informasjon om når du bør bruke modal og ikke-modal dialog.
 
 ## Slik bruker du Dialog
 

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -36,7 +36,7 @@ async function defaultPlay(canvasElement: HTMLElement) {
 
 const meta = preview.meta({
   component: Dialog,
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -517,7 +517,7 @@ export const DialogNonModal = meta.story({
           modal={false}
           style={{
             width: '300px',
-            left: '80%',
+            left: '65%',
           }}
           {...args}
         >

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -60,6 +60,13 @@ const meta = preview.meta({
       },
     },
   },
+  argTypes: {
+    asChild: {
+      description:
+        '**@deprecated** Will be removed in the next major version. Should always be a `<dialog>` element.',
+      control: false,
+    },
+  },
   play: async (ctx) => defaultPlay(ctx.canvasElement),
 });
 

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -352,6 +352,7 @@ export const DialogWithForm = meta.story({
             autofocus="true"
             label="Navn"
             value={input}
+            autocomplete="name"
             onChange={(e) => setInput(e.target.value)}
           />
           <div
@@ -500,7 +501,7 @@ export const DialogNonModal = meta.story({
       <>
         <Field style={{ width: '400px' }}>
           <Label>Besvarelse</Label>
-          <Textarea rows={8} />
+          <Textarea rows={8} autoComplete="off" />
         </Field>
         <Button variant="secondary" onClick={() => dialogRef.current?.show()}>
           Åpne skrivetips
@@ -574,6 +575,7 @@ export const Drawer = meta.story({
             setPlacement(target.value as DialogProps['placement']);
           }}
         >
+          <Fieldset.Legend>Velg plassering for dialogen</Fieldset.Legend>
           <div
             style={{
               display: 'flex',

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -167,35 +167,37 @@ export const WithoutDialogTriggerContext = meta.story({
 
 export const WithoutDialogTriggerContextWithCommand = meta.story({
   parameters: { docs: advancedCodeDocs },
-  render: (args) => (
-    <>
-      <Button command="show-modal" commandfor="dialog-with-command">
-        Åpne Dialog med command
-      </Button>
-      <Dialog id="dialog-with-command" {...args}>
-        <Prose>
-          <Heading>
-            Dialog med <code>command</code>
-          </Heading>
-          <Paragraph>
-            Her bruker vi <code>command</code> og <code>commandfor</code> for å
-            åpne og lukke dialogen
-          </Paragraph>
-          <Paragraph>
-            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Blanditiis
-            doloremque obcaecati assumenda odio ducimus sunt et.
-          </Paragraph>
-          <Button
-            variant="secondary"
-            command="close"
-            commandfor="dialog-with-command"
-          >
-            Lukk dialog
-          </Button>
-        </Prose>
-      </Dialog>
-    </>
-  ),
+  render(args) {
+    return (
+      <>
+        <Button command="show-modal" commandfor="dialog-with-command">
+          Åpne Dialog med command
+        </Button>
+        <Dialog id="dialog-with-command" {...args}>
+          <Prose>
+            <Heading>
+              Dialog med <code>command</code>
+            </Heading>
+            <Paragraph>
+              Her bruker vi <code>command</code> og <code>commandfor</code> for
+              å åpne og lukke dialogen
+            </Paragraph>
+            <Paragraph>
+              Lorem ipsum dolor sit, amet consectetur adipisicing elit.
+              Blanditiis doloremque obcaecati assumenda odio ducimus sunt et.
+            </Paragraph>
+            <Button
+              variant="secondary"
+              command="close"
+              commandfor="dialog-with-command"
+            >
+              Lukk dialog
+            </Button>
+          </Prose>
+        </Dialog>
+      </>
+    );
+  },
 });
 
 export const DialogWithOpenProp = meta.story({
@@ -269,11 +271,15 @@ export const CustomCloseButton = meta.story({
 
 export const BackdropClosedbyAny = meta.story({
   parameters: { docs: advancedCodeDocs },
-  render() {
+  render(args) {
     return (
       <Dialog.TriggerContext>
         <Dialog.Trigger variant="secondary">Åpne Dialog</Dialog.Trigger>
-        <Dialog closedby="any" onClose={() => alert('Dialog ble lukket')}>
+        <Dialog
+          {...args}
+          closedby="any"
+          onClose={() => alert('Dialog ble lukket')}
+        >
           <Heading>
             Dialog med{' '}
             <code>
@@ -291,10 +297,10 @@ export const BackdropClosedbyAny = meta.story({
 });
 
 export const WithHeaderAndFooter = meta.story({
-  render: () => (
+  render: (args) => (
     <Dialog.TriggerContext>
       <Dialog.Trigger>Gå til neste</Dialog.Trigger>
-      <Dialog>
+      <Dialog {...args}>
         <Dialog.Block>
           <Paragraph data-size="sm">Undertittel</Paragraph>
           <Heading>Dette må du vite før du går videre</Heading>
@@ -386,10 +392,10 @@ export const DialogWithForm = meta.story({
 });
 
 export const DialogWithMaxWidth = meta.story({
-  render: () => (
+  render: (args) => (
     <Dialog.TriggerContext>
       <Dialog.Trigger variant="secondary">Åpne Dialog</Dialog.Trigger>
-      <Dialog style={{ maxWidth: 1200 }}>
+      <Dialog style={{ maxWidth: 1200 }} {...args}>
         <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
           Dialog som er veldig bred
         </Heading>
@@ -413,12 +419,12 @@ const DATA_PLACES = [
 ];
 
 export const DialogWithSuggestion = meta.story({
-  render() {
+  render: (args) => {
     const dialogRef = useRef<HTMLDialogElement>(null);
     return (
       <Dialog.TriggerContext>
         <Dialog.Trigger variant="secondary">Åpne Dialog</Dialog.Trigger>
-        <Dialog style={{ overflow: 'visible' }} ref={dialogRef}>
+        <Dialog style={{ overflow: 'visible' }} ref={dialogRef} {...args}>
           <Dialog.Block>
             <Heading>Dialog med innhold utenfor</Heading>
           </Dialog.Block>
@@ -495,7 +501,7 @@ export const DialogNonModal = meta.story({
       gap: 'var(--ds-size-4)',
     },
   },
-  render() {
+  render: (args) => {
     const dialogRef = useRef<HTMLDialogElement>(null);
     return (
       <>
@@ -513,6 +519,7 @@ export const DialogNonModal = meta.story({
             width: '300px',
             left: '80%',
           }}
+          {...args}
         >
           <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
             Hva besvarelsen burde inneholde
@@ -549,7 +556,7 @@ export const DialogNonModal = meta.story({
 });
 
 export const Drawer = meta.story({
-  render() {
+  render: (args) => {
     const [placement, setPlacement] =
       useState<DialogProps['placement']>('bottom');
     const [modal, setModal] = useState(true);
@@ -608,6 +615,7 @@ export const Drawer = meta.story({
             closedby="any"
             placement={placement}
             style={{ zIndex: '10' }}
+            {...args}
           >
             <Dialog.Block>
               <Paragraph>

--- a/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
+++ b/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
@@ -85,6 +85,7 @@ exports[`Dialog Non Modal 1`] = `
   </label>
   <textarea
     rows="8"
+    autocomplete="off"
     id="<removed>"
     style="<removed>"
   >
@@ -174,6 +175,7 @@ exports[`Dialog With Form 1`] = `
     <div>
       <input
         autofocus="true"
+        autocomplete="name"
         type="text"
         value
         id="<removed>"
@@ -480,7 +482,13 @@ exports[`Drawer 1`] = `
       Modal
     </label>
   </ds-field>
-  <fieldset>
+  <fieldset aria-labelledby="<removed>">
+    <legend
+      data-weight="medium"
+      id="<removed>"
+    >
+      Velg plassering for dialogen
+    </legend>
     <div style="<removed>">
       <ds-field data-clickdelegatefor="<removed>">
         <input

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -55,7 +55,7 @@ import { Dropdown } from '@udir-design/react';
 
 ### Ikoner og andre komponenter
 
-Du kan legge ikon og lignende komponenter slik som `Avatar` rett inn i `Dropdown.Item`.
+Du kan legge ikoner og lignende komponenter, som for eksempel `Avatar`, direkte i `Dropdown.Item`.
 
 <Canvas of={DropdownStories.Avatars} />
 
@@ -71,7 +71,7 @@ Merk at vi ikke bruker `onClick` på triggeren, `Dropdown` håndterer dette inte
 
 Triggeren er en [`Button`](/docs/components-button--docs) som standard. Du kan bruke `asChild` for å endre `Dropdown.Trigger` elementet. Dersom du skal legge på funksjoner som `onClick`, legg det på ditt element, og legg `asChild` på `Dropdown.Trigger`.
 
-Fordi `Dropdown` bruker popover API-et, kan du også bruke `Dropdown` uten `Dropdown.TriggerContext` og `Dropdown.Trigger`. Da må du legge til `popovertarget={id}` på komponenten som skal brukes som trigger, og `id` på `Dropdown`.
+Fordi `Dropdown` bruker Popover API-et, kan du også bruke `Dropdown` uten `Dropdown.TriggerContext` og `Dropdown.Trigger`. Da må du legge til `popovertarget={id}` på komponenten som skal brukes som trigger, og `id` på `Dropdown`.
 
 <Canvas of={DropdownStories.WithoutContext} />
 
@@ -97,7 +97,7 @@ Dersom du bruker `Dropdown` uten å gjøre noe selv, vil fokuserbare elementer i
 
 ## Kompatibilitet
 
-`Dropdown` bruker [popover API-et](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). Dette API-et er klassifisert som [Baseline:
+``Popover` bruker [Popover API-et](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). API-et ble klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) i april 2024, da Firefox som siste nettleser fikk støtte. Enkelte brukere kan fortsatt være låst til eldre nettleserversjoner av ulike årsaker. I slike tilfeller kan det være aktuelt å legge til en polyfill for å sikre at `Dropdown` fungerer for alle.
 Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024,
 med Firefox som siste nettleser la det til. I noen tilfeller kan en oppleve at brukere av ulike grunner er låst til eldre nettleserversjoner, og da kan det være aktuelt å legge til en polyfill for å sikre at `Dropdown` fungerer for alle.
 

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -97,8 +97,7 @@ Dersom du bruker `Dropdown` uten å gjøre noe selv, vil fokuserbare elementer i
 
 ## Kompatibilitet
 
-``Popover` bruker [Popover API-et](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). API-et ble klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) i april 2024, da Firefox som siste nettleser fikk støtte. Enkelte brukere kan fortsatt være låst til eldre nettleserversjoner av ulike årsaker. I slike tilfeller kan det være aktuelt å legge til en polyfill for å sikre at `Dropdown` fungerer for alle.
-Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024,
+`Popover` bruker [Popover API-et](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). API-et ble klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024,
 med Firefox som siste nettleser la det til. I noen tilfeller kan en oppleve at brukere av ulike grunner er låst til eldre nettleserversjoner, og da kan det være aktuelt å legge til en polyfill for å sikre at `Dropdown` fungerer for alle.
 
 - [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -10,12 +10,13 @@ Dropdown er en generisk nedtrekksliste. Den legger grunnmuren for å bygge menye
 
 **Passer til å**
 
-- brukes som kontekstmeny
+- tilby flere valg i en meny uten at de tar plass i grensesnittet
 - liste ut handlinger
 
 **Passer ikke til å**
 
-- beskrive handlinger eller elementer (se [`Popover`](/docs/components-popover--docs) eller [`Tooltip`](/docs/components-tooltip--docs))
+- beskrive handlinger eller elementer - bruk heller [`Popover`](/docs/components-popover--docs) eller [`Tooltip`](/docs/components-tooltip--docs)
+- tilby handlinger som er primære eller ofte brukt - bruk heller [`Button`](/docs/components-button--docs)
 
 ## Slik bruker du Dropdown
 
@@ -51,6 +52,8 @@ import { Dropdown } from '@udir-design/react';
 ```
 
 ## Eksempler
+
+### Ikoner og andre komponenter
 
 Du kan legge ikon og lignende komponenter slik som `Avatar` rett inn i `Dropdown.Item`.
 

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -24,6 +24,13 @@ const meta = preview.meta({
     },
     layout: 'centered',
   },
+  argTypes: {
+    asChild: {
+      description:
+        '**@deprecated** This is not supported anymore, as the element needs to be `ds-field`.',
+      control: false,
+    },
+  },
 });
 
 export const Preview = meta.story({

--- a/@udir-design/react/src/components/field/docs/FakeFieldCounter.tsx
+++ b/@udir-design/react/src/components/field/docs/FakeFieldCounter.tsx
@@ -1,7 +1,15 @@
 import type { FunctionComponent } from 'react';
 import type { FieldCounterProps } from '../Field';
 
+type FieldCounterDocsProps = Omit<FieldCounterProps, 'hint'> & {
+  /**
+   * **@deprecated** The hint attribute is deprecated.
+   */
+  hint?: string;
+};
+
 /**
  * This component only exists to add relevant html props for FieldCounter
  */
-export const FieldCounter: FunctionComponent<FieldCounterProps> = () => null;
+export const FieldCounter: FunctionComponent<FieldCounterDocsProps> = () =>
+  null;

--- a/@udir-design/react/src/components/progressBar/ProgressBar.mdx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.mdx
@@ -5,7 +5,7 @@ import * as ProgressBarStories from './ProgressBar.stories';
 
 # ProgressBar
 
-`ProgressBar` viser fremgang i en prosess. Den kan for eksempel brukes i skjemaer med flere sider for å vise hvor mange sider som er fullført.
+`ProgressBar` viser fremgang i en prosess. Den kan for eksempel brukes i skjemaer med flere steg for å vise hvor mange steg som er fullført.
 
 **Passer til å**
 
@@ -29,8 +29,8 @@ import { ProgressBar } from '@udir-design/react';
 
 ## Eksempler
 
-Eksempelet under viser et skjema med 7 sider som bruker `ProgressBar` for å vise fremgang.
-I dette eksempelet setter vi fokuset tilbake til `ProgressBar` når vi bytter side, slik at
+Eksempelet under viser et skjema med 7 steg som bruker `ProgressBar` for å vise fremgang.
+I dette eksempelet setter vi fokus tilbake til `ProgressBar` når vi går til neste steg, slik at
 skjermleser leser opp elementet og tastaturnavigasjon tar deg videre til skjemafeltene.
 
 <Canvas of={ProgressBarStories.FormExample} />

--- a/@udir-design/react/src/components/progressBar/ProgressBar.mdx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.mdx
@@ -9,11 +9,12 @@ import * as ProgressBarStories from './ProgressBar.stories';
 
 **Passer til å**
 
+- vise fremgang i en prosess
 - brukes i skjemaer uten gruppering der spørsmålene er frivillige
 
 **Passer ikke til å**
 
-- brukes i skjemaer med validering, bruk heller [`FormNavigation`](#)
+- brukes i skjemaer med validering, bruk heller [`FormNavigation`](/docs/components-formnavigation--docs)
 
 ## Slik bruker du ProgressBar
 

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -17,6 +17,7 @@ export * from './link/Link';
 export * from './list/List';
 export * from './logo';
 export * from './popover/Popover';
+export * from './progressBar/ProgressBar';
 export * from './radio/Radio';
 export * from './search/Search';
 export * from './skipLink/SkipLink';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -8,6 +8,7 @@ export * from './card/Card';
 export * from './checkbox/Checkbox';
 export * from './details/Details';
 export * from './divider/Divider';
+export * from './dropdown/Dropdown';
 export * from './field/Field';
 export * from './fieldNecessity';
 export * from './fieldset/Fieldset';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -23,6 +23,7 @@ export * from './skipLink/SkipLink';
 export * from './spinner/Spinner';
 export * from './switch/Switch';
 export * from './tag/Tag';
+export * from './tooltip/Tooltip';
 export * from './typography/heading/Heading';
 export * from './typography/label/Label';
 export * from './typography/paragraph/Paragraph';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -7,6 +7,7 @@ export * from './button/Button';
 export * from './card/Card';
 export * from './checkbox/Checkbox';
 export * from './details/Details';
+export * from './dialog/Dialog';
 export * from './divider/Divider';
 export * from './field/Field';
 export * from './fieldNecessity';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './avatar/Avatar';
+export * from './breadcrumbs/Breadcrumbs';
 export * from './button/Button';
 export * from './card/Card';
 export * from './checkbox/Checkbox';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -22,6 +22,7 @@ export * from './search/Search';
 export * from './skipLink/SkipLink';
 export * from './spinner/Spinner';
 export * from './switch/Switch';
+export * from './tabs/Tabs';
 export * from './tag/Tag';
 export * from './typography/heading/Heading';
 export * from './typography/label/Label';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -23,6 +23,7 @@ export * from './skipLink/SkipLink';
 export * from './spinner/Spinner';
 export * from './switch/Switch';
 export * from './tag/Tag';
+export * from './textarea/Textarea';
 export * from './typography/heading/Heading';
 export * from './typography/label/Label';
 export * from './typography/paragraph/Paragraph';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -23,6 +23,7 @@ export * from './skipLink/SkipLink';
 export * from './spinner/Spinner';
 export * from './switch/Switch';
 export * from './tag/Tag';
+export * from './textfield/Textfield';
 export * from './typography/heading/Heading';
 export * from './typography/label/Label';
 export * from './typography/paragraph/Paragraph';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './avatar/Avatar';
+export * from './badge/Badge';
 export * from './button/Button';
 export * from './card/Card';
 export * from './checkbox/Checkbox';

--- a/@udir-design/react/src/components/stable.ts
+++ b/@udir-design/react/src/components/stable.ts
@@ -22,6 +22,7 @@ export * from './search/Search';
 export * from './skipLink/SkipLink';
 export * from './spinner/Spinner';
 export * from './switch/Switch';
+export * from './tableOfContents/TableOfContents';
 export * from './tag/Tag';
 export * from './typography/heading/Heading';
 export * from './typography/label/Label';

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.mdx
@@ -5,11 +5,11 @@ import * as TableOfContentStories from './TableOfContents.stories';
 
 # Table Of Contents
 
-`TableOfContents` gir brukeren bedre oversikt over innhold i lengre artikler. Komponenten inneholder lenker som scroller ned til den valgte overskriften.
+`TableOfContents` gir brukeren bedre oversikt over innholdet i lengre artikler. Komponenten inneholder lenker til overskriftene, slik at brukeren raskt kan navigere til ønsket del av siden.
 
 **Passer til å**
 
-- gi et overblikk på sider med mye innhold
+- gi overblikk på sider med mye innhold
 - la brukeren navigere til overskrifter på en side
 
 **Passer ikke til å**
@@ -47,9 +47,9 @@ const h = [
 
 ### Generere overskrifter automatisk
 
-Hooken [`useTableOfContents`](/docs/utilities-usetableofcontents--docs) kan brukes for å automatisk fylle `TableOfContents` med alle overskrifter som har en id, i dokumentet. Du kan velge om den skal ta med kun `h2` eller både `h2` og `h3`.
+Hooken [`useTableOfContents`](/docs/utilities-usetableofcontents--docs) kan brukes til å automatisk fylle `TableOfContents` med alle overskrifter i dokumentet som har en ID. Du kan velge om den skal inkludere bare `h2`, eller både `h2` og `h3`.
 
-Dersom det er enkelte overskrifter du ikke vil inkludere i innholdsfortegnelsen kan du bruke `data-toc-ignore` på `Heading`.
+Hvis det er enkelte overskrifter du ikke vil inkludere i innholdsfortegnelsen, kan du bruke `data-toc-ignore` på `Heading`.
 
 <Canvas
   of={TableOfContentStories.Automatic}
@@ -58,7 +58,7 @@ Dersom det er enkelte overskrifter du ikke vil inkludere i innholdsfortegnelsen 
 
 ### Legge til overskrifter manuelt
 
-Dersom du har behov for full kontroll over innholdet i `TableOfContents` kan du lage en liste av objekter som inneholder `name`, `level` og `id`. Id brukes til å lenke til riktig overskrift, så det er viktig at denne stemmer overens med overskriftens id i dokumentet.
+Dersom du har behov for full kontroll over innholdet i `TableOfContents`, kan du lage en liste med objekter som inneholder `name`, `level` og `id`. ID-en brukes til å lenke til riktig overskrift, så det er viktig at denne stemmer overens med overskriftens ID i dokumentet.
 
 <Canvas
   of={TableOfContentStories.Manual}
@@ -67,7 +67,7 @@ Dersom du har behov for full kontroll over innholdet i `TableOfContents` kan du 
 
 ### Starte i lukket tilstand
 
-`TableOfContents` starter som standard i åpnet tilstand. Du kan endre dette til å starte i lukket tilstand ved å sette `defaultClosed`.
+`TableOfContents` starter som standard i åpen tilstand. Du kan starte den i lukket tilstand ved å sette `defaultClosed`.
 
 <Canvas
   of={TableOfContentStories.DefaultClosed}
@@ -76,7 +76,7 @@ Dersom du har behov for full kontroll over innholdet i `TableOfContents` kan du 
 
 ### Kontrollert tilstand
 
-`TableOfContents` holder selv styr på om den er åpen eller lukket, men dette kan også kontrolleres ved å bruke `open` og `onToggle`. For eksempel kan vi styre tilstanden basert basert på om innholdsfortegnelsen er synlig eller ikke.
+`TableOfContents` holder selv styr på om den er åpen eller lukket, men dette kan også kontrolleres ved å bruke `open` og `onToggle`. For eksempel kan vi styre tilstanden basert på om innholdsfortegnelsen er synlig eller ikke.
 
 <Canvas
   of={TableOfContentStories.ControlledState}

--- a/@udir-design/react/src/components/tableOfContents/TableOfContents.stories.tsx
+++ b/@udir-design/react/src/components/tableOfContents/TableOfContents.stories.tsx
@@ -12,7 +12,7 @@ import { TableOfContents } from './TableOfContents';
 
 const meta = preview.meta({
   component: TableOfContents,
-  tags: ['beta', 'udir'],
+  tags: ['udir'],
   parameters: {
     componentOrigin: {
       originator: 'self',

--- a/@udir-design/react/src/components/tabs/Tabs.mdx
+++ b/@udir-design/react/src/components/tabs/Tabs.mdx
@@ -7,11 +7,11 @@ import * as TabsStories from './Tabs.stories';
 # Tabs
 
 `Tabs` lar brukerne navigere mellom relaterte deler av innholdet, der én del vises om gangen. Dette er en effektiv måte å organisere og presentere relatert innhold på samme side.
-Vær oppmerksom på at alle `Tabs.Panel` lastes inn når komponenten vises. Du kan selv implementere lasting av hver `Tabs.Panel` ved behov.
+Vær oppmerksom på at alle `Tabs.Panel` lastes inn når komponenten vises. Ved behov kan du selv implementere lasting av hver `Tabs.Panel`.
 
 **Passer til å**
 
-- strukturere innhold uten å laste en ny side
+- strukturere innhold uten å laste inn en ny side
 - dele opp innhold i tydelig merkede seksjoner
 - forenkle navigasjon når brukeren ikke trenger å se alt samtidig
 
@@ -19,7 +19,7 @@ Vær oppmerksom på at alle `Tabs.Panel` lastes inn når komponenten vises. Du k
 
 - gi en umiddelbar oversikt over innhold, da `Tabs` skjuler informasjon
 - presentere innhold som må sammenlignes på tvers av seksjoner
-- veilede brukeren gjennom en steg-for-steg-prosess der rekkefølgen er viktig
+- veilede brukeren gjennom en trinnvis prosess der rekkefølgen er viktig
 - erstatte hovednavigasjon eller brukes til filtrering og sortering
 - være en løsning når innholdet like gjerne kan vises på én side eller fordeles på flere sider
 
@@ -45,11 +45,11 @@ import { Tabs } from '@udir-design/react';
 
 ## Eksempler
 
-Tabbene i `Tabs` kan ha tre typer innhold:
+Tabene i `Tabs` kan ha tre typer innhold:
 
 - bare tekst
 - tekst med ikon til venstre for teksten
-- bare ikon med `Tooltip`
+- bare ikoner med `Tooltip`
 
 ### Bare tekst
 
@@ -57,19 +57,19 @@ Tabbene i `Tabs` kan ha tre typer innhold:
 
 ### Med ikoner og tekst
 
-Kombinasjonen av ikoner og tekst gir både visuell og tekstlig beskrivelse av innholdet. Ikonene skal markeres med `aria-hidden`.
+Kombinasjonen av ikoner og tekst gir både en visuell og tekstlig beskrivelse av innholdet. Ikonene skal markeres med `aria-hidden`.
 
 <Canvas of={TabsStories.IconsWithText} />
 
 ### Bare ikoner
 
-Alternativet "Bare ikon" brukes kun når du vet at brukerne vil forstå ikonet. Det kan for eksempel være ekspertbrukere eller brukere av interne tjenester, som kjenner symbolene i den aktuelle `Tabs` godt. Forklar handlingene med [`Tooltip`](/docs/components-tooltip--docs) når du kun bruker ikoner.
+Alternativet "Bare ikoner" brukes kun når du vet at brukerne vil forstå ikonene. Det kan for eksempel være ekspertbrukere eller brukere av interne tjenester som kjenner symbolene i den aktuelle `Tabs`-komponenten godt. Forklar handlingene med [`Tooltip`](/docs/components-tooltip--docs) når du kun bruker ikoner.
 
 <Canvas of={TabsStories.OnlyIcons} />
 
 ### Kontrollere Tabs utenfra
 
-Bruk `value` og `onChange` på `Tabs` for å kontrollere hvilken tab som er aktiv utenfra. Eksemplet nedenfor har en tab som er en liste over brukere og en annen som viser din profil. Når du klikker på din egen bruker i lista, endres den aktive taben til "Din profil".
+Bruk `value` og `onChange` på `Tabs` for å kontrollere hvilken tab som er aktiv utenfra. I eksemplet under er én tab en liste over brukere, og en annen viser din profil. Når du klikker på din egen bruker i listen, endres den aktive taben til "Din profil".
 
 <Canvas of={TabsStories.Controlled} />
 
@@ -83,13 +83,12 @@ Før du velger `Tabs`, vurder om det er bedre å:
 
 - forenkle og redusere mengden innhold
 - fordele innholdet på flere sider
-- beholde alt på én side, med tydelige overskrifter
+- beholde alt på én side med tydelige overskrifter
 - bruke en innholdsfortegnelse for enklere navigasjon
 
 ### Endre URL
 
-Tabs bør ikke ta brukeren til en ny side, da det vil være en uventet oppførsel som kan forvirre brukeren. En skjermleser vil også miste kontekst ved at den havner på toppen av siden etter ny innlasting.
-Noen ganger kan det likevel være nyttig å knytte valgt tab til en URL, uten at det teller som navigasjon. Det kan løses ved bruk av shallow-routing, noe de fleste routing-rammeverk støtter. Under er et eksempel med bruk av Next.js.
+`Tabs` bør ikke sende brukeren til en ny side, fordi det kan oppleves som uventet og forvirrende. En skjermleser vil også miste kontekst dersom brukeren havner øverst på siden etter ny innlasting. I noen tilfeller kan det likevel være nyttig å knytte valgt tab til en URL, uten at det regnes som navigasjon. Dette kan løses med shallow routing, som de fleste routing-rammeverk støtter. Under er et eksempel med Next.js.
 
 ```tsx
 <Tabs
@@ -107,25 +106,25 @@ Noen ganger kan det likevel være nyttig å knytte valgt tab til en URL, uten at
 
 ### Beste praksis
 
-- Begrens antall `Tabs` – for mange skaper dårlig oversikt, særlig på små skjermer.
-- Bruk tydelig navn på en tab – `Tabs` skjuler innhold, så taben må klart indikere hva brukeren får se.
-- Plasser viktigst innhold først – organiser `Tabs` etter brukerens behov.
-- Hold `Tabs` på én linje – lange `Tabs` eller for mange `Tabs` kan gjøre navigasjonen vanskelig.
-- Unngå deaktiverte `Tabs` – fjern deaktiverte `Tabs` eller forklar hvorfor de er tomme.
+- Begrens antall `Tabs` - for mange gir dårlig oversikt, særlig på små skjermer.
+- Bruk et tydelig navn på en tab - `Tabs` skjuler innhold, så hver tab må tydelig indikere hva brukeren får se.
+- Plasser det viktigste innholdet først - organiser `Tabs` etter brukerens behov.
+- Hold `Tabs` på én linje - lange `Tabs` eller for mange `Tabs` kan gjøre navigasjonen vanskelig.
+- Unngå deaktiverte `Tabs` - fjern deaktiverte `Tabs` eller forklar hvorfor de er tomme.
 
 ## Tekst i Tabs
 
 ### Tydelige merkelapper og overskrifter
 
-Teksten i `Tabs` bør være kort og beskrivende, slik at brukeren lett forstår hva de vil se når de klikker. Hvis det er vanskelig å lage presise tabber, kan det tyde på at innholdet ikke er godt strukturert.
+Teksten i `Tabs` bør være kort og beskrivende, slik at brukeren lett forstår hva de vil se når de klikker. Hvis det er vanskelig å lage presise tabnavn, kan det tyde på at innholdet ikke er godt nok strukturert.
 
-Hvis det er behov for å gi en overordnet kontekst, kan en felles tittel plasseres over `Tabs` som gir rask oversikt over innholdet.
+Hvis det er behov for å gi en overordnet kontekst, kan du plassere en felles tittel over `Tabs` for å gi en rask oversikt over innholdet.
 
 ## Tilgjengelighet
 
 - Hver tab må ha en unik tittel.
-- Ved bruk av ikoner, sørg for at de har `aria-hidden`.
-- Dersom et `Tabs.Panel` ikke har fokuserbare elementer, får selve panelet fokus.
+- Ved bruk av ikoner, sørg for at de markeres med `aria-hidden`.
+- Hvis et `Tabs.Panel` ikke har fokuserbare elementer, får selve panelet fokus.
 
 ### Tastaturnavigasjon
 

--- a/@udir-design/react/src/components/tabs/Tabs.mdx
+++ b/@udir-design/react/src/components/tabs/Tabs.mdx
@@ -69,7 +69,7 @@ Alternativet "Bare ikoner" brukes kun når du vet at brukerne vil forstå ikonen
 
 ### Kontrollere Tabs utenfra
 
-Bruk `value` og `onChange` på `Tabs` for å kontrollere hvilken tab som er aktiv utenfra. I eksemplet under er én tab en liste over brukere, og en annen viser din profil. Når du klikker på din egen bruker i listen, endres den aktive taben til "Din profil".
+Bruk `value` og `onChange` når en tilstand eller handling utenfor `Tabs` skal styre hvilken tab som er aktiv. I eksemplet under viser én tab en liste over brukere, mens en annen viser din profil. Når du klikker på din egen bruker i listen av brukere, byttes den aktive taben til «Din profil».
 
 <Canvas of={TabsStories.Controlled} />
 

--- a/@udir-design/react/src/components/tabs/Tabs.mdx
+++ b/@udir-design/react/src/components/tabs/Tabs.mdx
@@ -49,7 +49,7 @@ Tabene i `Tabs` kan ha tre typer innhold:
 
 - bare tekst
 - tekst med ikon til venstre for teksten
-- bare ikoner med `Tooltip`
+- bare ikoner med [`Tooltip`](/docs/components-tooltip--docs)
 
 ### Bare tekst
 
@@ -113,8 +113,6 @@ Før du velger `Tabs`, vurder om det er bedre å:
 - Unngå deaktiverte `Tabs` - fjern deaktiverte `Tabs` eller forklar hvorfor de er tomme.
 
 ## Tekst i Tabs
-
-### Tydelige merkelapper og overskrifter
 
 Teksten i `Tabs` bør være kort og beskrivende, slik at brukeren lett forstår hva de vil se når de klikker. Hvis det er vanskelig å lage presise tabnavn, kan det tyde på at innholdet ikke er godt nok strukturert.
 

--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -11,7 +11,7 @@ import {
   PersonIcon,
 } from '@udir-design/icons';
 import preview from '.storybook/preview';
-import { formatReactSource } from '.storybook/utils/sourceTransformers';
+import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Avatar } from '../avatar/Avatar';
 import { Button } from '../button/Button';
 import { Link } from '../link/Link';
@@ -38,7 +38,7 @@ const meta = preview.meta({
       originator: 'digdir',
     },
     layout: 'centered',
-    /* a11y complains on aria-controls on tabs when there is no tabs-panel, which there are several places in the examples */
+    /* a11y complains about aria-controls on tabs when there is no tab panel, which is the case in several examples */
     a11y: {
       config: {
         rules: [
@@ -153,6 +153,9 @@ export const OnlyText = meta.story({
           <Tabs.Tab value="prøver">Prøver</Tabs.Tab>
           <Tabs.Tab value="prøvesvar">Prøvesvar</Tabs.Tab>
         </Tabs.List>
+        <Tabs.Panel value="oversikt">Innhold for oversikt</Tabs.Panel>
+        <Tabs.Panel value="prøver">Innhold for prøver</Tabs.Panel>
+        <Tabs.Panel value="prøvesvar">Innhold for prøvesvar</Tabs.Panel>
       </Tabs>
     );
   },
@@ -179,6 +182,9 @@ export const IconsWithText = meta.story({
             Videregående
           </Tabs.Tab>
         </Tabs.List>
+        <Tabs.Panel value="barnehage">Innhold for barnehage</Tabs.Panel>
+        <Tabs.Panel value="grunnskole">Innhold for grunnskole</Tabs.Panel>
+        <Tabs.Panel value="videregående">Innhold for videregående</Tabs.Panel>
       </Tabs>
     );
   },
@@ -212,11 +218,21 @@ export const OnlyIcons = meta.story({
           </Tabs.Tab>
         </Tooltip>
       </Tabs.List>
+      <Tabs.Panel value="gallery">Innhold for galleri</Tabs.Panel>
+      <Tabs.Panel value="profile">Innhold for profilen din</Tabs.Panel>
+      <Tabs.Panel value="notifications">Innhold for varsler</Tabs.Panel>
+      <Tabs.Panel value="settings">Innhold for innstillinger</Tabs.Panel>
     </Tabs>
   ),
 });
 
 export const Controlled = meta.story({
+  parameters: {
+    customStyles: {
+      width: '500px',
+    },
+    docs: advancedCodeDocs,
+  },
   render: (args) => {
     const [tab, setTab] = useState('users');
     return (
@@ -311,11 +327,5 @@ export const Controlled = meta.story({
         </Tabs.Panel>
       </Tabs>
     );
-  },
-  parameters: {
-    customStyles: {
-      width: '500px',
-    },
-    docs: { source: { type: 'code', transform: formatReactSource } },
   },
 });

--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -32,7 +32,7 @@ const meta = preview.meta({
     'Tabs.Tab': TabsTab,
     'Tabs.Panel': TabsPanel,
   },
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -236,96 +236,74 @@ export const Controlled = meta.story({
   render: (args) => {
     const [tab, setTab] = useState('users');
     return (
-      <Tabs {...args} value={tab} onChange={setTab}>
-        <Tabs.List>
-          <Tabs.Tab value="users">
-            <PersonGroupIcon aria-hidden />
-            Brukere
-          </Tabs.Tab>
-          <Tabs.Tab value="profile">
-            <PersonIcon aria-hidden />
-            Din profil
-          </Tabs.Tab>
-        </Tabs.List>
-        <Tabs.Panel value="users">
-          <List.Unordered
-            style={{
-              listStyle: 'none',
-              padding: 0,
-            }}
-          >
-            <List.Item
-              style={{
-                display: 'flex',
-              }}
-            >
-              <Button variant="secondary" onClick={() => setTab('profile')}>
-                <Avatar aria-label="Bruker 1" data-color="accent" /> Hilde
-                Hansen (deg)
-              </Button>
-            </List.Item>
-            <List.Item
-              style={{
-                display: 'flex',
-              }}
-            >
-              <Link
-                href="#"
-                style={{
-                  alignItems: 'center',
-                  display: 'flex',
-                  gap: 'var(--ds-size-2)',
-                }}
-              >
-                <Avatar aria-label="Bruker 2" data-color="support1" />
-                Stian Stølan
-              </Link>
-            </List.Item>
-            <List.Item
-              style={{
-                display: 'flex',
-              }}
-            >
-              <Link
-                href="#"
-                style={{
-                  alignItems: 'center',
-                  display: 'flex',
-                  gap: 'var(--ds-size-2)',
-                }}
-              >
-                <Avatar aria-label="Bruker 3" data-color="support2" />
-                Lina Larsen
-              </Link>
-            </List.Item>
-          </List.Unordered>
-        </Tabs.Panel>
-        <Tabs.Panel value="profile">
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 'var(--ds-size-2)',
-            }}
-          >
-            <Avatar aria-label="Bruker 1" data-color="accent" /> Hilde Hansen
-          </div>
+      <>
+        <style>
+          {`
+          .example-list-unordered {
+            list-style: none;
+            padding: 0;
+          }
+          .example-list-item {
+            display: flex;
+           }
+          .example-list-content {
+            align-items: center;
+            display: flex;
+            gap: var(--ds-size-2);
+          }
+          .example-list-header {
+            margin-bottom: var(--ds-size-2);
+            margin-top: var(--ds-size-4);
+          }`}
+        </style>
+        <Tabs {...args} value={tab} onChange={setTab}>
+          <Tabs.List>
+            <Tabs.Tab value="users">
+              <PersonGroupIcon aria-hidden />
+              Brukere
+            </Tabs.Tab>
+            <Tabs.Tab value="profile">
+              <PersonIcon aria-hidden />
+              Din profil
+            </Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="users">
+            <List.Unordered className="example-list-unordered">
+              <List.Item className="example-list-item">
+                <Button variant="secondary" onClick={() => setTab('profile')}>
+                  <Avatar aria-label="Bruker 1" data-color="accent" /> Hilde
+                  Hansen (deg)
+                </Button>
+              </List.Item>
+              <List.Item className="example-list-item">
+                <Link href="#" className="example-list-content">
+                  <Avatar aria-label="Bruker 2" data-color="support1" />
+                  Stian Stølan
+                </Link>
+              </List.Item>
+              <List.Item className="example-list-item">
+                <Link href="#" className="example-list-content">
+                  <Avatar aria-label="Bruker 3" data-color="support2" />
+                  Lina Larsen
+                </Link>
+              </List.Item>
+            </List.Unordered>
+          </Tabs.Panel>
+          <Tabs.Panel value="profile">
+            <div className="example-list-content">
+              <Avatar aria-label="Bruker 1" data-color="accent" /> Hilde Hansen
+            </div>
 
-          <Heading
-            level={3}
-            style={{
-              marginBottom: 'var(--ds-size-2)',
-              marginTop: 'var(--ds-size-4)',
-            }}
-          >
-            Detaljer
-          </Heading>
-          <Paragraph>34 år</Paragraph>
-          <Paragraph>Mysen, Norge</Paragraph>
-          <Paragraph>Lærer</Paragraph>
-          <Paragraph>Mysen Videregående skole</Paragraph>
-        </Tabs.Panel>
-      </Tabs>
+            <Heading level={3} className="example-list-header">
+              Detaljer
+            </Heading>
+            <Paragraph>34 år</Paragraph>
+            <Paragraph>Mysen, Norge</Paragraph>
+            <Paragraph>Lærer</Paragraph>
+            <Paragraph>Mysen Videregående skole</Paragraph>
+          </Tabs.Panel>
+        </Tabs>
+      </>
     );
   },
 });

--- a/@udir-design/react/src/components/tabs/__snapshots__/Tabs.stories.tsx.snap
+++ b/@udir-design/react/src/components/tabs/__snapshots__/Tabs.stories.tsx.snap
@@ -158,6 +158,7 @@ exports[`Icons With Text 1`] = `
       role="tab"
       aria-selected="true"
       tabindex="0"
+      id="<removed>"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -234,6 +235,31 @@ exports[`Icons With Text 1`] = `
       Videregående
     </ds-tab>
   </ds-tablist>
+  <ds-tabpanel
+    id="<removed>"
+    aria-hidden="false"
+    tabindex="0"
+    aria-labelledby="<removed>"
+    role="tabpanel"
+  >
+    Innhold for barnehage
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Innhold for grunnskole
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Innhold for videregående
+  </ds-tabpanel>
 </ds-tabs>
 `;
 
@@ -249,6 +275,7 @@ exports[`Only Icons 1`] = `
       role="tab"
       aria-selected="false"
       tabindex="-1"
+      id="<removed>"
       aria-label="Galleri"
     >
       <svg
@@ -279,6 +306,7 @@ exports[`Only Icons 1`] = `
       role="tab"
       aria-selected="true"
       tabindex="0"
+      id="<removed>"
       aria-label="Profilen din"
     >
       <svg
@@ -361,6 +389,40 @@ exports[`Only Icons 1`] = `
       </svg>
     </ds-tab>
   </ds-tablist>
+  <ds-tabpanel
+    id="<removed>"
+    aria-hidden="true"
+    aria-labelledby="<removed>"
+    role="tabpanel"
+    hidden
+  >
+    Innhold for galleri
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="false"
+    tabindex="0"
+    aria-labelledby="<removed>"
+  >
+    Innhold for profilen din
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Innhold for varsler
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Innhold for innstillinger
+  </ds-tabpanel>
 </ds-tabs>
 `;
 
@@ -373,6 +435,7 @@ exports[`Only Text 1`] = `
       role="tab"
       aria-selected="true"
       tabindex="0"
+      id="<removed>"
     >
       Oversikt
     </ds-tab>
@@ -395,6 +458,31 @@ exports[`Only Text 1`] = `
       Prøvesvar
     </ds-tab>
   </ds-tablist>
+  <ds-tabpanel
+    id="<removed>"
+    aria-hidden="false"
+    tabindex="0"
+    aria-labelledby="<removed>"
+    role="tabpanel"
+  >
+    Innhold for oversikt
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Innhold for prøver
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Innhold for prøvesvar
+  </ds-tabpanel>
 </ds-tabs>
 `;
 

--- a/@udir-design/react/src/components/tabs/__snapshots__/Tabs.stories.tsx.snap
+++ b/@udir-design/react/src/components/tabs/__snapshots__/Tabs.stories.tsx.snap
@@ -1,6 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Controlled 1`] = `
+<style>
+  .example-list-unordered {
+            list-style: none;
+            padding: 0;
+          }
+          .example-list-item {
+            display: flex;
+           }
+          .example-list-content {
+            align-items: center;
+            display: flex;
+            gap: var(--ds-size-2);
+          }
+          .example-list-header {
+            margin-bottom: var(--ds-size-2);
+            margin-top: var(--ds-size-4);
+          }
+</style>
 <ds-tabs>
   <ds-tablist role="tablist">
     <ds-tab
@@ -66,8 +84,8 @@ exports[`Controlled 1`] = `
     aria-labelledby="<removed>"
     role="tabpanel"
   >
-    <ul style="<removed>">
-      <li style="<removed>">
+    <ul>
+      <li>
         <button
           data-variant="secondary"
           type="button"
@@ -82,11 +100,8 @@ exports[`Controlled 1`] = `
           Hilde Hansen (deg)
         </button>
       </li>
-      <li style="<removed>">
-        <a
-          href="#"
-          style="<removed>"
-        >
+      <li>
+        <a href="#">
           <span
             data-variant="circle"
             role="img"
@@ -97,11 +112,8 @@ exports[`Controlled 1`] = `
           Stian Stølan
         </a>
       </li>
-      <li style="<removed>">
-        <a
-          href="#"
-          style="<removed>"
-        >
+      <li>
+        <a href="#">
           <span
             data-variant="circle"
             role="img"
@@ -120,7 +132,7 @@ exports[`Controlled 1`] = `
     aria-hidden="true"
     hidden
   >
-    <div style="<removed>">
+    <div>
       <span
         data-variant="circle"
         role="img"
@@ -130,7 +142,7 @@ exports[`Controlled 1`] = `
       </span>
       Hilde Hansen
     </div>
-    <h3 style="<removed>">
+    <h3>
       Detaljer
     </h3>
     <p data-variant="default">

--- a/@udir-design/react/src/components/textarea/Textarea.mdx
+++ b/@udir-design/react/src/components/textarea/Textarea.mdx
@@ -6,21 +6,21 @@ import * as TextareaStories from './Textarea.stories';
 
 # Textarea
 
-`Textarea` er et skjemaelement for å samle inn tekst som er lengre enn én linje. Det tilbyr grunnleggende funksjonalitet og er nyttig når du trenger full kontroll over komponentenes oppsett og validering, noe som gjør det ideelt for bygging av spesialtilpassede elementer.
+`Textarea` er et skjemaelement for å samle inn tekst som er lengre enn én linje. Komponenten gir grunnleggende funksjonalitet og er nyttig når du trenger full kontroll over oppsett og validering, noe som gjør det ideelt for bygging av spesialtilpassede elementer.
 
-Se også [`Textfield`](/docs/components-textfield--docs) som er en gruppering av komponenter som ofte brukes sammen. Da slipper du å sy sammen `Label`, `Description`, `Input` og `ValidationMessage` selv hver gang.
+Se også [`Textfield`](/docs/components-textfield--docs) som er en gruppering av komponenter som ofte brukes sammen. Da slipper du å sette sammen `Label`, `Description`, `Input` og `ValidationMessage` manuelt hver gang.
 
 **Passer til å**
 
-- la brukeren skrive mer enn én linje tekst
-- være et tekstfelt der det ikke finnes en forhåndsdefinert liste med svaralternativer
-- gi brukeren plass til å formulere seg fritt
-- skreddersy større tekstfelter til spesifikke behov
+- la brukeren skrive tekst over flere linjer
+- samle inn åpne svar der det ikke finnes forhåndsdefinerte svaralternativer
+- gi brukeren rom til å formulere seg fritt
+- tilpasse større tekstfelter til spesifikke behov
 
 **Passer ikke til å**
 
-- motta korte svar som navn, e-postadresser og telefonnummer - bruk [`Input`](/docs/components-input--docs) for disse
-- motta strukturerte data som skal valideres, f.eks fødselsnummer eller dato
+- motta korte svar som navn, e-postadresser og telefonnummer - bruk [`Input`](/docs/components-input--docs) i stedet
+- motta strukturerte data som krever validering, for eksempel fødselsnummer eller dato
 
 ## Slik bruker du Textarea
 
@@ -51,27 +51,27 @@ import { Textarea, Label } from '@udir-design/react';
 
 ## Retningslinjer
 
-Bruk `Textarea` når brukerne forventes å skrive inn mer enn én linje med tekst, for eksempel ved åpne spørsmål, tilbakemeldinger, eller andre situasjoner hvor lengre tekstinnhold er nødvendig.
+Bruk `Textarea` når brukerne forventes å skrive mer enn én linje tekst, for eksempel ved åpne spørsmål, tilbakemeldinger eller andre situasjoner hvor lengre tekstinnhold er nødvendig.
 
-Vær oppmerksom på at brukerne kan synes det er vanskelig å skrive fritekst eller svare på åpne spørsmål. Noen ganger kan det være bedre å bryte opp spørsmålet i flere enklere spørsmål, og gi brukerne mulighet til å svare med for eksempel [`Radio`](/docs/components-radio--docs).
+Vær oppmerksom på at å skrive fritekst eller svare på åpne spørsmål kan oppleves som krevende for noen brukere. Vurder derfor om spørsmålet kan deles opp i flere enklere spørsmål, eller om brukeren heller kan svare med for eksempel [`Radio`](/docs/components-radio--docs).
 
 ### Høyden på tekstområdet
 
-Høyden på `Textarea` bør tilpasses forventet tekstmengde. Forventer du at brukeren skal skrive tre linjer, bør høyden reflektere dette. For lengre tekster er det viktig å gi mer visuell plass for en bedre brukeropplevelse. Du kan endre høyde med `rows="{number}"`.
+Høyden på `Textarea` bør tilpasses forventet tekstmengde. Forventer du at brukeren skal skrive tre linjer, bør høyden reflektere dette. For lengre svar bør feltet få mer visuell plass for å gi en bedre brukeropplevelse. Du kan justere høyden med `rows="{number}"`.
 
-`Textarea` skal kunne tilpasses i høyden, når brukeren har behov for mer plass. Feltet vil automatisk utvide seg når brukeren skriver, dersom du ikke setter `rows`, slik at de alltid kan se hele innholdet sitt uten å måtte bruke rullefelt.
+`Textarea` skal kunne tilpasses i høyden dersom brukeren har behov for mer plass. Hvis antall rader ikke er satt, utvider feltet seg automatisk når brukeren skriver, slik at innholdet forblir synlig uten bruk av rullefelt.
 
 ### Bredden på tekstområdet
 
-Et tekstområde bør ikke være bredere enn 50-75 tegn inkludert mellomrom. Hvis vi holder oss til det, blir lesbarheten best for alle brukere.
+Et tekstområde bør ikke være bredere enn 50-75 tegn, inkludert mellomrom. Dette gir best lesbarhet for brukerne.
 
 ### Øvrige retningslinjer
 
-I tillegg til de retningslinjene, bør du også følge de generelle retninglinjene for [`Textfield`](/docs/components-Textfield--docs) og [`Input`](/docs/components-input--docs).
+I tillegg til retningslinjene over, bør du følge de generelle retningslinjene for [`Textfield`](/docs/components-textfield--docs) og [`Input`](/docs/components-input--docs).
 
 - [Unngå plassholdertekster](/docs/components-textfield--docs#unng%C3%A5-placeholder)
 - [Inndata og formatering](/docs/components-textfield--docs#inndata)
 - [Tekst i komponenten](/docs/components-textfield--docs#tekst-i-textfield)
-- [Ikke bruk deaktivert Textfield](/docs/components-textfield--docs#ikke-bruk-deaktivert-textfield)
-- [Unngå skrivebeskyttet Textfield](/docs/components-textfield--docs#unng%C3%A5-skrivebeskyttet-textfield)
+- [Ikke bruk deaktivert `Textfield`](/docs/components-textfield--docs#ikke-bruk-deaktivert-textfield)
+- [Unngå skrivebeskyttet `Textfield`](/docs/components-textfield--docs#unng%C3%A5-skrivebeskyttet-textfield)
 - [Tilgjengelighet](/docs/components-textfield--docs#tilgjengelighet)

--- a/@udir-design/react/src/components/textarea/Textarea.stories.tsx
+++ b/@udir-design/react/src/components/textarea/Textarea.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Button } from '../button/Button';
 import { Field } from '../field/Field';
 import { Label } from '../typography/label/Label';
@@ -101,6 +102,7 @@ export const Controlled = meta.story({
       flexDirection: 'column',
       gap: 'var(--ds-size-2)',
     },
+    docs: advancedCodeDocs,
   },
   render: (args) => {
     const [value, setValue] = useState(`${args.value || ''}`);

--- a/@udir-design/react/src/components/textarea/Textarea.stories.tsx
+++ b/@udir-design/react/src/components/textarea/Textarea.stories.tsx
@@ -9,7 +9,7 @@ import { Textarea as FakeTextarea } from './docs/FakeTextarea';
 
 const meta = preview.meta({
   component: FakeTextarea,
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/textarea/Textarea.stories.tsx
+++ b/@udir-design/react/src/components/textarea/Textarea.stories.tsx
@@ -29,6 +29,7 @@ export const Preview = meta.story({
     rows: 3,
     cols: 20,
     id: 'my-textarea',
+    autoComplete: 'off',
   },
   render: (args) => (
     <Field>
@@ -74,6 +75,7 @@ export const Preview = meta.story({
 export const FullWidth = meta.story({
   args: {
     id: 'my-textarea',
+    autoComplete: 'off',
   },
   parameters: {
     customStyles: {
@@ -91,6 +93,7 @@ export const FullWidth = meta.story({
 export const Controlled = meta.story({
   args: {
     id: 'textfield-controlled',
+    autoComplete: 'off',
   },
   parameters: {
     customStyles: {
@@ -131,6 +134,7 @@ export const Disabled = meta.story({
   args: {
     id: 'textarea-disabled',
     disabled: true,
+    autoComplete: 'off',
   },
   render: (args) => (
     <Field>
@@ -144,6 +148,7 @@ export const ReadOnly = meta.story({
   args: {
     id: 'textarea-readonly',
     readOnly: true,
+    autoComplete: 'off',
   },
   render: (args) => (
     <Field>

--- a/@udir-design/react/src/components/textarea/__snapshots__/Textarea.stories.tsx.snap
+++ b/@udir-design/react/src/components/textarea/__snapshots__/Textarea.stories.tsx.snap
@@ -10,6 +10,7 @@ exports[`Controlled 1`] = `
   </label>
   <textarea
     id="<removed>"
+    autocomplete="off"
     rows="4"
     style="<removed>"
   >
@@ -35,6 +36,7 @@ exports[`Disabled 1`] = `
   <textarea
     id="<removed>"
     disabled
+    autocomplete="off"
     style="<removed>"
   >
   </textarea>
@@ -53,6 +55,7 @@ exports[`Focused 1`] = `
     rows="3"
     cols="20"
     id="<removed>"
+    autocomplete="off"
     style="<removed>"
   >
   </textarea>
@@ -69,6 +72,7 @@ exports[`Full Width 1`] = `
   </label>
   <textarea
     id="<removed>"
+    autocomplete="off"
     style="<removed>"
   >
   </textarea>
@@ -87,6 +91,7 @@ exports[`Preview 1`] = `
     rows="3"
     cols="20"
     id="<removed>"
+    autocomplete="off"
     style="<removed>"
   >
   </textarea>
@@ -104,6 +109,7 @@ exports[`Read Only 1`] = `
   <textarea
     id="<removed>"
     readonly
+    autocomplete="off"
     style="<removed>"
   >
   </textarea>

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -43,7 +43,7 @@ Du endrer til `Textarea` ved å sette `multiline` til `true`. Da kan brukerne sk
 
 ### Prefix/Suffix
 
-Prefixer og suffixer er nyttige for å vise enheter, valuta eller annen informasjon som er relevant for feltet. Disse skal **ikke** brukes alene, da skjermlesere ikke leser dem opp. Det er viktig at samme informasjon som vises i prefixet eller suffixet, også inkluderes i `label`.
+Prefixer og suffixer er nyttige for å vise enheter, valuta eller annen informasjon som er relevant for feltet. Disse skal **ikke** brukes alene, siden skjermlesere ikke leser dem opp. Det er derfor viktig at samme informasjon som vises i prefixet eller suffixet, også inkluderes i `label`.
 
 <Canvas of={TextfieldStories.Affix} />
 
@@ -69,7 +69,7 @@ Tilstanden til `Textfield` kan kontrolleres ved å bruke `value` og `onChange`. 
 
 ### Unngå placeholder
 
-`Placeholder` forsvinner når brukerne skriver i feltet. Det er derfor bedre å inkludere hint og viktig informasjon i `label` eller den tilhørende beskrivelsen. For å oppfylle kontrastkravene i WCAG må placeholder-teksten ha så stor kontrast mot bakgrunnen at brukerne kan misforstå og tro at textfield er utfylt.
+`Placeholder` forsvinner når brukerne skriver i feltet. Det er derfor bedre å inkludere hint og viktig informasjon i `label` eller den tilhørende beskrivelsen. For å oppfylle kontrastkravene i WCAG må placeholder-teksten ha høy nok kontrast mot bakgrunnen. Dette kan føre til at brukere mistolker feltet som allerede utfylt.
 
 ### Tilpass bredden på tekstfeltet
 
@@ -77,7 +77,7 @@ Tilpass bredden etter hva brukerne skal skrive inn - f.eks. kort bredde for tele
 
 ### Tillat kopier og lim inn
 
-Brukere som skal fylle ut et tekstområde, trenger ofte å kopiere og lime inn informasjon, så denne funksjonen må ikke deaktiveres. Dette gjør det enkelt for brukerne å fylle inn nødvendige opplysninger uten begrensninger.
+Brukere som skal fylle ut et tekstområde, trenger ofte å kopiere og lime inn informasjon. Denne funksjonen bør derfor ikke deaktiveres, siden det gjør det enklere å fylle inn nødvendige opplysninger uten begrensninger.
 
 ### Inndata
 

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -16,6 +16,11 @@ Den har innebygget `label`, `description`, `validationmessage`, `affix` og `coun
 
 - skrive inn korte tekster (`multiline={false}`)
 - skrive inn lengre tekster (`multiline={true}`)
+- håndere skjemafelt med label, hjelpetekst og valideringsmeldinger
+
+**Passer ikke til å**
+
+- velge mellom forhåndsdefinerte alternativer, bruk heller [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs), [`Select`](/docs/components-select--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
 
 ## Slik bruker du Textfield
 

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -131,7 +131,7 @@ export const Format = meta.story({
   parameters: {
     docs: advancedCodeDocs,
   },
-  render: () => {
+  render: (args) => {
     const [nationalIdentityNumber, setNationalIdentityNumber] =
       useState<string>('');
     const tooLong = nationalIdentityNumber.length > 11;
@@ -144,6 +144,8 @@ export const Format = meta.story({
 
     return (
       <Textfield
+        {...args}
+        autocomplete="off"
         label="Fødselsnummer"
         id="format"
         inputMode="numeric"

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -131,7 +131,7 @@ export const Format = meta.story({
   parameters: {
     docs: advancedCodeDocs,
   },
-  render: (args) => {
+  render: () => {
     const [nationalIdentityNumber, setNationalIdentityNumber] =
       useState<string>('');
     const tooLong = nationalIdentityNumber.length > 11;
@@ -144,8 +144,7 @@ export const Format = meta.story({
 
     return (
       <Textfield
-        {...args}
-        autocomplete="off"
+        autoComplete="off"
         label="Fødselsnummer"
         id="format"
         inputMode="numeric"

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -2,10 +2,10 @@ import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Button } from '../button/Button';
 import { Divider } from '../divider/Divider';
 import { Paragraph } from '../typography/paragraph/Paragraph';
-import { ValidationMessage } from '../typography/validationMessage/ValidationMessage';
 import { Textfield } from './Textfield';
 
 const meta = preview.meta({
@@ -89,20 +89,11 @@ export const Preview = meta.story({
       expect(input).not.toHaveFocus();
     });
 
-    if (!args.disabled && !args.readOnly) {
-      await step('User can type in the text field', async () => {
-        await userEvent.clear(input);
-        await userEvent.type(input, 'Hello World');
-        expect(input).toHaveValue('Hello World');
-      });
-    } else {
-      await step(
-        'Text field is disabled or read-only so it should not be editable',
-        async () => {
-          expect(input).toBeDisabled();
-        },
-      );
-    }
+    await step('User can type in the text field', async () => {
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Hello World');
+      expect(input).toHaveValue('Hello World');
+    });
   },
 });
 
@@ -126,18 +117,20 @@ export const Affix = meta.story({
 });
 
 export const Counter = meta.story({
-  render: () => (
-    <Textfield
-      id="textfield-counter"
-      multiline
-      rows={4}
-      label="Legg til en beskrivelse"
-      counter={75}
-    />
-  ),
+  args: {
+    id: 'textfield-counter',
+    label: 'Legg til en beskrivelse',
+    multiline: true,
+    rows: 4,
+    counter: 75,
+  },
+  render: (args) => <Textfield {...args} />,
 });
 
 export const Format = meta.story({
+  parameters: {
+    docs: advancedCodeDocs,
+  },
   render: () => {
     const [nationalIdentityNumber, setNationalIdentityNumber] =
       useState<string>('');
@@ -145,29 +138,24 @@ export const Format = meta.story({
     const hasNonDigits = /\D/.test(nationalIdentityNumber);
 
     const updateNumber = (e: ChangeEvent<HTMLInputElement>) => {
-      // removing spaces from stored value so users can space how they like withour error message
+      // removing spaces from stored value so users can space how they like without error message
       setNationalIdentityNumber(e.target.value.replace(/\s+/g, ''));
     };
 
     return (
-      <>
-        <Textfield
-          label="Fødselsnummer"
-          id="format"
-          inputMode="numeric"
-          onChange={(e) => updateNumber(e)}
-        />
-        {tooLong && (
-          <ValidationMessage>
-            Fødselsnummer skal kun være 11 tegn
-          </ValidationMessage>
-        )}
-        {hasNonDigits && (
-          <ValidationMessage>
-            Fødselsnummer skal kun inneholde siffere
-          </ValidationMessage>
-        )}
-      </>
+      <Textfield
+        label="Fødselsnummer"
+        id="format"
+        inputMode="numeric"
+        onChange={(e) => updateNumber(e)}
+        error={
+          tooLong
+            ? 'Fødselsnummer skal kun være 11 tegn'
+            : hasNonDigits
+              ? 'Fødselsnummer skal kun inneholde siffere'
+              : undefined
+        }
+      />
     );
   },
 });
@@ -176,6 +164,7 @@ export const Controlled = meta.story({
   args: {
     label: 'Fullt navn',
     id: 'textfield-controlled',
+    autoComplete: 'name',
   },
   parameters: {
     customStyles: {
@@ -183,6 +172,7 @@ export const Controlled = meta.story({
       flexDirection: 'column',
       gap: 'var(--ds-size-2)',
     },
+    docs: advancedCodeDocs,
   },
   render: (args) => {
     const [value, setValue] = useState<string>('');

--- a/@udir-design/react/src/components/textfield/Textfield.stories.tsx
+++ b/@udir-design/react/src/components/textfield/Textfield.stories.tsx
@@ -10,7 +10,7 @@ import { Textfield } from './Textfield';
 
 const meta = preview.meta({
   component: Textfield,
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   argTypes: {
     multiline: {
       type: 'boolean',

--- a/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
+++ b/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
@@ -141,6 +141,7 @@ exports[`Format 1`] = `
   </label>
   <div>
     <input
+      autocomplete="off"
       id="<removed>"
       inputmode="numeric"
       type="text"

--- a/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
+++ b/@udir-design/react/src/components/textfield/__snapshots__/Textfield.stories.tsx.snap
@@ -36,6 +36,7 @@ exports[`Controlled 1`] = `
     <div>
       <input
         id="<removed>"
+        autocomplete="name"
         type="text"
         value
       >

--- a/@udir-design/react/src/components/tooltip/Tooltip.mdx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.mdx
@@ -59,7 +59,7 @@ Hvis du trenger å vise rikt innhold, for eksempel lengre tekster, bilder eller 
 
 ## Tekst i Tooltip
 
-En `Tooltip` bør være kort, helst én setning og maks fire ord, slik at den ikke dekker annet viktig innhold på skjermen. En `Tooltip` skal heller ikke gjenta tekst som allerede finnes på siden. Den skal i stedet gi ekstra hjelp eller forklare noe som ikke er åpenbart ved første øyekast.
+En `Tooltip` bør være kort og ikke inneholde mer enn én kort setning eller noen få ord, slik at den ikke dekker annet viktig innhold på skjermen. En `Tooltip` skal heller ikke gjenta tekst som allerede finnes på siden. Den skal i stedet gi ekstra hjelp eller forklare noe som ikke er åpenbart ved første øyekast.
 
 ## Tilgjengelighet
 

--- a/@udir-design/react/src/components/tooltip/Tooltip.mdx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.mdx
@@ -59,7 +59,7 @@ Hvis du trenger å vise rikt innhold, for eksempel lengre tekster, bilder eller 
 
 ## Tekst i Tooltip
 
-En `Tooltip` bør være kort og ikke inneholde mer enn én kort setning eller noen få ord, slik at den ikke dekker annet viktig innhold på skjermen. En `Tooltip` skal heller ikke gjenta tekst som allerede finnes på siden. Den skal i stedet gi ekstra hjelp eller forklare noe som ikke er åpenbart ved første øyekast.
+En `Tooltip` bør være kort, helst ett eller noen få ord, slik at den ikke dekker annet viktig innhold på skjermen. En `Tooltip` skal heller ikke gjenta tekst som allerede finnes på siden. Den skal i stedet gi ekstra hjelp eller forklare noe som ikke er åpenbart ved første øyekast.
 
 ## Tilgjengelighet
 

--- a/@udir-design/react/src/components/tooltip/Tooltip.mdx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.mdx
@@ -45,35 +45,35 @@ Vurder om `Tooltip` skal plasseres over, under eller ved siden av elementet.
 
 ### Tilgjengelig label eller description
 
-Dersom det ikke er tekst i trigger-elementet, vil tooltip-innholdet bli brukt som tilgjengelig tekst (label). I motsatt fall fungerer det som tilleggsinformasjon (description). Teknisk skjer dette ved at vi automatisk setter enten `aria-labelledby` eller `aria-describedby`. Du kan overstyre dette ved å bruke `type`-prop'en på `Tooltip`.
+Hvis trigger-elementet ikke har synlig tekst, brukes innholdet i `Tooltip` som tilgjengelig tekst (label). Hvis trigger-elementet allerede har tekst, brukes tooltipen som tilleggsinformasjon (description). Teknisk gjøres dette med `aria-labelledby` eller `aria-describedby`. Du kan overstyre dette ved å bruke `type`-propen på `Tooltip`.
 
 <Canvas of={TooltipStories.Aria} />
 
 ## Retningslinjer
 
-`Tooltip` gir kort tilleggsinformasjon uten å forstyrre hovedinnholdet. `Tooltip` er ikke ment for informasjon som er essensiell for å fullføre oppgaven. Viktig innhold bør i stedet plasseres som `brødtekst` eller `hjelpetekst` på selve siden.
+`Tooltip` gir kort tilleggsinformasjon uten å forstyrre hovedinnholdet. `Tooltip` er ikke ment for informasjon som er nødvendig for å fullføre en oppgave. Viktig innhold bør heller plasseres som `brødtekst` eller `hjelpetekst` på selve siden.
 
-`Tooltip` rendrer en `<span>`, så du kan bruke den i f.eks. `<div>`, men ikke inni `<svg>`.
+`Tooltip` rendrer en `<span>` og kan derfor brukes i for eksempel en `<div>`, men ikke inni en `<svg>`.
 
-Hvis det er behov for å vise rikt innhold, for eksempel lengre tekster, bilder eller knapper, kan vi i stedet bruke en [`Popover`](/docs/components-popover--docs).
+Hvis du trenger å vise rikt innhold, for eksempel lengre tekster, bilder eller knapper, kan du bruke [`Popover`](/docs/components-popover--docs) i stedet.
 
 ## Tekst i Tooltip
 
-En `Tooltip` skal ikke inneholde mer enn en setning eller maks fire ord, for å unngå at de blokkerer annet viktig innhold på skjermen. `Tooltip` skal ikke gjenta tekst som allerede finnes på siden. De skal tilby ekstra hjelp eller forklaringer som ikke er åpenbare ved første øyekast.
+En `Tooltip` bør være kort, helst én setning og maks fire ord, slik at den ikke dekker annet viktig innhold på skjermen. En `Tooltip` skal heller ikke gjenta tekst som allerede finnes på siden. Den skal i stedet gi ekstra hjelp eller forklare noe som ikke er åpenbart ved første øyekast.
 
 ## Tilgjengelighet
 
 ### Interaksjon med mus
 
-`Tooltip` vises når et element får hover, og blir borte når musen forlater elementet.
+`Tooltip` vises når brukeren holder musepekeren over et element, og skjules når musepekeren flyttes bort.
 
 ### Interaksjon med tastatur
 
-`Tooltip` vises når et element får tastaturfokus, og forsvinner når fokus fjernes.
+`Tooltip` vises når et element får tastaturfokus, og skjules når fokuset fjernes.
 
 ### Interaksjon med touch
 
-På berøringsskjermer er `Tooltip` mindre egnet, fordi de vanligvis aktiveres ved `hover` eller `fokus`, som ikke støttes på disse enhetene. `Tooltip` vises i stedet kun når brukeren trykker på elementet, og forsvinner igjen når brukeren trykker utenfor elementet.
+På berøringsskjermer er `Tooltip` mindre egnet, fordi de vanligvis aktiveres ved `hover` eller `fokus`, som ikke støttes på disse enhetene. `Tooltip` vises i stedet kun når brukeren trykker på elementet, og skjules igjen når brukeren trykker utenfor elementet.
 
 ## Kompatibilitet
 
@@ -81,6 +81,6 @@ I Safari fungerer ikke fade-in animasjon.
 
 ### Polyfill
 
-`Tooltip` bruker [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). Dette API-et er klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024, da Firefox som siste nettleser la det til. I noen tilfeller kan en oppleve at brukere av ulike grunner er låst til eldre nettleserversjoner, og da kan det være aktuelt å legge til en polyfill for å sikre at `Tooltip` fungerer for alle.
+`Tooltip` bruker [Popover API-et](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). Dette API-et ble klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) i april 2024, da Firefox som siste nettleser fikk støtte. I noen tilfeller kan enkelte brukere fortsatt være låst til eldre nettleserversjoner. I slike tilfeller kan det være aktuelt å legge til en polyfill for å sikre at `Tooltip` fungerer for alle.
 
 - [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)

--- a/@udir-design/react/src/components/tooltip/Tooltip.mdx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.mdx
@@ -45,7 +45,7 @@ Vurder om `Tooltip` skal plasseres over, under eller ved siden av elementet.
 
 ### Tilgjengelig label eller description
 
-Hvis trigger-elementet ikke har synlig tekst, brukes innholdet i `Tooltip` som tilgjengelig tekst (label). Hvis trigger-elementet allerede har tekst, brukes tooltipen som tilleggsinformasjon (description). Teknisk gjøres dette med `aria-labelledby` eller `aria-describedby`. Du kan overstyre dette ved å bruke `type`-propen på `Tooltip`.
+Hvis trigger-elementet ikke har synlig tekst, brukes innholdet i `Tooltip` som tilgjengelig tekst (label). Hvis trigger-elementet allerede har tekst, brukes tooltipen som tilleggsinformasjon (description). Teknisk gjøres dette med `aria-label` eller `aria-description`.
 
 <Canvas of={TooltipStories.Aria} />
 

--- a/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
@@ -12,7 +12,7 @@ import { Tooltip } from './Tooltip';
 
 const meta = preview.meta({
   component: Tooltip,
-  tags: ['beta', 'digdir'],
+  tags: ['digdir'],
   parameters: {
     componentOrigin: {
       originator: 'digdir',

--- a/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
@@ -25,8 +25,9 @@ const meta = preview.meta({
     },
   },
   args: {
-    // Children is required in Tooltip props, so we must set something
+    // Children and content is required in Tooltip props, so we must set something
     children: undefined,
+    content: undefined,
   },
 });
 
@@ -53,10 +54,10 @@ export const Preview = meta.story({
 });
 
 export const Placement = meta.story({
-  render: () => {
+  render: (args) => {
     return (
       <div style={{ display: 'flex', gap: 'var(--ds-size-2)' }}>
-        <Tooltip placement="left" content="Slett">
+        <Tooltip {...args} placement="left" content="Slett">
           <Button icon variant="secondary">
             <TrashIcon aria-hidden />
           </Button>
@@ -82,9 +83,9 @@ export const Placement = meta.story({
 });
 
 export const Aria = meta.story({
-  render: () => (
+  render: (args) => (
     <div style={{ display: 'flex', gap: 'var(--ds-size-2)' }}>
-      <Tooltip content="Jeg er hovedinformasjon (aria-labelledby)">
+      <Tooltip {...args} content="Jeg er hovedinformasjon (aria-labelledby)">
         <Button icon>
           <FilesIcon aria-hidden />
         </Button>

--- a/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
@@ -24,6 +24,18 @@ const meta = preview.meta({
       alignItems: 'center',
     },
   },
+  argTypes: {
+    type: {
+      description:
+        '**@deprecated** This prop has no effect. The tooltip will automatically use `aria-description` if the trigger already has accessible text, and `aria-label` otherwise.',
+      control: false,
+    },
+    open: {
+      description:
+        '**@deprecated** This should not be used on Tooltip. Use a Popover instead.',
+      control: false,
+    },
+  },
   args: {
     // Children and content is required in Tooltip props, so we must set something
     children: undefined,
@@ -85,12 +97,12 @@ export const Placement = meta.story({
 export const Aria = meta.story({
   render: (args) => (
     <div style={{ display: 'flex', gap: 'var(--ds-size-2)' }}>
-      <Tooltip {...args} content="Jeg er hovedinformasjon (aria-labelledby)">
+      <Tooltip {...args} content="Jeg er hovedinformasjon (aria-label)">
         <Button icon>
           <FilesIcon aria-hidden />
         </Button>
       </Tooltip>
-      <Tooltip content="Jeg er tillegsinformasjon (aria-describedby)">
+      <Tooltip content="Jeg er tillegsinformasjon (aria-description)">
         <Button>Tekst i trigger</Button>
       </Tooltip>
     </div>

--- a/@udir-design/react/src/components/tooltip/__snapshots__/Tooltip.stories.tsx.snap
+++ b/@udir-design/react/src/components/tooltip/__snapshots__/Tooltip.stories.tsx.snap
@@ -6,10 +6,10 @@ exports[`Aria 1`] = `
     data-icon="true"
     data-variant="primary"
     type="button"
-    data-tooltip="Jeg er hovedinformasjon (aria-labelledby)"
+    data-tooltip="Jeg er hovedinformasjon (aria-label)"
     data-placement="top"
     data-autoplacement="true"
-    aria-label="Jeg er hovedinformasjon (aria-labelledby)"
+    aria-label="Jeg er hovedinformasjon (aria-label)"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -33,10 +33,10 @@ exports[`Aria 1`] = `
   <button
     data-variant="primary"
     type="button"
-    data-tooltip="Jeg er tillegsinformasjon (aria-describedby)"
+    data-tooltip="Jeg er tillegsinformasjon (aria-description)"
     data-placement="top"
     data-autoplacement="true"
-    aria-description="Jeg er tillegsinformasjon (aria-describedby)"
+    aria-description="Jeg er tillegsinformasjon (aria-description)"
   >
     Tekst i trigger
   </button>

--- a/@udir-design/react/src/demo/DashboardDemo.stories.tsx
+++ b/@udir-design/react/src/demo/DashboardDemo.stories.tsx
@@ -9,6 +9,7 @@ import { Button } from 'src/components/button/Button';
 import { Divider } from 'src/components/divider/Divider';
 import { Dropdown } from 'src/components/dropdown/Dropdown';
 import { Header } from 'src/components/header';
+import { Paragraph } from 'src/components/typography/paragraph/Paragraph';
 import { DashboardDemo } from '../../demo-pages/dashboard-demo/DashboardDemo';
 import { demoParameters } from './demoParameters';
 
@@ -36,7 +37,7 @@ export const DashboardStory = meta.story({
             name="Stian Hansen"
             description="Admin"
             popoverTarget="usermenu2"
-            data-show="md"
+            data-show="sm"
             avatar={
               <Badge.Position overlap="circle">
                 <Badge
@@ -72,6 +73,62 @@ export const DashboardStory = meta.story({
             </Dropdown.List>
             <Divider />
             <Dropdown.List>
+              <Dropdown.Item>
+                <Button variant="tertiary">
+                  <LeaveIcon aria-hidden />
+                  Logg ut
+                </Button>
+              </Dropdown.Item>
+            </Dropdown.List>
+          </Dropdown>
+          <Button
+            data-hide="sm"
+            popoverTarget="usermenuSmall"
+            variant="tertiary"
+          >
+            <Badge.Position overlap="circle">
+              <Badge
+                count={notifications}
+                maxCount={9}
+                aria-hidden
+                data-color="danger"
+              />
+              <Avatar aria-label="Stian Hansen">SH</Avatar>
+            </Badge.Position>
+          </Button>
+          <Dropdown id="usermenuSmall" placement="bottom-end">
+            <Dropdown.List>
+              <Dropdown.Item>
+                <Dropdown.Heading>Detaljer</Dropdown.Heading>
+              </Dropdown.Item>
+              <Dropdown.Item
+                style={{
+                  marginLeft: 'var(--ds-size-4)',
+                }}
+              >
+                <Paragraph>Stian Hansen</Paragraph>
+              </Dropdown.Item>
+              <Dropdown.Item
+                style={{
+                  marginBottom: 'var(--ds-size-4)',
+                  marginLeft: 'var(--ds-size-4)',
+                }}
+              >
+                <Paragraph>Admin</Paragraph>
+              </Dropdown.Item>
+              <Divider />
+              <Dropdown.Item>
+                <Dropdown.Heading>Bytt profil</Dropdown.Heading>
+              </Dropdown.Item>
+              <Dropdown.Item>
+                <Dropdown.Button>
+                  <Avatar aria-hidden>
+                    <BriefcaseIcon />
+                  </Avatar>
+                  Grålum skole <Badge count={10} maxCount={9} />
+                </Dropdown.Button>
+              </Dropdown.Item>
+              <Divider />
               <Dropdown.Item>
                 <Button variant="tertiary">
                   <LeaveIcon aria-hidden />

--- a/@udir-design/react/src/demo/DashboardDemo.stories.tsx
+++ b/@udir-design/react/src/demo/DashboardDemo.stories.tsx
@@ -101,11 +101,7 @@ export const DashboardStory = meta.story({
               <Dropdown.Item>
                 <Dropdown.Heading>Detaljer</Dropdown.Heading>
               </Dropdown.Item>
-              <Dropdown.Item
-                style={{
-                  marginLeft: 'var(--ds-size-4)',
-                }}
-              >
+              <Dropdown.Item>
                 <Paragraph>Stian Hansen</Paragraph>
               </Dropdown.Item>
               <Dropdown.Item

--- a/@udir-design/react/src/demo/DashboardDemo.stories.tsx
+++ b/@udir-design/react/src/demo/DashboardDemo.stories.tsx
@@ -27,6 +27,7 @@ const meta = preview.meta({
 
 export const DashboardStory = meta.story({
   render: (args) => {
+    const notifications = 10;
     const [colorMode, setColorMode] = useState<'light' | 'dark'>('light');
     return (
       <>
@@ -36,7 +37,18 @@ export const DashboardStory = meta.story({
             description="Admin"
             popoverTarget="usermenu2"
             data-show="md"
-            avatar={<Avatar aria-hidden>SH</Avatar>}
+            avatar={
+              <Badge.Position overlap="circle">
+                <Badge
+                  count={notifications}
+                  maxCount={9}
+                  aria-hidden
+                  data-color="danger"
+                />
+                <Avatar aria-hidden>SH</Avatar>
+              </Badge.Position>
+            }
+            aria-label={`Stian Hansen Admin - ${notifications} varsler`}
           />
           <Dropdown id="usermenu2" placement="bottom-end" autoPlacement={false}>
             <Dropdown.Heading>Bytt profil</Dropdown.Heading>

--- a/@udir-design/react/src/demo/DashboardDemo.stories.tsx
+++ b/@udir-design/react/src/demo/DashboardDemo.stories.tsx
@@ -101,7 +101,7 @@ export const DashboardStory = meta.story({
               <Dropdown.Item>
                 <Dropdown.Heading>Detaljer</Dropdown.Heading>
               </Dropdown.Item>
-              <Dropdown.Item>
+              <Dropdown.Item style={{ marginLeft: 'var(--ds-size-4)' }}>
                 <Paragraph>Stian Hansen</Paragraph>
               </Dropdown.Item>
               <Dropdown.Item

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -30,6 +30,7 @@ exports[`Dashboard Page 2 1`] = `
         data-color="neutral"
         popovertarget="usermenu2"
         data-show="md"
+        aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
           <span>
@@ -40,12 +41,24 @@ exports[`Dashboard Page 2 1`] = `
           </span>
         </div>
         <span
-          data-variant="circle"
-          role="img"
-          aria-hidden="true"
+          data-overlap="circle"
+          data-placement="top-right"
         >
-          <span>
-            SH
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-hidden="true"
+          >
+            <span>
+              SH
+            </span>
           </span>
         </span>
       </button>
@@ -689,6 +702,7 @@ exports[`Dashboard Page 3 1`] = `
         data-color="neutral"
         popovertarget="usermenu2"
         data-show="md"
+        aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
           <span>
@@ -699,12 +713,24 @@ exports[`Dashboard Page 3 1`] = `
           </span>
         </div>
         <span
-          data-variant="circle"
-          role="img"
-          aria-hidden="true"
+          data-overlap="circle"
+          data-placement="top-right"
         >
-          <span>
-            SH
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-hidden="true"
+          >
+            <span>
+              SH
+            </span>
           </span>
         </span>
       </button>
@@ -1348,6 +1374,7 @@ exports[`Dashboard Page 4 1`] = `
         data-color="neutral"
         popovertarget="usermenu2"
         data-show="md"
+        aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
           <span>
@@ -1358,12 +1385,24 @@ exports[`Dashboard Page 4 1`] = `
           </span>
         </div>
         <span
-          data-variant="circle"
-          role="img"
-          aria-hidden="true"
+          data-overlap="circle"
+          data-placement="top-right"
         >
-          <span>
-            SH
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-hidden="true"
+          >
+            <span>
+              SH
+            </span>
           </span>
         </span>
       </button>
@@ -2007,6 +2046,7 @@ exports[`Dashboard Story 1`] = `
         data-color="neutral"
         popovertarget="usermenu2"
         data-show="md"
+        aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
           <span>
@@ -2017,12 +2057,24 @@ exports[`Dashboard Story 1`] = `
           </span>
         </div>
         <span
-          data-variant="circle"
-          role="img"
-          aria-hidden="true"
+          data-overlap="circle"
+          data-placement="top-right"
         >
-          <span>
-            SH
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-hidden="true"
+          >
+            <span>
+              SH
+            </span>
           </span>
         </span>
       </button>

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -29,7 +29,7 @@ exports[`Dashboard Page 2 1`] = `
         type="button"
         data-color="neutral"
         popovertarget="usermenu2"
-        data-show="md"
+        data-show="sm"
         aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
@@ -148,6 +148,128 @@ exports[`Dashboard Page 2 1`] = `
           </li>
         </ul>
       </div>
+      <button
+        data-variant="tertiary"
+        type="button"
+        popovertarget="usermenuSmall"
+        data-hide="sm"
+      >
+        <span
+          data-overlap="circle"
+          data-placement="top-right"
+        >
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-label="Stian Hansen"
+          >
+            <span>
+              SH
+            </span>
+          </span>
+        </span>
+      </button>
+      <div
+        id="<removed>"
+        popover="manual"
+        data-placement="bottom-end"
+        data-variant="default"
+      >
+        <ul>
+          <li>
+            <h2>
+              Detaljer
+            </h2>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Stian Hansen
+            </p>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Admin
+            </p>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <h2>
+              Bytt profil
+            </h2>
+          </li>
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <span
+                data-variant="circle"
+                role="img"
+                aria-hidden="true"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="1em"
+                  height="1em"
+                  fill="none"
+                  viewbox="0 0 24 24"
+                  focusable="false"
+                  role="img"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    d="M2.25 7.5c0-.69.56-1.25 1.25-1.25h4.25V5c0-.966.784-1.75 1.75-1.75h5c.966 0 1.75.784 1.75 1.75v1.25h4.25c.69 0 1.25.56 1.25 1.25v5c0 .69-.56 1.25-1.25 1.25h-.25v4.75c0 .69-.56 1.25-1.25 1.25H5c-.69 0-1.25-.56-1.25-1.25v-4.75H3.5c-.69 0-1.25-.56-1.25-1.25zm7-2.5a.25.25 0 0 1 .25-.25h5a.25.25 0 0 1 .25.25v1.25h-5.5zM12 15.75a.75.75 0 0 0 .75-.75v-1.25h6v4.5H5.25v-4.5h6V15c0 .414.336.75.75.75m0-5.5a.75.75 0 0 1 .75.75v1.25h7.5v-4.5H3.75v4.5h7.5V11a.75.75 0 0 1 .75-.75"
+                    clip-rule="evenodd"
+                  >
+                  </path>
+                </svg>
+              </span>
+              Grålum skole
+              <span
+                data-count="9+"
+                data-variant="base"
+              >
+              </span>
+            </button>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M5 3.25A1.75 1.75 0 0 0 3.25 5v14c0 .966.784 1.75 1.75 1.75h3.5a.75.75 0 0 0 0-1.5H5a.25.25 0 0 1-.25-.25V5A.25.25 0 0 1 5 4.75h3.5a.75.75 0 0 0 0-1.5zm9.97 3.72a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H8.5a.75.75 0 0 1 0-1.5h9.69l-3.22-3.22a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+              Logg ut
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </header>
@@ -162,7 +284,7 @@ exports[`Dashboard Page 2 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_e_-overview"
+        aria-controls="_r_i_-overview"
         data-value="overview"
         role="tab"
         aria-selected="false"
@@ -172,7 +294,7 @@ exports[`Dashboard Page 2 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_e_-tests"
+        aria-controls="_r_i_-tests"
         data-value="tests"
         role="tab"
         aria-selected="true"
@@ -182,7 +304,7 @@ exports[`Dashboard Page 2 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_e_-test-answers"
+        aria-controls="_r_i_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="false"
@@ -191,7 +313,7 @@ exports[`Dashboard Page 2 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_e_-settings"
+        aria-controls="_r_i_-settings"
         data-value="settings"
         role="tab"
         aria-selected="false"
@@ -701,7 +823,7 @@ exports[`Dashboard Page 3 1`] = `
         type="button"
         data-color="neutral"
         popovertarget="usermenu2"
-        data-show="md"
+        data-show="sm"
         aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
@@ -820,6 +942,128 @@ exports[`Dashboard Page 3 1`] = `
           </li>
         </ul>
       </div>
+      <button
+        data-variant="tertiary"
+        type="button"
+        popovertarget="usermenuSmall"
+        data-hide="sm"
+      >
+        <span
+          data-overlap="circle"
+          data-placement="top-right"
+        >
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-label="Stian Hansen"
+          >
+            <span>
+              SH
+            </span>
+          </span>
+        </span>
+      </button>
+      <div
+        id="<removed>"
+        popover="manual"
+        data-placement="bottom-end"
+        data-variant="default"
+      >
+        <ul>
+          <li>
+            <h2>
+              Detaljer
+            </h2>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Stian Hansen
+            </p>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Admin
+            </p>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <h2>
+              Bytt profil
+            </h2>
+          </li>
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <span
+                data-variant="circle"
+                role="img"
+                aria-hidden="true"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="1em"
+                  height="1em"
+                  fill="none"
+                  viewbox="0 0 24 24"
+                  focusable="false"
+                  role="img"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    d="M2.25 7.5c0-.69.56-1.25 1.25-1.25h4.25V5c0-.966.784-1.75 1.75-1.75h5c.966 0 1.75.784 1.75 1.75v1.25h4.25c.69 0 1.25.56 1.25 1.25v5c0 .69-.56 1.25-1.25 1.25h-.25v4.75c0 .69-.56 1.25-1.25 1.25H5c-.69 0-1.25-.56-1.25-1.25v-4.75H3.5c-.69 0-1.25-.56-1.25-1.25zm7-2.5a.25.25 0 0 1 .25-.25h5a.25.25 0 0 1 .25.25v1.25h-5.5zM12 15.75a.75.75 0 0 0 .75-.75v-1.25h6v4.5H5.25v-4.5h6V15c0 .414.336.75.75.75m0-5.5a.75.75 0 0 1 .75.75v1.25h7.5v-4.5H3.75v4.5h7.5V11a.75.75 0 0 1 .75-.75"
+                    clip-rule="evenodd"
+                  >
+                  </path>
+                </svg>
+              </span>
+              Grålum skole
+              <span
+                data-count="9+"
+                data-variant="base"
+              >
+              </span>
+            </button>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M5 3.25A1.75 1.75 0 0 0 3.25 5v14c0 .966.784 1.75 1.75 1.75h3.5a.75.75 0 0 0 0-1.5H5a.25.25 0 0 1-.25-.25V5A.25.25 0 0 1 5 4.75h3.5a.75.75 0 0 0 0-1.5zm9.97 3.72a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H8.5a.75.75 0 0 1 0-1.5h9.69l-3.22-3.22a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+              Logg ut
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </header>
@@ -834,7 +1078,7 @@ exports[`Dashboard Page 3 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_q_-overview"
+        aria-controls="_r_10_-overview"
         data-value="overview"
         role="tab"
         aria-selected="false"
@@ -844,7 +1088,7 @@ exports[`Dashboard Page 3 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_q_-tests"
+        aria-controls="_r_10_-tests"
         data-value="tests"
         role="tab"
         aria-selected="false"
@@ -853,7 +1097,7 @@ exports[`Dashboard Page 3 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_q_-test-answers"
+        aria-controls="_r_10_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="true"
@@ -863,7 +1107,7 @@ exports[`Dashboard Page 3 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_q_-settings"
+        aria-controls="_r_10_-settings"
         data-value="settings"
         role="tab"
         aria-selected="false"
@@ -1373,7 +1617,7 @@ exports[`Dashboard Page 4 1`] = `
         type="button"
         data-color="neutral"
         popovertarget="usermenu2"
-        data-show="md"
+        data-show="sm"
         aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
@@ -1492,6 +1736,128 @@ exports[`Dashboard Page 4 1`] = `
           </li>
         </ul>
       </div>
+      <button
+        data-variant="tertiary"
+        type="button"
+        popovertarget="usermenuSmall"
+        data-hide="sm"
+      >
+        <span
+          data-overlap="circle"
+          data-placement="top-right"
+        >
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-label="Stian Hansen"
+          >
+            <span>
+              SH
+            </span>
+          </span>
+        </span>
+      </button>
+      <div
+        id="<removed>"
+        popover="manual"
+        data-placement="bottom-end"
+        data-variant="default"
+      >
+        <ul>
+          <li>
+            <h2>
+              Detaljer
+            </h2>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Stian Hansen
+            </p>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Admin
+            </p>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <h2>
+              Bytt profil
+            </h2>
+          </li>
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <span
+                data-variant="circle"
+                role="img"
+                aria-hidden="true"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="1em"
+                  height="1em"
+                  fill="none"
+                  viewbox="0 0 24 24"
+                  focusable="false"
+                  role="img"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    d="M2.25 7.5c0-.69.56-1.25 1.25-1.25h4.25V5c0-.966.784-1.75 1.75-1.75h5c.966 0 1.75.784 1.75 1.75v1.25h4.25c.69 0 1.25.56 1.25 1.25v5c0 .69-.56 1.25-1.25 1.25h-.25v4.75c0 .69-.56 1.25-1.25 1.25H5c-.69 0-1.25-.56-1.25-1.25v-4.75H3.5c-.69 0-1.25-.56-1.25-1.25zm7-2.5a.25.25 0 0 1 .25-.25h5a.25.25 0 0 1 .25.25v1.25h-5.5zM12 15.75a.75.75 0 0 0 .75-.75v-1.25h6v4.5H5.25v-4.5h6V15c0 .414.336.75.75.75m0-5.5a.75.75 0 0 1 .75.75v1.25h7.5v-4.5H3.75v4.5h7.5V11a.75.75 0 0 1 .75-.75"
+                    clip-rule="evenodd"
+                  >
+                  </path>
+                </svg>
+              </span>
+              Grålum skole
+              <span
+                data-count="9+"
+                data-variant="base"
+              >
+              </span>
+            </button>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M5 3.25A1.75 1.75 0 0 0 3.25 5v14c0 .966.784 1.75 1.75 1.75h3.5a.75.75 0 0 0 0-1.5H5a.25.25 0 0 1-.25-.25V5A.25.25 0 0 1 5 4.75h3.5a.75.75 0 0 0 0-1.5zm9.97 3.72a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H8.5a.75.75 0 0 1 0-1.5h9.69l-3.22-3.22a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+              Logg ut
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </header>
@@ -1506,7 +1872,7 @@ exports[`Dashboard Page 4 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_16_-overview"
+        aria-controls="_r_1e_-overview"
         data-value="overview"
         role="tab"
         aria-selected="false"
@@ -1516,7 +1882,7 @@ exports[`Dashboard Page 4 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_16_-tests"
+        aria-controls="_r_1e_-tests"
         data-value="tests"
         role="tab"
         aria-selected="false"
@@ -1525,7 +1891,7 @@ exports[`Dashboard Page 4 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_16_-test-answers"
+        aria-controls="_r_1e_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="false"
@@ -1534,7 +1900,7 @@ exports[`Dashboard Page 4 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_16_-settings"
+        aria-controls="_r_1e_-settings"
         data-value="settings"
         role="tab"
         aria-selected="true"
@@ -2045,7 +2411,7 @@ exports[`Dashboard Story 1`] = `
         type="button"
         data-color="neutral"
         popovertarget="usermenu2"
-        data-show="md"
+        data-show="sm"
         aria-label="Stian Hansen Admin - 10 varsler"
       >
         <div>
@@ -2164,6 +2530,128 @@ exports[`Dashboard Story 1`] = `
           </li>
         </ul>
       </div>
+      <button
+        data-variant="tertiary"
+        type="button"
+        popovertarget="usermenuSmall"
+        data-hide="sm"
+      >
+        <span
+          data-overlap="circle"
+          data-placement="top-right"
+        >
+          <span
+            data-count="9+"
+            data-variant="base"
+            aria-hidden="true"
+            data-color="danger"
+          >
+          </span>
+          <span
+            data-variant="circle"
+            role="img"
+            aria-label="Stian Hansen"
+          >
+            <span>
+              SH
+            </span>
+          </span>
+        </span>
+      </button>
+      <div
+        id="<removed>"
+        popover="manual"
+        data-placement="bottom-end"
+        data-variant="default"
+      >
+        <ul>
+          <li>
+            <h2>
+              Detaljer
+            </h2>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Stian Hansen
+            </p>
+          </li>
+          <li style="<removed>">
+            <p data-variant="default">
+              Admin
+            </p>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <h2>
+              Bytt profil
+            </h2>
+          </li>
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <span
+                data-variant="circle"
+                role="img"
+                aria-hidden="true"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="1em"
+                  height="1em"
+                  fill="none"
+                  viewbox="0 0 24 24"
+                  focusable="false"
+                  role="img"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="currentColor"
+                    fill-rule="evenodd"
+                    d="M2.25 7.5c0-.69.56-1.25 1.25-1.25h4.25V5c0-.966.784-1.75 1.75-1.75h5c.966 0 1.75.784 1.75 1.75v1.25h4.25c.69 0 1.25.56 1.25 1.25v5c0 .69-.56 1.25-1.25 1.25h-.25v4.75c0 .69-.56 1.25-1.25 1.25H5c-.69 0-1.25-.56-1.25-1.25v-4.75H3.5c-.69 0-1.25-.56-1.25-1.25zm7-2.5a.25.25 0 0 1 .25-.25h5a.25.25 0 0 1 .25.25v1.25h-5.5zM12 15.75a.75.75 0 0 0 .75-.75v-1.25h6v4.5H5.25v-4.5h6V15c0 .414.336.75.75.75m0-5.5a.75.75 0 0 1 .75.75v1.25h7.5v-4.5H3.75v4.5h7.5V11a.75.75 0 0 1 .75-.75"
+                    clip-rule="evenodd"
+                  >
+                  </path>
+                </svg>
+              </span>
+              Grålum skole
+              <span
+                data-count="9+"
+                data-variant="base"
+              >
+              </span>
+            </button>
+          </li>
+          <hr aria-hidden="true">
+          <li>
+            <button
+              data-variant="tertiary"
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M5 3.25A1.75 1.75 0 0 0 3.25 5v14c0 .966.784 1.75 1.75 1.75h3.5a.75.75 0 0 0 0-1.5H5a.25.25 0 0 1-.25-.25V5A.25.25 0 0 1 5 4.75h3.5a.75.75 0 0 0 0-1.5zm9.97 3.72a.75.75 0 0 1 1.06 0l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 1 1-1.06-1.06l3.22-3.22H8.5a.75.75 0 0 1 0-1.5h9.69l-3.22-3.22a.75.75 0 0 1 0-1.06"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+              Logg ut
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </header>
@@ -2178,7 +2666,7 @@ exports[`Dashboard Story 1`] = `
   <ds-tabs>
     <ds-tablist role="tablist">
       <ds-tab
-        aria-controls="_r_2_-overview"
+        aria-controls="_r_4_-overview"
         data-value="overview"
         role="tab"
         aria-selected="true"
@@ -2188,7 +2676,7 @@ exports[`Dashboard Story 1`] = `
         Oversikt
       </ds-tab>
       <ds-tab
-        aria-controls="_r_2_-tests"
+        aria-controls="_r_4_-tests"
         data-value="tests"
         role="tab"
         aria-selected="false"
@@ -2197,7 +2685,7 @@ exports[`Dashboard Story 1`] = `
         Prøver
       </ds-tab>
       <ds-tab
-        aria-controls="_r_2_-test-answers"
+        aria-controls="_r_4_-test-answers"
         data-value="test-answers"
         role="tab"
         aria-selected="false"
@@ -2206,7 +2694,7 @@ exports[`Dashboard Story 1`] = `
         Prøvesvar
       </ds-tab>
       <ds-tab
-        aria-controls="_r_2_-settings"
+        aria-controls="_r_4_-settings"
         data-value="settings"
         role="tab"
         aria-selected="false"

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -188,7 +188,7 @@ exports[`Dashboard Page 2 1`] = `
               Detaljer
             </h2>
           </li>
-          <li style="<removed>">
+          <li>
             <p data-variant="default">
               Stian Hansen
             </p>
@@ -982,7 +982,7 @@ exports[`Dashboard Page 3 1`] = `
               Detaljer
             </h2>
           </li>
-          <li style="<removed>">
+          <li>
             <p data-variant="default">
               Stian Hansen
             </p>
@@ -1776,7 +1776,7 @@ exports[`Dashboard Page 4 1`] = `
               Detaljer
             </h2>
           </li>
-          <li style="<removed>">
+          <li>
             <p data-variant="default">
               Stian Hansen
             </p>
@@ -2570,7 +2570,7 @@ exports[`Dashboard Story 1`] = `
               Detaljer
             </h2>
           </li>
-          <li style="<removed>">
+          <li>
             <p data-variant="default">
               Stian Hansen
             </p>

--- a/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DashboardDemo.stories.tsx.snap
@@ -188,7 +188,7 @@ exports[`Dashboard Page 2 1`] = `
               Detaljer
             </h2>
           </li>
-          <li>
+          <li style="<removed>">
             <p data-variant="default">
               Stian Hansen
             </p>
@@ -982,7 +982,7 @@ exports[`Dashboard Page 3 1`] = `
               Detaljer
             </h2>
           </li>
-          <li>
+          <li style="<removed>">
             <p data-variant="default">
               Stian Hansen
             </p>
@@ -1776,7 +1776,7 @@ exports[`Dashboard Page 4 1`] = `
               Detaljer
             </h2>
           </li>
-          <li>
+          <li style="<removed>">
             <p data-variant="default">
               Stian Hansen
             </p>
@@ -2570,7 +2570,7 @@ exports[`Dashboard Story 1`] = `
               Detaljer
             </h2>
           </li>
-          <li>
+          <li style="<removed>">
             <p data-variant="default">
               Stian Hansen
             </p>

--- a/PR_REVIEW_SUMMARY.md
+++ b/PR_REVIEW_SUMMARY.md
@@ -2,11 +2,12 @@
 
 This branch consolidates the following 10 component promotions from beta to stable into a single PR to save Chromatic credits.
 
-## Approved (8 PRs)
+## Approved (9 PRs)
 
 ### 1. Tooltip — [#777](https://github.com/Utdanningsdirektoratet/designsystem/pull/777)
 
 - **Changes:** Moved export from `beta.ts` → `stable.ts`. Removed beta tag from stories. Spread `args` into story renders for correct Storybook code examples. Polished Norwegian docs (accessibility, guidelines, polyfill sections).
+- **Post-review fixes:** Corrected `aria-labelledby`/`aria-describedby` → `aria-label`/`aria-description` in docs and story strings. Removed reference to deprecated `type` prop from docs text. Marked deprecated `type` and `open` props in Storybook args table. Rebased on main.
 - **Review:** ✅ Approved by **adrianflatner**. No unresolved comments.
 
 ### 2. Breadcrumbs — [#776](https://github.com/Utdanningsdirektoratet/designsystem/pull/776)
@@ -32,6 +33,7 @@ This branch consolidates the following 10 component promotions from beta to stab
 ### 6. Dialog — [#754](https://github.com/Utdanningsdirektoratet/designsystem/pull/754)
 
 - **Changes:** Export move + beta tag removal. Extensive docs rewrite: restructured Modal vs Non-modal section to top, rewrote copy for clarity, improved explanations of `command`/`commandfor`, `closedby`, `closeButton`, `autofocus`. Stories updated with `{...args}` spread. No API changes.
+- **Post-review fixes:** Marked deprecated `asChild` prop in Storybook args table. Rebased on main.
 - **Review:** ✅ Approved by **adrianflatner** ("Nice!"). 1 minor comment addressed. No unresolved comments.
 
 ### 7. Dropdown — [#753](https://github.com/Utdanningsdirektoratet/designsystem/pull/753)
@@ -47,15 +49,25 @@ This branch consolidates the following 10 component promotions from beta to stab
 ### 9. Badge — [#667](https://github.com/Utdanningsdirektoratet/designsystem/pull/667)
 
 - **Changes:** Export move + beta tag removal. Fixed Nynorsk typos in docs. Stories refactored: replaced inline styles with CSS classes, added args passthrough. DashboardDemo updated with Badge on Header.UserButton and responsive small-screen variant with dropdown.
+- **Post-review fixes:** Refactored DashboardDemo to use `avatar` prop with `Badge.Position` (matching the pattern in TestHeader.tsx) instead of wrapping the entire UserButton.
 - **Review:** ✅ Approved by **adrianflatner** ("Looks good, må se på `dir`"). RTL positioning issue noted but documented — not blocking. No unresolved comments.
 
-## Awaiting Approval (1 PR)
+## ~~Awaiting Approval~~ (0 PRs)
 
 ### 10. Textarea — [#761](https://github.com/Utdanningsdirektoratet/designsystem/pull/761)
 
 - **Changes:** Export move + beta tag removal. Added `autoComplete: 'off'` to all story args. Added `advancedCodeDocs` to Controlled story. Docs rewritten with clearer Norwegian, fixed case-sensitive link. Snapshots updated.
-- **Review:** ⚠️ **Review required** — **adrianflatner** commented (requesting `advancedCodeDocs` on Controlled story) which was addressed, but **no formal approval yet**. No unresolved comments remain.
+- **Review:** ✅ Approved by **une**. adrianflatner's earlier comment (requesting `advancedCodeDocs` on Controlled story) was addressed.
 
 ## Common Pattern
 
 Every PR follows the same structure: move export from `beta.ts` → `stable.ts`, remove `'beta'` Storybook tag, polish Norwegian documentation, and improve story quality (args spreading, accessibility fixes, `advancedCodeDocs`). No component API changes in any of them — all are purely promotions + docs/stories cleanup.
+
+All 10 PR branches have been rebased on `main` and conflicts resolved.
+
+## Additional: Deprecated Props Fix
+
+### Field — [fix/field-deprecated-props](https://github.com/Utdanningsdirektoratet/designsystem/tree/fix/field-deprecated-props)
+
+- **Changes:** Marked deprecated upstream props (`asChild` on Field, `hint` on Field.Counter) in Storybook args tables. Field is already stable but was missing these annotations.
+- **Review:** Pending — not part of the original beta-to-stable PRs.

--- a/PR_REVIEW_SUMMARY.md
+++ b/PR_REVIEW_SUMMARY.md
@@ -1,0 +1,61 @@
+# Beta → Stable: Batch 3 — PR Review Summary
+
+This branch consolidates the following 10 component promotions from beta to stable into a single PR to save Chromatic credits.
+
+## Approved (8 PRs)
+
+### 1. Tooltip — [#777](https://github.com/Utdanningsdirektoratet/designsystem/pull/777)
+
+- **Changes:** Moved export from `beta.ts` → `stable.ts`. Removed beta tag from stories. Spread `args` into story renders for correct Storybook code examples. Polished Norwegian docs (accessibility, guidelines, polyfill sections).
+- **Review:** ✅ Approved by **adrianflatner**. No unresolved comments.
+
+### 2. Breadcrumbs — [#776](https://github.com/Utdanningsdirektoratet/designsystem/pull/776)
+
+- **Changes:** Export move + beta tag removal. New `PlacementWithHeader` story showing breadcrumbs below a Header. New play test verifying `aria-current="page"` on last breadcrumb. Docs updated with placement guidelines (max-width, centering). Grammar fixes. Demo page updated with breadcrumbs CSS.
+- **Review:** ✅ Approved by **Hannareie**. 6 inline text suggestions — all applied. No unresolved comments.
+
+### 3. Tabs — [#767](https://github.com/Utdanningsdirektoratet/designsystem/pull/767)
+
+- **Changes:** Export move + beta tag removal. Added missing `Tabs.Panel` elements to stories (fixing a11y warnings). Replaced inline styles with CSS classes in Controlled example. Added `advancedCodeDocs` for docs source transform. Norwegian docs polished.
+- **Review:** ✅ Approved by **adrianflatner**. 2 comments (add Tooltip link, remove unnecessary heading) — both addressed. No unresolved comments.
+
+### 4. TableOfContents — [#766](https://github.com/Utdanningsdirektoratet/designsystem/pull/766)
+
+- **Changes:** Minimal — export move + beta tag removal + minor Norwegian copy edits. Very small diff (4 files).
+- **Review:** ✅ Approved by **adrianflatner**. No inline comments. Author noted a minor RTL icon direction issue (not blocking).
+
+### 5. Textfield — [#760](https://github.com/Utdanningsdirektoratet/designsystem/pull/760)
+
+- **Changes:** Export move + beta tag removal. Stories refactored: simplified play tests, added `autoComplete` attributes, switched `Format` story to use built-in `error` prop instead of external `<ValidationMessage>`. Docs expanded with "Passer ikke til å" section and improved accessibility guidance.
+- **Review:** ✅ Approved by **Hannareie** ("Ser bra ut🚀"). All suggestions accepted. No unresolved comments.
+
+### 6. Dialog — [#754](https://github.com/Utdanningsdirektoratet/designsystem/pull/754)
+
+- **Changes:** Export move + beta tag removal. Extensive docs rewrite: restructured Modal vs Non-modal section to top, rewrote copy for clarity, improved explanations of `command`/`commandfor`, `closedby`, `closeButton`, `autofocus`. Stories updated with `{...args}` spread. No API changes.
+- **Review:** ✅ Approved by **adrianflatner** ("Nice!"). 1 minor comment addressed. No unresolved comments.
+
+### 7. Dropdown — [#753](https://github.com/Utdanningsdirektoratet/designsystem/pull/753)
+
+- **Changes:** Export move only. Docs improved with better use-case guidance, new "Ikoner og andre komponenter" subheading, grammar polish, fixed Popover capitalization. No code changes.
+- **Review:** ✅ Approved by **Hannareie** ("Ser bra ut🚀"). 3 inline suggestions all applied. No unresolved comments.
+
+### 8. ProgressBar — [#751](https://github.com/Utdanningsdirektoratet/designsystem/pull/751)
+
+- **Changes:** Export move. Also fixed `export type *` → `export *` so values are actually re-exported (not just types). Docs: added use-case bullet, fixed broken `FormNavigation` link, replaced "sider" → "steg". Very small diff (~11 lines).
+- **Review:** ✅ Approved by **Hannareie** ("Ser bra ut 🚀"). 3 inline suggestions applied. No unresolved comments.
+
+### 9. Badge — [#667](https://github.com/Utdanningsdirektoratet/designsystem/pull/667)
+
+- **Changes:** Export move + beta tag removal. Fixed Nynorsk typos in docs. Stories refactored: replaced inline styles with CSS classes, added args passthrough. DashboardDemo updated with Badge on Header.UserButton and responsive small-screen variant with dropdown.
+- **Review:** ✅ Approved by **adrianflatner** ("Looks good, må se på `dir`"). RTL positioning issue noted but documented — not blocking. No unresolved comments.
+
+## Awaiting Approval (1 PR)
+
+### 10. Textarea — [#761](https://github.com/Utdanningsdirektoratet/designsystem/pull/761)
+
+- **Changes:** Export move + beta tag removal. Added `autoComplete: 'off'` to all story args. Added `advancedCodeDocs` to Controlled story. Docs rewritten with clearer Norwegian, fixed case-sensitive link. Snapshots updated.
+- **Review:** ⚠️ **Review required** — **adrianflatner** commented (requesting `advancedCodeDocs` on Controlled story) which was addressed, but **no formal approval yet**. No unresolved comments remain.
+
+## Common Pattern
+
+Every PR follows the same structure: move export from `beta.ts` → `stable.ts`, remove `'beta'` Storybook tag, polish Norwegian documentation, and improve story quality (args spreading, accessibility fixes, `advancedCodeDocs`). No component API changes in any of them — all are purely promotions + docs/stories cleanup.


### PR DESCRIPTION
Kombinert PR med tredje batch av stabile komponentar, for å kjøre færre Chromatic-bygg. Inneheld endringane frå:

- [feat(Tooltip): promote from beta to stable (#777)](https://github.com/Utdanningsdirektoratet/designsystem/pull/777)
- [feat(Breadcrumbs): promote from beta to stable (#776)](https://github.com/Utdanningsdirektoratet/designsystem/pull/776)
- [feat(Tabs): promote from beta to stable (#767)](https://github.com/Utdanningsdirektoratet/designsystem/pull/767)
- [feat(TableOfContents): promote from beta to stable (#766)](https://github.com/Utdanningsdirektoratet/designsystem/pull/766)
- [feat(Textarea): promote from beta to stable (#761)](https://github.com/Utdanningsdirektoratet/designsystem/pull/761)
- [feat(Textfield): promote from beta to stable (#760)](https://github.com/Utdanningsdirektoratet/designsystem/pull/760)
- [feat(Dialog): promote from beta to stable (#754)](https://github.com/Utdanningsdirektoratet/designsystem/pull/754)
- [feat(Dropdown): promote from beta to stable (#753)](https://github.com/Utdanningsdirektoratet/designsystem/pull/753)
- [feat(ProgressBar): promote from beta to stable (#751)](https://github.com/Utdanningsdirektoratet/designsystem/pull/751)
- [feat(Badge): promote from beta to stable (#667)](https://github.com/Utdanningsdirektoratet/designsystem/pull/667)

I tillegg er deprecated props markerte i Storybook args-tabellen for Tooltip, Dialog og Field.