### PR TITLE
feat(Suggestion): add count display mode for multiple selection

### DIFF
--- a/@udir-design/react/src/components/Språkstøtte.mdx
+++ b/@udir-design/react/src/components/Språkstøtte.mdx
@@ -34,3 +34,4 @@ Se hvilke tekstvariabler som er tilgjengelige for overstyring i dokumentasjonen 
 - [FileUpload](/docs/components-fileupload--docs#språkstøtte)
 - [DemoBanner](/docs/components-demobanner--docs#språkstøtte)
 - [FormSummary](/docs/components-formsummary--docs#språkstøtte)
+- [Suggestion](/docs/components-suggestion--docs#språkstøtte)

--- a/@udir-design/react/src/components/suggestion/Suggestion.mdx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.mdx
@@ -2,6 +2,7 @@ import { Meta, Canvas, Controls, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as SuggestionStories from './Suggestion.stories';
 import { SuggestionList } from './Suggestion';
 import { Alert } from '@udir-design/react/alpha';
+import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
 
 <Meta of={SuggestionStories} />
 
@@ -41,7 +42,15 @@ import { Suggestion } from '@udir-design/react/alpha';
 
 ### Flervalg
 
+Bruk `multiple` for å kunne velge flere alternativer.
+
 <Canvas of={SuggestionStories.Multiple} />
+
+### Flervalg med tag for å vise antall valgte alternativer
+
+Bruk `display="count"` for å vise antall valgte alternativer i en tag. Teksten i taggen kan tilpasses med CSS-variabelen `--dsc-suggestion-count-label`.
+
+<Canvas of={SuggestionStories.MultipleCount} />
 
 ### Filter
 
@@ -67,3 +76,11 @@ I eksempelet under viser vi `Spinner` i `Suggestion.Empty`.
 
 `Suggestion` baserer seg på [u-combobox fra u-elements](https://u-elements.github.io/u-elements/elements/u-combobox).
 Den er inspirert av [open-ui sitt combobox mønster](https://open-ui.org/components/combobox.explainer/).
+
+## Språkstøtte
+
+Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+
+Følgende tekstvariabler er tilgjengelige for overstyring:
+
+<CssLanguageVariables variables={['--dsc-suggestion-count-label']} />

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -488,6 +488,34 @@ export const FetchExternal = meta.story({
 
 export const Multiple = Preview.extend({ args: { multiple: true } });
 
+export const MultipleCount = meta.story({
+  render(args) {
+    return (
+      <Field>
+        <Label>Velg destinasjoner</Label>
+        <Suggestion
+          {...(args as SuggestionMultipleProps)}
+          multiple
+          display="count"
+          defaultSelected={['Oslo', 'Sogndal']}
+        >
+          <Suggestion.Input />
+          <Suggestion.Clear />
+          <Suggestion.List>
+            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            {DATA_PLACES.map((place) => (
+              <Suggestion.Option key={place} label={place} value={place}>
+                {place}
+                <div>Kommune</div>
+              </Suggestion.Option>
+            ))}
+          </Suggestion.List>
+        </Suggestion>
+      </Field>
+    );
+  },
+});
+
 export const DefaultValue = meta.story({
   render(args) {
     return (

--- a/@udir-design/react/src/components/suggestion/Suggestion.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.tsx
@@ -14,26 +14,67 @@ import {
   type SuggestionOptionProps,
   type SuggestionSingleProps as DigdirSuggestionSingleProps,
 } from '@digdir/designsystemet-react';
-import type {
-  ComponentRef,
-  ForwardRefExoticComponent,
-  RefAttributes,
+import {
+  type ComponentRef,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  forwardRef,
 } from 'react';
+import './suggestion.css';
 
-type SuggestionSingleProps = Omit<DigdirSuggestionSingleProps, 'data-color'>;
+type SuggestionDisplayProps = {
+  /**
+   * How selected items are displayed when `multiple` is true.
+   *
+   * - `chips` renders removable chips for each selected item (default)
+   * - `count` hides chips and shows a count label (e.g. "2 valgt")
+   *
+   * Customize the label text with the `--dsc-suggestion-count-label` CSS variable.
+   *
+   * @default 'chips'
+   */
+  display?: 'chips' | 'count';
+};
+
+type SuggestionSingleProps = Omit<DigdirSuggestionSingleProps, 'data-color'> &
+  SuggestionDisplayProps;
 type SuggestionMultipleProps = Omit<
   DigdirSuggestionMultipleProps,
   'data-color'
->;
+> &
+  SuggestionDisplayProps;
 type SuggestionProps = SuggestionSingleProps | SuggestionMultipleProps;
 
-const Suggestion = DigdirSuggestion as ForwardRefExoticComponent<
+const SuggestionBase = forwardRef<
+  ComponentRef<typeof DigdirSuggestion>,
+  SuggestionProps
+>(function Suggestion({ display = 'chips', ...rest }, ref) {
+  const multiple = 'multiple' in rest && rest.multiple === true;
+
+  return (
+    <DigdirSuggestion
+      {...(rest as DigdirSuggestionSingleProps)}
+      data-display={multiple && display === 'count' ? 'count' : undefined}
+      ref={ref}
+    />
+  );
+});
+
+const Suggestion: ForwardRefExoticComponent<
   SuggestionProps & RefAttributes<ComponentRef<typeof DigdirSuggestion>>
-> &
-  Pick<
-    typeof DigdirSuggestion,
-    'Clear' | 'Empty' | 'Input' | 'List' | 'Option'
-  >;
+> & {
+  Clear: typeof SuggestionClear;
+  Empty: typeof SuggestionEmpty;
+  Input: typeof SuggestionInput;
+  List: typeof SuggestionList;
+  Option: typeof SuggestionOption;
+} = Object.assign(SuggestionBase, {
+  Clear: SuggestionClear,
+  Empty: SuggestionEmpty,
+  Input: SuggestionInput,
+  List: SuggestionList,
+  Option: SuggestionOption,
+});
 
 Suggestion.displayName = 'Suggestion';
 SuggestionClear.displayName = 'Suggestion.Clear';

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -830,10 +830,10 @@ exports[`Default Value 1`] = `
       placeholder=" "
       type="text"
       id="<removed>"
-      list=":u-datalist10"
-      popovertarget=":u-datalist10"
+      list=":u-datalist11"
+      popovertarget=":u-datalist11"
       aria-autocomplete="list"
-      aria-controls=":u-datalist10"
+      aria-controls=":u-datalist11"
       autocomplete="off"
       enterkeyhint="done"
       role="combobox"
@@ -1004,10 +1004,10 @@ exports[`In Details 1`] = `
           placeholder=" "
           type="text"
           id="<removed>"
-          list=":u-datalist11"
-          popovertarget=":u-datalist11"
+          list=":u-datalist12"
+          popovertarget=":u-datalist12"
           aria-autocomplete="list"
-          aria-controls=":u-datalist11"
+          aria-controls=":u-datalist12"
           autocomplete="off"
           enterkeyhint="done"
           role="combobox"
@@ -1172,6 +1172,178 @@ exports[`Multiple 1`] = `
         role="option"
         aria-disabled="false"
         aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Oslo
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Brønnøysund"
+        value="Brønnøysund"
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Brønnøysund
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Stavanger"
+        value="Stavanger"
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Stavanger
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Trondheim"
+        value="Trondheim"
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Trondheim
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Bergen"
+        value="Bergen"
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Bergen
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Lillestrøm"
+        value="Lillestrøm"
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Lillestrøm
+        <div>
+          Kommune
+        </div>
+      </u-option>
+    </u-datalist>
+  </ds-suggestion>
+</ds-field>
+`;
+
+exports[`Multiple Count 1`] = `
+<ds-field>
+  <label
+    data-weight="medium"
+    for="<removed>"
+  >
+    Velg destinasjoner
+  </label>
+  <ds-suggestion
+    data-multiple
+    data-display="count"
+  >
+    <data
+      value="Oslo"
+      aria-label="Oslo, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Oslo
+    </data>
+    <data
+      value="Sogndal"
+      aria-label="Sogndal, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Sogndal
+    </data>
+    <input
+      placeholder=" "
+      type="text"
+      id="<removed>"
+      aria-description="Navigate left to find 2 selected"
+      list=":u-datalist10"
+      popovertarget=":u-datalist10"
+      aria-autocomplete="list"
+      aria-controls=":u-datalist10"
+      autocomplete="off"
+      enterkeyhint="done"
+      role="combobox"
+      aria-expanded="true"
+    >
+    <button
+      aria-label="Tøm"
+      hidden
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <u-datalist
+      data-nofilter
+      data-sr-plural="%d forslag"
+      data-sr-singular="%d forslag"
+      popover="manual"
+      role="listbox"
+      data-sr-of="of"
+      tabindex="-1"
+      aria-multiselectable="true"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg destinasjoner"
+      data-floating="bottom"
+      style="<removed>"
+    >
+      <u-option
+        label="Sogndal"
+        value="Sogndal"
+        selected
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="false"
+      >
+        Sogndal
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Oslo"
+        value="Oslo"
+        selected
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
         id="<removed>"
         aria-hidden="false"
       >

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -25,6 +25,7 @@
 
     /* Hide listbox when in count display mode. */
     &::part(items) {
+      position: absolute;
       @composes ds-sr-only from '@digdir/designsystemet-css/base.css';
     }
 

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -20,13 +20,12 @@
     /* Keep <data> in rendering tree for counter-increment but hide visually. */
     & > data {
       counter-increment: selected;
-      position: absolute;
-      visibility: hidden;
+      @composes ds-sr-only from '@digdir/designsystemet-css/base.css';
     }
 
     /* Hide listbox when in count display mode. */
     &::part(items) {
-      visibility: hidden;
+      @composes ds-sr-only from '@digdir/designsystemet-css/base.css';
     }
 
     /* NOTE: This styling should be reflected in tag.css */

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -1,0 +1,59 @@
+/* Translations are defined outside component class so users can easily add translations */
+:root,
+[lang='nb'] {
+  --dsc-suggestion-count-label: 'valgt';
+}
+
+[lang='nn'] {
+  --dsc-suggestion-count-label: 'valde';
+}
+
+[lang='en'] {
+  --dsc-suggestion-count-label: 'selected';
+}
+
+.ds-suggestion {
+  /* Count display mode: use CSS counter to show number of selected items */
+  &[data-display='count'] {
+    counter-reset: selected;
+
+    /* Keep <data> in rendering tree for counter-increment but hide visually. */
+    & > data {
+      counter-increment: selected;
+      position: absolute;
+      visibility: hidden;
+    }
+
+    /* Hide listbox when in count display mode. */
+    &::part(items) {
+      visibility: hidden;
+    }
+
+    /* NOTE: This styling should be reflected in tag.css */
+    &:has(> data)::after {
+      content: counter(selected) ' ' var(--dsc-suggestion-count-label);
+      position: absolute;
+      inset-inline-start: var(--ds-size-3);
+      top: 50%;
+      translate: 0 -50%;
+      pointer-events: none;
+      z-index: 1;
+      align-items: center;
+      background: var(--ds-color-surface-tinted);
+      border: solid transparent var(--ds-border-width-default);
+      border-radius: var(--ds-border-radius-sm);
+      box-sizing: border-box;
+      color: var(--ds-color-text-default);
+      font-size: var(--ds-body-sm-font-size);
+      line-height: var(--ds-line-height-sm);
+      min-height: var(--ds-size-8);
+      padding: 0 var(--ds-size-2);
+      display: inline-flex;
+    }
+
+    /* Hide count display when focused to prevent overlap with input text. */
+    &:focus-within::after {
+      display: none;
+    }
+  }
+}

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -13,6 +13,12 @@
 }
 
 .ds-suggestion {
+  /* u-combobox 2.0.5 changed [role="listbox"] from display:contents to inline-flex,
+     so chips no longer participate in the host's flex-wrap. Restore wrapping. */
+  &::part(items) {
+    flex-wrap: wrap;
+  }
+
   /* Count display mode: use CSS counter to show number of selected items */
   &[data-display='count'] {
     counter-reset: selected;


### PR DESCRIPTION
## Hva er gjort?

When display="count" is set on a multiple Suggestion, selected chips
are hidden visually and a count tag (e.g. "2 valgt") is shown inside the input
using a CSS ::after pseudo-element with content: counter(selected). 

Using [CSS counters](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Counter_styles/Using_counters) to count number of <data>(chips) in the tree. 

The tag hides on focus to avoid overlapping typed text.

Customize the label via the --dsc-count-label CSS variable
(defaults to "valgt").

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er testet med skjermleser og/eller annet UU-verktøy