### PR TITLE
ci: add docs preview deployments for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,103 +147,31 @@ jobs:
       id-token: write
 
   deploy-docs:
-    runs-on: ubuntu-latest
     needs: [release]
     # Deploy on pushes to main & release/* branches
     if: |
       always() && !failure() && !cancelled() &&
       github.event_name == 'push' &&
       (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
-    environment: docs
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/pnpm-setup
-
-      - name: Build storybook
-        run: pnpm turbo run build:docs --filter=@udir-design/react
-
-      - shell: bash
-        env:
-          BRANCH: ${{ github.ref_name }}
-        run: echo "DESTINATION_PATH=${BRANCH/release\//}" >> $GITHUB_ENV
-      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
-        name: Empty target directory
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
-        with:
-          azcliversion: 2.78.0
-          inlineScript: |
-            az storage blob delete-batch --account-name stdesignsystemdocs -s '$web' --pattern "$DESTINATION_PATH/*"
-      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
-        name: Upload to target directory
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
-        with:
-          azcliversion: 2.78.0
-          inlineScript: |
-            az storage blob upload-batch --account-name stdesignsystemdocs -s @udir-design/react/storybook-static -d '$web' --destination-path $DESTINATION_PATH
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      destination-path: ${{ github.ref_name }}
+      environment: docs
+    secrets: inherit
 
   deploy-docs-preview:
-    runs-on: ubuntu-latest
     needs: [main]
     if: |
       github.event_name == 'pull_request' &&
       github.event.action != 'closed' &&
       !startsWith(github.base_ref, 'release/') &&
       needs.main.outputs.run_ui_tests == 'true'
-    environment: docs-preview
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/pnpm-setup
-
-      - name: Build storybook
-        run: pnpm turbo run build:docs --filter=@udir-design/react
-
-      - name: Set destination path
-        run: echo "DESTINATION_PATH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-
-      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
-        name: Empty target directory
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
-        with:
-          azcliversion: 2.78.0
-          inlineScript: |
-            az storage blob delete-batch --account-name stdesignsystemdocs -s '$web' --pattern "$DESTINATION_PATH/*"
-
-      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
-        name: Upload to target directory
-        env:
-          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
-        with:
-          azcliversion: 2.78.0
-          inlineScript: |
-            az storage blob upload-batch --account-name stdesignsystemdocs -s @udir-design/react/storybook-static -d '$web' --destination-path $DESTINATION_PATH
-
-      - name: Post preview link
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          COMMENT_MARKER="<!-- docs-preview -->"
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          PREVIEW_URL="https://stdesignsystemdocs.z1.web.core.windows.net/pr-${PR_NUMBER}/"
-          BODY="${COMMENT_MARKER}
-          📚 **Docs preview**: ${PREVIEW_URL}"
-
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- docs-preview -->")) | .id' 2>/dev/null | head -1)
-
-          if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -f body="${BODY}"
-          else
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}"
-          fi
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      destination-path: pr-${{ github.event.pull_request.number }}
+      environment: docs-preview
+      post-preview-comment: true
+    secrets: inherit
 
   cleanup-docs-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,18 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - closed
 
 permissions:
   actions: read
   contents: read
   checks: write
+  pull-requests: write
 
 jobs:
   main:
     runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
     outputs:
       run_ui_tests: ${{ steps.job_condition.outputs.run_ui_tests }}
       run_nextjs_smoke: ${{ steps.job_condition.outputs.run_nextjs_smoke }}
@@ -151,7 +154,7 @@ jobs:
       always() && !failure() && !cancelled() &&
       github.event_name == 'push' &&
       (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
-    environment: production
+    environment: docs
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -182,3 +185,87 @@ jobs:
           azcliversion: 2.78.0
           inlineScript: |
             az storage blob upload-batch --account-name stdesignsystemdocs -s @udir-design/react/storybook-static -d '$web' --destination-path $DESTINATION_PATH
+
+  deploy-docs-preview:
+    runs-on: ubuntu-latest
+    needs: [main]
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      !startsWith(github.base_ref, 'release/') &&
+      needs.main.outputs.run_ui_tests == 'true'
+    environment: docs-preview
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/pnpm-setup
+
+      - name: Build storybook
+        run: pnpm turbo run build:docs --filter=@udir-design/react
+
+      - name: Set destination path
+        run: echo "DESTINATION_PATH=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+
+      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        name: Empty target directory
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
+        with:
+          azcliversion: 2.78.0
+          inlineScript: |
+            az storage blob delete-batch --account-name stdesignsystemdocs -s '$web' --pattern "$DESTINATION_PATH/*"
+
+      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        name: Upload to target directory
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
+        with:
+          azcliversion: 2.78.0
+          inlineScript: |
+            az storage blob upload-batch --account-name stdesignsystemdocs -s @udir-design/react/storybook-static -d '$web' --destination-path $DESTINATION_PATH
+
+      - name: Post preview link
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT_MARKER="<!-- docs-preview -->"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PREVIEW_URL="https://stdesignsystemdocs.z1.web.core.windows.net/pr-${PR_NUMBER}/"
+          BODY="${COMMENT_MARKER}
+          📚 **Docs preview**: ${PREVIEW_URL}"
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- docs-preview -->")) | .id' 2>/dev/null | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -f body="${BODY}"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}"
+          fi
+
+  cleanup-docs-preview:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    environment: docs-preview
+    steps:
+      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        name: Delete preview blobs
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING}}
+        with:
+          azcliversion: 2.78.0
+          inlineScript: |
+            az storage blob delete-batch --account-name stdesignsystemdocs -s '$web' --pattern "pr-${{ github.event.pull_request.number }}/*"
+
+      - name: Delete preview comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- docs-preview -->")) | .id' 2>/dev/null | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X DELETE
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,10 +190,5 @@ jobs:
       - name: Delete preview comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- docs-preview -->")) | .id' 2>/dev/null | head -1)
