### PR TITLE
feat: custom sequential monochromatic color palettes

### DIFF
--- a/@udir-design/react/src/design-tokens/docs/color/datavis-color-display.tsx
+++ b/@udir-design/react/src/design-tokens/docs/color/datavis-color-display.tsx
@@ -1,6 +1,7 @@
 import { Card } from 'src/components/card';
 import { Paragraph } from 'src/components/typography/paragraph';
 import {
+  generateSequentialMonochromaticColors,
   getCategoricalColors,
   getSequentialDivergentColors,
   getSequentialMonochromaticColors,
@@ -55,6 +56,25 @@ export const DatavisSeqColorDisplay = () => {
     <div className={classes.containerNoGap}>
       <div className={classes.containerMd}>
         {datavisSeqMonoColors.map((color, index) => (
+          <div
+            key={index}
+            className={classes.swatchBox}
+            style={{ background: color }}
+          >
+            <Paragraph data-size="xs">{index + 1}</Paragraph>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const DatavisGenSeqColorDisplay = () => {
+  const generatedColors = generateSequentialMonochromaticColors(16);
+  return (
+    <div className={classes.containerNoGap}>
+      <div className={classes.containerMd}>
+        {generatedColors.map((color, index) => (
           <div
             key={index}
             className={classes.swatchBox}

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation.mdx
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation.mdx
@@ -4,6 +4,7 @@ import { Link } from 'src/components/link/Link';
 import {
   DatavisValueColorDisplay,
   DatavisSeqColorDisplay,
+  DatavisGenSeqColorDisplay,
   DatavisSeqDivColorDisplay,
 } from '../../design-tokens/docs/color/datavis-color-display';
 import rechartsExample from './docs/rechartsExample.tsx?raw';
@@ -15,14 +16,15 @@ import * as stories from './dataVisualisation.stories.tsx';
 
 # Hjelpefunksjoner for datavisualisering
 
-Verktøy for å bruke datavisualiseringsfarger i diagrammer og grafer. Disse funksjonene returnerer CSS-variabler som automatisk tilpasser seg når temaet endres (lys/mørk modus).
+Verktøy for å bruke datavisualiseringsfarger i diagrammer og grafer. Funksjonene under returnerer enten farger som CSS-variabler eller hex-fargeverdier, eller ferdig konfigurert temainnstilling for Highcharts. CSS-variablene tilpasser seg automatisk når temaet endres (lys/mørk modus).
 
 - `getCategoricalColors()`
 - `getSequentialMonochromaticColors()`
+- `generateSequentialMonochromaticColors(count: number)`
 - `getSequentialDivergentColors()`
 - `getHighchartsTheme()`
 
-Les også <Link href="./typedoc/modules/utilities_datavis_alpha.html" target="_none">detaljert dokumentasjon generert fra kildekoden (på engelsk)</Link>.
+Les også <Link href="./typedoc/modules/utilities_datavis_alpha.html">detaljert dokumentasjon generert fra kildekoden (på engelsk)</Link>.
 
 <SimpleAlert type="tip">
   Se [Farger for
@@ -77,6 +79,19 @@ const colors = getSequentialMonochromaticColors();
 
 <Unstyled>
   <DatavisSeqColorDisplay />
+</Unstyled>
+
+**`generateSequentialMonochromaticColors(count: number)`** - Genererer et egenvalgt antall hex-fargeverdier (minimum 1).
+
+```tsx
+import { generateSequentialMonochromaticColors } from '@udir-design/react/utilities/alpha';
+
+const colors = generateSequentialMonochromaticColors(16);
+// ['#5ba27e', '#4a8f6b', '#397b58', ...]
+```
+
+<Unstyled>
+  <DatavisGenSeqColorDisplay />
 </Unstyled>
 
 ---

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
@@ -55,43 +55,6 @@ describe('getSequentialMonochromaticColors', () => {
       getSequentialMonochromaticColors(),
     );
   });
-
-  it('returns correct number of colors when count is specified', () => {
-    expect(getSequentialMonochromaticColors(4)).toHaveLength(4);
-    expect(getSequentialMonochromaticColors(1)).toHaveLength(1);
-  });
-
-  it('returns first and last palette colors when count is 2', () => {
-    const colors = getSequentialMonochromaticColors(2);
-    expect(colors).toEqual([
-      'var(--uds-data-color-sequential-monochromatic-1)',
-      'var(--uds-data-color-sequential-monochromatic-8)',
-    ]);
-  });
-
-  it('evenly distributes colors across the palette for count=4', () => {
-    const colors = getSequentialMonochromaticColors(4);
-    expect(colors).toEqual([
-      'var(--uds-data-color-sequential-monochromatic-1)',
-      'var(--uds-data-color-sequential-monochromatic-3)',
-      'var(--uds-data-color-sequential-monochromatic-6)',
-      'var(--uds-data-color-sequential-monochromatic-8)',
-    ]);
-  });
-
-  it('returns first color only when count is 1', () => {
-    expect(getSequentialMonochromaticColors(1)).toEqual([
-      'var(--uds-data-color-sequential-monochromatic-1)',
-    ]);
-  });
-
-  it('throws RangeError for count below 1', () => {
-    expect(() => getSequentialMonochromaticColors(0)).toThrow(RangeError);
-  });
-
-  it('throws RangeError for count above 8', () => {
-    expect(() => getSequentialMonochromaticColors(9)).toThrow(RangeError);
-  });
 });
 
 describe('getSequentialDivergentColors', () => {
@@ -169,6 +132,7 @@ describe('generateMonochromaticColors', () => {
     expect(generateMonochromaticColors(10)).toHaveLength(10);
     expect(generateMonochromaticColors(1)).toHaveLength(1);
     expect(generateMonochromaticColors(8)).toHaveLength(8);
+    expect(generateMonochromaticColors(14)).toHaveLength(14);
   });
 
   it('returns hex color strings', () => {

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  generateMonochromaticColors,
+  generateSequentialMonochromaticColors,
   getCategoricalColors,
   getSequentialDivergentColors,
   getSequentialMonochromaticColors,
@@ -57,39 +57,42 @@ describe('getSequentialMonochromaticColors', () => {
   });
 });
 
-describe('generateMonochromaticColors', () => {
+describe('generateSequentialMonochromaticColors', () => {
   it('returns correct number of colors', () => {
-    expect(generateMonochromaticColors(10)).toHaveLength(10);
-    expect(generateMonochromaticColors(1)).toHaveLength(1);
-    expect(generateMonochromaticColors(8)).toHaveLength(8);
-    expect(generateMonochromaticColors(14)).toHaveLength(14);
+    expect(generateSequentialMonochromaticColors(10)).toHaveLength(10);
+    expect(generateSequentialMonochromaticColors(1)).toHaveLength(1);
+    expect(generateSequentialMonochromaticColors(8)).toHaveLength(8);
+    expect(generateSequentialMonochromaticColors(14)).toHaveLength(14);
   });
 
   it('returns hex color strings', () => {
-    for (const color of generateMonochromaticColors(10)) {
+    for (const color of generateSequentialMonochromaticColors(10)) {
       expect(color).toMatch(/^#[0-9a-f]{6}$/);
     }
   });
 
   it('starts with the lightest anchor color', () => {
-    expect(generateMonochromaticColors(10)[0]).toBe('#5ba27e');
+    expect(generateSequentialMonochromaticColors(10)[0]).toBe('#5ba27e');
   });
 
   it('ends with the darkest anchor color', () => {
-    const colors = generateMonochromaticColors(10);
+    const colors = generateSequentialMonochromaticColors(10);
     expect(colors[colors.length - 1]).toBe('#0b1e15');
   });
 
   it('returns just the start color when count is 1', () => {
-    expect(generateMonochromaticColors(1)).toEqual(['#5ba27e']);
+    expect(generateSequentialMonochromaticColors(1)).toEqual(['#5ba27e']);
   });
 
   it('returns start and end when count is 2', () => {
-    expect(generateMonochromaticColors(2)).toEqual(['#5ba27e', '#0b1e15']);
+    expect(generateSequentialMonochromaticColors(2)).toEqual([
+      '#5ba27e',
+      '#0b1e15',
+    ]);
   });
 
   it('throws RangeError for count below 1', () => {
-    expect(() => generateMonochromaticColors(0)).toThrow(RangeError);
+    expect(() => generateSequentialMonochromaticColors(0)).toThrow(RangeError);
   });
 });
 

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
@@ -30,11 +30,11 @@ describe('getCategoricalColors', () => {
 });
 
 describe('getSequentialMonochromaticColors', () => {
-  it('returns 8 colors by default', () => {
+  it('returns 8 sequential monochromatic CSS-colorvalues', () => {
     expect(getSequentialMonochromaticColors()).toHaveLength(8);
   });
 
-  it('returns all 8 colors as CSS variable references', () => {
+  it('returns a list of 8 sequential monochromatic CSS-colorvalues', () => {
     for (const color of getSequentialMonochromaticColors()) {
       expect(color).toMatch(
         /^var\(--uds-data-color-sequential-monochromatic-\d+\)$/,
@@ -42,7 +42,7 @@ describe('getSequentialMonochromaticColors', () => {
     }
   });
 
-  it('returns colors numbered 1-8 in order when called with default', () => {
+  it('returns colors numbered 1-8 in order', () => {
     getSequentialMonochromaticColors().forEach((color, i) => {
       expect(color).toBe(
         `var(--uds-data-color-sequential-monochromatic-${i + 1})`,
@@ -54,6 +54,42 @@ describe('getSequentialMonochromaticColors', () => {
     expect(getSequentialMonochromaticColors()).toEqual(
       getSequentialMonochromaticColors(),
     );
+  });
+});
+
+describe('generateMonochromaticColors', () => {
+  it('returns correct number of colors', () => {
+    expect(generateMonochromaticColors(10)).toHaveLength(10);
+    expect(generateMonochromaticColors(1)).toHaveLength(1);
+    expect(generateMonochromaticColors(8)).toHaveLength(8);
+    expect(generateMonochromaticColors(14)).toHaveLength(14);
+  });
+
+  it('returns hex color strings', () => {
+    for (const color of generateMonochromaticColors(10)) {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it('starts with the lightest anchor color', () => {
+    expect(generateMonochromaticColors(10)[0]).toBe('#5ba27e');
+  });
+
+  it('ends with the darkest anchor color', () => {
+    const colors = generateMonochromaticColors(10);
+    expect(colors[colors.length - 1]).toBe('#0b1e15');
+  });
+
+  it('returns just the start color when count is 1', () => {
+    expect(generateMonochromaticColors(1)).toEqual(['#5ba27e']);
+  });
+
+  it('returns start and end when count is 2', () => {
+    expect(generateMonochromaticColors(2)).toEqual(['#5ba27e', '#0b1e15']);
+  });
+
+  it('throws RangeError for count below 1', () => {
+    expect(() => generateMonochromaticColors(0)).toThrow(RangeError);
   });
 });
 
@@ -124,41 +160,5 @@ describe('getHighchartsTheme', () => {
 
   it('returns the same theme each call', () => {
     expect(getHighchartsTheme()).toEqual(getHighchartsTheme());
-  });
-});
-
-describe('generateMonochromaticColors', () => {
-  it('returns correct number of colors', () => {
-    expect(generateMonochromaticColors(10)).toHaveLength(10);
-    expect(generateMonochromaticColors(1)).toHaveLength(1);
-    expect(generateMonochromaticColors(8)).toHaveLength(8);
-    expect(generateMonochromaticColors(14)).toHaveLength(14);
-  });
-
-  it('returns hex color strings', () => {
-    for (const color of generateMonochromaticColors(10)) {
-      expect(color).toMatch(/^#[0-9a-f]{6}$/);
-    }
-  });
-
-  it('starts with the lightest anchor color', () => {
-    expect(generateMonochromaticColors(10)[0]).toBe('#5ba27e');
-  });
-
-  it('ends with the darkest anchor color', () => {
-    const colors = generateMonochromaticColors(10);
-    expect(colors[colors.length - 1]).toBe('#0b1e15');
-  });
-
-  it('returns just the start color when count is 1', () => {
-    expect(generateMonochromaticColors(1)).toEqual(['#5ba27e']);
-  });
-
-  it('returns start and end when count is 2', () => {
-    expect(generateMonochromaticColors(2)).toEqual(['#5ba27e', '#0b1e15']);
-  });
-
-  it('throws RangeError for count below 1', () => {
-    expect(() => generateMonochromaticColors(0)).toThrow(RangeError);
   });
 });

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  generateMonochromaticColors,
   getCategoricalColors,
   getSequentialDivergentColors,
   getSequentialMonochromaticColors,
@@ -29,11 +30,11 @@ describe('getCategoricalColors', () => {
 });
 
 describe('getSequentialMonochromaticColors', () => {
-  it('returns 8 sequential monochromatic CSS-colorvalues', () => {
+  it('returns 8 colors by default', () => {
     expect(getSequentialMonochromaticColors()).toHaveLength(8);
   });
 
-  it('returns a list of 8 sequential monochromatic CSS-colorvalues', () => {
+  it('returns all 8 colors as CSS variable references', () => {
     for (const color of getSequentialMonochromaticColors()) {
       expect(color).toMatch(
         /^var\(--uds-data-color-sequential-monochromatic-\d+\)$/,
@@ -41,7 +42,7 @@ describe('getSequentialMonochromaticColors', () => {
     }
   });
 
-  it('returns colors numbered 1-8 in order', () => {
+  it('returns colors numbered 1-8 in order when called with default', () => {
     getSequentialMonochromaticColors().forEach((color, i) => {
       expect(color).toBe(
         `var(--uds-data-color-sequential-monochromatic-${i + 1})`,
@@ -53,6 +54,43 @@ describe('getSequentialMonochromaticColors', () => {
     expect(getSequentialMonochromaticColors()).toEqual(
       getSequentialMonochromaticColors(),
     );
+  });
+
+  it('returns correct number of colors when count is specified', () => {
+    expect(getSequentialMonochromaticColors(4)).toHaveLength(4);
+    expect(getSequentialMonochromaticColors(1)).toHaveLength(1);
+  });
+
+  it('returns first and last palette colors when count is 2', () => {
+    const colors = getSequentialMonochromaticColors(2);
+    expect(colors).toEqual([
+      'var(--uds-data-color-sequential-monochromatic-1)',
+      'var(--uds-data-color-sequential-monochromatic-8)',
+    ]);
+  });
+
+  it('evenly distributes colors across the palette for count=4', () => {
+    const colors = getSequentialMonochromaticColors(4);
+    expect(colors).toEqual([
+      'var(--uds-data-color-sequential-monochromatic-1)',
+      'var(--uds-data-color-sequential-monochromatic-3)',
+      'var(--uds-data-color-sequential-monochromatic-6)',
+      'var(--uds-data-color-sequential-monochromatic-8)',
+    ]);
+  });
+
+  it('returns first color only when count is 1', () => {
+    expect(getSequentialMonochromaticColors(1)).toEqual([
+      'var(--uds-data-color-sequential-monochromatic-1)',
+    ]);
+  });
+
+  it('throws RangeError for count below 1', () => {
+    expect(() => getSequentialMonochromaticColors(0)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for count above 8', () => {
+    expect(() => getSequentialMonochromaticColors(9)).toThrow(RangeError);
   });
 });
 
@@ -123,5 +161,40 @@ describe('getHighchartsTheme', () => {
 
   it('returns the same theme each call', () => {
     expect(getHighchartsTheme()).toEqual(getHighchartsTheme());
+  });
+});
+
+describe('generateMonochromaticColors', () => {
+  it('returns correct number of colors', () => {
+    expect(generateMonochromaticColors(10)).toHaveLength(10);
+    expect(generateMonochromaticColors(1)).toHaveLength(1);
+    expect(generateMonochromaticColors(8)).toHaveLength(8);
+  });
+
+  it('returns hex color strings', () => {
+    for (const color of generateMonochromaticColors(10)) {
+      expect(color).toMatch(/^#[0-9a-f]{6}$/);
+    }
+  });
+
+  it('starts with the lightest anchor color', () => {
+    expect(generateMonochromaticColors(10)[0]).toBe('#5ba27e');
+  });
+
+  it('ends with the darkest anchor color', () => {
+    const colors = generateMonochromaticColors(10);
+    expect(colors[colors.length - 1]).toBe('#0b1e15');
+  });
+
+  it('returns just the start color when count is 1', () => {
+    expect(generateMonochromaticColors(1)).toEqual(['#5ba27e']);
+  });
+
+  it('returns start and end when count is 2', () => {
+    expect(generateMonochromaticColors(2)).toEqual(['#5ba27e', '#0b1e15']);
+  });
+
+  it('throws RangeError for count below 1', () => {
+    expect(() => generateMonochromaticColors(0)).toThrow(RangeError);
   });
 });

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation/index.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation/index.ts
@@ -75,7 +75,7 @@ function interpolateRgb(start: string, end: string, t: number): string {
 }
 
 /**
- * Generates a monochromatic color palette by interpolating between the
+ * Generates a sequential monochromatic color palette by interpolating between the
  * lightest and darkest palette anchors. Returns hex color strings.
  *
  * Unlike `getSequentialMonochromaticColors`, this function is not limited
@@ -87,13 +87,15 @@ function interpolateRgb(start: string, end: string, t: number): string {
  *
  * @example
  * ```tsx
- * import { generateMonochromaticColors } from '@udir-design/react/alpha/utilities';
+ * import { generateSequentialMonochromaticColors } from '@udir-design/react/alpha/utilities';
  *
- * const colors = generateMonochromaticColors(10);
+ * const colors = generateSequentialMonochromaticColors(10);
  * // ['#5ba27e', '#4f9272', ..., '#0b1e15']
  * ```
  */
-export function generateMonochromaticColors(count: number): readonly string[] {
+export function generateSequentialMonochromaticColors(
+  count: number,
+): readonly string[] {
   if (count < 1) {
     throw new RangeError(`count must be at least 1, got ${count}`);
   }

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation/index.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation/index.ts
@@ -27,11 +27,15 @@ export function getCategoricalColors(): readonly string[] {
   );
 }
 
+const MONOCHROMATIC_PALETTE_SIZE = 8;
+
 /**
  * Gets the sequential monochromatic color palette for data visualisation.
- * Returns CSS variable reference.
+ * Returns CSS variable references, evenly distributed across the palette.
  *
- * @returns Array of 8 CSS variable references from light to dark
+ * @param count - Number of colors to return (1–8). Defaults to 8.
+ *               Colors are evenly distributed across the palette.
+ * @returns Array of CSS variable references from light to dark
  *
  * @example
  * ```tsx
@@ -40,12 +44,87 @@ export function getCategoricalColors(): readonly string[] {
  *
  * const colors = getSequentialMonochromaticColors();
  * // ['var(--uds-data-color-sequential-monochromatic-1)', ...]
+ *
+ * const threeColors = getSequentialMonochromaticColors(3);
+ * // ['var(--uds-data-color-sequential-monochromatic-1)',
+ * //  'var(--uds-data-color-sequential-monochromatic-4)',
+ * //  'var(--uds-data-color-sequential-monochromatic-8)']
  * ```
  */
-export function getSequentialMonochromaticColors(): readonly string[] {
-  return Array.from(
-    { length: 8 },
-    (_, i) => `var(--uds-data-color-sequential-monochromatic-${i + 1})`,
+export function getSequentialMonochromaticColors(
+  count: number = MONOCHROMATIC_PALETTE_SIZE,
+): readonly string[] {
+  if (count < 1 || count > MONOCHROMATIC_PALETTE_SIZE) {
+    throw new RangeError(
+      `count must be between 1 and ${MONOCHROMATIC_PALETTE_SIZE}, got ${count}`,
+    );
+  }
+  if (count === 1) {
+    return [`var(--uds-data-color-sequential-monochromatic-1)`];
+  }
+  return Array.from({ length: count }, (_, i) => {
+    const index = Math.round(
+      (i * (MONOCHROMATIC_PALETTE_SIZE - 1)) / (count - 1),
+    );
+    return `var(--uds-data-color-sequential-monochromatic-${index + 1})`;
+  });
+}
+
+/**
+ * Anchor hex values for the monochromatic palette (light mode).
+ * These mirror --uds-data-color-sequential-monochromatic-1 and -8.
+ */
+const MONOCHROMATIC_HEX_START = '#5ba27e';
+const MONOCHROMATIC_HEX_END = '#0b1e15';
+
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.slice(1), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    '#' +
+    [r, g, b].map((v) => Math.round(v).toString(16).padStart(2, '0')).join('')
+  );
+}
+
+function interpolateRgb(start: string, end: string, t: number): string {
+  const [r1, g1, b1] = hexToRgb(start);
+  const [r2, g2, b2] = hexToRgb(end);
+  return rgbToHex(r1 + t * (r2 - r1), g1 + t * (g2 - g1), b1 + t * (b2 - b1));
+}
+
+/**
+ * Generates a monochromatic color palette by interpolating between the
+ * lightest and darkest palette anchors. Returns hex color strings.
+ *
+ * Unlike `getSequentialMonochromaticColors`, this function is not limited
+ * to 8 colors and always returns resolved hex values rather than CSS variable
+ * references. The anchor colors are fixed to the light mode palette.
+ *
+ * @param count - Number of colors to generate (minimum 1)
+ * @returns Array of hex color strings from light to dark
+ *
+ * @example
+ * ```tsx
+ * import { generateMonochromaticColors } from '@udir-design/react/alpha/utilities';
+ *
+ * const colors = generateMonochromaticColors(10);
+ * // ['#5ba27e', '#4f9272', ..., '#0b1e15']
+ * ```
+ */
+export function generateMonochromaticColors(count: number): readonly string[] {
+  if (count < 1) {
+    throw new RangeError(`count must be at least 1, got ${count}`);
+  }
+  if (count === 1) return [MONOCHROMATIC_HEX_START];
+  return Array.from({ length: count }, (_, i) =>
+    interpolateRgb(
+      MONOCHROMATIC_HEX_START,
+      MONOCHROMATIC_HEX_END,
+      i / (count - 1),
+    ),
   );
 }
 

--- a/@udir-design/react/src/utilities/datavis/dataVisualisation/index.ts
+++ b/@udir-design/react/src/utilities/datavis/dataVisualisation/index.ts
@@ -27,15 +27,11 @@ export function getCategoricalColors(): readonly string[] {
   );
 }
 
-const MONOCHROMATIC_PALETTE_SIZE = 8;
-
 /**
  * Gets the sequential monochromatic color palette for data visualisation.
- * Returns CSS variable references, evenly distributed across the palette.
+ * Returns CSS variable reference.
  *
- * @param count - Number of colors to return (1–8). Defaults to 8.
- *               Colors are evenly distributed across the palette.
- * @returns Array of CSS variable references from light to dark
+ * @returns Array of 8 CSS variable references from light to dark
  *
  * @example
  * ```tsx
@@ -44,30 +40,13 @@ const MONOCHROMATIC_PALETTE_SIZE = 8;
  *
  * const colors = getSequentialMonochromaticColors();
  * // ['var(--uds-data-color-sequential-monochromatic-1)', ...]
- *
- * const threeColors = getSequentialMonochromaticColors(3);
- * // ['var(--uds-data-color-sequential-monochromatic-1)',
- * //  'var(--uds-data-color-sequential-monochromatic-4)',
- * //  'var(--uds-data-color-sequential-monochromatic-8)']
  * ```
  */
-export function getSequentialMonochromaticColors(
-  count: number = MONOCHROMATIC_PALETTE_SIZE,
-): readonly string[] {
-  if (count < 1 || count > MONOCHROMATIC_PALETTE_SIZE) {
-    throw new RangeError(
-      `count must be between 1 and ${MONOCHROMATIC_PALETTE_SIZE}, got ${count}`,
-    );
-  }
-  if (count === 1) {
-    return [`var(--uds-data-color-sequential-monochromatic-1)`];
-  }
-  return Array.from({ length: count }, (_, i) => {
-    const index = Math.round(
-      (i * (MONOCHROMATIC_PALETTE_SIZE - 1)) / (count - 1),
-    );
-    return `var(--uds-data-color-sequential-monochromatic-${index + 1})`;
-  });
+export function getSequentialMonochromaticColors(): readonly string[] {
+  return Array.from(
+    { length: 8 },
+    (_, i) => `var(--uds-data-color-sequential-monochromatic-${i + 1})`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Hva er gjort?

Det er lagt til støtte for å generere et valgfritt antall sekvensielle monokromatiske farger.

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