-          if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X DELETE
-          fi
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr comment "$PR_NUMBER" --delete-last --yes || true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -67,18 +67,7 @@ jobs:
         if: inputs.post-preview-comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          COMMENT_MARKER="<!-- docs-preview -->"
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          PREVIEW_URL="https://stdesignsystemdocs.z1.web.core.windows.net/${DESTINATION_PATH}/"
-          BODY="${COMMENT_MARKER}
-          📚 **Docs preview**: ${PREVIEW_URL}"
-
-          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- docs-preview -->")) | .id' 2>/dev/null | head -1)
-
-          if [ -n "$COMMENT_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -f body="${BODY}"
-          else
-            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}"
-          fi
+          BODY="📚 **Docs preview**: https://stdesignsystemdocs.z1.web.core.windows.net/${DESTINATION_PATH}/"
+          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body "$BODY"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,84 @@
+# Reusable workflow for building and deploying Storybook docs to Azure Blob Storage.
+# Called from ci.yml for both production and PR preview deployments.
+
+name: Deploy Docs
+
+on:
+  workflow_call:
+    inputs:
+      destination-path:
+        description: >
+          Target path in the storage container. A 'release/' prefix is
+          automatically stripped (e.g. 'release/1.0.0' becomes '1.0.0').
+        required: true
+        type: string
+      environment:
+        description: GitHub environment to use (must contain DOCS_STORAGE_CONNECTION_STRING).
+        required: true
+        type: string
+      post-preview-comment:
+        description: Post or update a PR comment with the preview link.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/pnpm-setup
+
+      - name: Build storybook
+        run: pnpm turbo run build:docs --filter=@udir-design/react
+
+      - name: Set destination path
+        env:
+          RAW_PATH: ${{ inputs.destination-path }}
+        run: echo "DESTINATION_PATH=${RAW_PATH/release\//}" >> $GITHUB_ENV
+
+      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        name: Empty target directory
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING }}
+        with:
+          azcliversion: 2.78.0
+          inlineScript: |
+            az storage blob delete-batch --account-name stdesignsystemdocs -s '$web' --pattern "$DESTINATION_PATH/*"
+
+      - uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        name: Upload to target directory
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.DOCS_STORAGE_CONNECTION_STRING }}
+        with:
+          azcliversion: 2.78.0
+          inlineScript: |
+            az storage blob upload-batch --account-name stdesignsystemdocs -s @udir-design/react/storybook-static -d '$web' --destination-path $DESTINATION_PATH
+
+      - name: Post preview link
+        if: inputs.post-preview-comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT_MARKER="<!-- docs-preview -->"
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PREVIEW_URL="https://stdesignsystemdocs.z1.web.core.windows.net/${DESTINATION_PATH}/"
+          BODY="${COMMENT_MARKER}
+          📚 **Docs preview**: ${PREVIEW_URL}"
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- docs-preview -->")) | .id' 2>/dev/null | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -f body="${BODY}"
+          else
+            gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" -f body="${BODY}"
+          fi


### PR DESCRIPTION
Deployer Storybook-dokumentasjon til `pr-<nummer>/` på Azure Blob Storage
når ein PR blir opna eller oppdatert, og ryddar opp når PR-en blir lukka.

## Kva er gjort?

- Ny gjenbrukbar workflow `deploy-docs.yml` for bygging og utrulling av docs
- `deploy-docs` og `deploy-docs-preview` i `ci.yml` brukar no denne
- Ny `cleanup-docs-preview`-jobb som slettar blobs og kommentar ved lukking
- `environment: production` erstatta med `docs` og `docs-preview`