### PR TITLE
feat: add list view of fileupload items

### DIFF
--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -65,6 +65,12 @@ Filnavnet er en [`Link`](/docs/components-link--docs) med `download`-attributtet
 
 <Canvas of={FileUploadStories.Upload} />
 
+### Listevisning
+
+`FileUpload.List` er en variant av `FileUpload.Item` som viser filene i en liste. Denne kan brukes når det er mange filer, eller når det er viktig å vise mer informasjon om hver fil.
+
+<Canvas of={FileUploadStories.List} />
+
 ## Tekst i FileUpload
 
 I både `FileUpload.Dropzone` og `FileUpload.Trigger` bruker du `label` og `description` til å beskrive hva slags filer brukeren kan laste opp. Det skal som hovedregel være en `label` på `FileUpload`.

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -67,7 +67,7 @@ Filnavnet er en [`Link`](/docs/components-link--docs) med `download`-attributtet
 
 ### Listevisning
 
-`FileUpload.List` er en variant av `FileUpload.Item` som viser filene i en liste. Denne kan brukes når det er mange filer, eller når det er viktig å vise mer informasjon om hver fil.
+`FileUpload.List` er en variant av `FileUpload.Item` som viser filene i en liste. Denne visningen kan være nyttig når mange filer skal vises, og en listevisning er mer hensiktsmessig.
 
 <Canvas of={FileUploadStories.List} />
 

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -6,8 +6,10 @@ import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Heading } from 'src/components/typography/heading';
+import { Prose } from '../typography/prose';
 import { FileUploadDropzone } from './docs/FakeFileUploadDropzone';
 import { FileUploadItem } from './docs/FakeFileUploadItem';
+import { FileUploadList } from './docs/FakeFileUploadList';
 import { FileUploadTrigger } from './docs/FakeFileUploadTrigger';
 import { FileUpload } from './index';
 
@@ -16,6 +18,7 @@ const meta = preview.meta({
   subcomponents: {
     'FileUpload.Dropzone': FileUploadDropzone,
     'FileUpload.Item': FileUploadItem,
+    'FileUpload.List': FileUploadList,
   },
   tags: ['udir'],
   parameters: {
@@ -478,6 +481,40 @@ export const Upload = meta.story({
           </>
         )}
       </div>
+    );
+  },
+});
+
+export const List = meta.story({
+  parameters: { docs: advancedCodeDocs },
+  args: {
+    'data-size': 'md',
+  },
+  render: (args) => {
+    const dummyFiles = [
+      { file: new File(['abc'.repeat(100000)], 'kandidat-12.pdf') },
+      { file: new File(['abc'.repeat(100000)], 'kandidat-13.pdf') },
+      { file: new File(['abc'.repeat(100000)], 'kandidat-14.pdf') },
+      { file: new File(['abc'.repeat(100000)], 'kandidat-15.pdf') },
+      {
+        file: new File(['abc'.repeat(288000)], 'kandidat-16.tsx'),
+        error: 'Filformatet støttes ikke',
+      },
+    ];
+
+    const [files, setFiles] = useState(dummyFiles);
+
+    const removeFile = (fileToRemove: File) => {
+      setFiles((prev) => prev.filter(({ file }) => file !== fileToRemove));
+    };
+
+    return (
+      <Prose>
+        <Heading level={3} data-size="2xs">
+          Vedlegg ({files.length}):
+        </Heading>
+        <FileUpload.List {...args} items={files} onRemove={removeFile} />
+      </Prose>
     );
   },
 });

--- a/@udir-design/react/src/components/fileUpload/FileUpload.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.tsx
@@ -1,5 +1,5 @@
 import { FileUploadDropzone } from './FileUploadDropzone';
-import { FileUploadItem } from './FileUploadItem';
+import { FileUploadItem, FileUploadList } from './FileUploadItem';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type FileUpload = {
@@ -26,14 +26,24 @@ export type FileUpload = {
    * <FileUpload.Item />
    */
   Item: typeof FileUploadItem;
+  /**
+   * Component that displays multiple uploaded files
+   * in a compact list with dividers
+   *
+   * @example
+   * <FileUpload.List items={items} onRemove={handleRemove} />
+   */
+  List: typeof FileUploadList;
 };
 
 export const FileUpload: FileUpload = {
   Trigger: FileUploadTrigger,
   Dropzone: FileUploadDropzone,
   Item: FileUploadItem,
+  List: FileUploadList,
 };
 
 FileUpload.Trigger.displayName = 'FileUpload.Trigger';
 FileUpload.Dropzone.displayName = 'FileUpload.Dropzone';
 FileUpload.Item.displayName = 'FileUpload.Item';
+FileUpload.List.displayName = 'FileUpload.List';

--- a/@udir-design/react/src/components/fileUpload/FileUpload.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.tsx
@@ -1,5 +1,6 @@
 import { FileUploadDropzone } from './FileUploadDropzone';
-import { FileUploadItem, FileUploadList } from './FileUploadItem';
+import { FileUploadItem } from './FileUploadItem';
+import { FileUploadList } from './FileUploadList';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type FileUpload = {

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -17,7 +17,6 @@ import {
 } from '@udir-design/icons';
 import { Button } from '../button';
 import { Card } from '../card';
-import { Divider } from '../divider';
 import { Link } from '../link';
 import { Spinner } from '../spinner';
 
@@ -124,104 +123,6 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
 );
 FileUploadItem.displayName = 'FileUpload.Item';
 
-export interface FileUploadListItem {
-  /**
-   * Either a native File or file metadata.
-   */
-  file: File;
-  /**
-   * href to file location.
-   */
-  href?: string;
-  /**
-   * Error message relating to the item.
-   */
-  error?: string;
-  /**
-   * Toggle loading state.
-   *
-   * @default false
-   */
-  loading?: boolean;
-  /**
-   * @default false
-   */
-  readonly?: boolean;
-}
-
-export interface FileUploadListProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'data-color'
-> {
-  'data-size'?: Size;
-  /**
-   * List of file items to display.
-   */
-  items: FileUploadListItem[];
-  /**
-   * Callback when the remove button is clicked.
-   */
-  onRemove: (file: File, event: MouseEvent<HTMLButtonElement>) => void;
-}
-
-export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
-  ({ items, onRemove, className, 'data-size': size, ...rest }, ref) => (
-    <Card
-      ref={ref}
-      className={cl('uds-file-upload__list', className)}
-      data-size={size}
-      {...rest}
-    >
-      <ul>
-        {items.map((item, index) => (
-          <li
-            key={item.file.name}
-            className="uds-file-upload__list-item"
-            aria-busy={item.loading || undefined}
-          >
-            {index > 0 && <Divider />}
-            <div className="uds-file-upload__list-row">
-              <div className="uds-file-upload__list-icon">
-                <Icon
-                  file={item.file}
-                  showError={Boolean(item.error)}
-                  loading={item.loading}
-                />
-              </div>
-              <div className="uds-file-upload__list-content">
-                <FileName file={item.file} href={item.href} />
-                {!item.loading && (
-                  <span className="uds-file-upload__list-size">
-                    {formatFileSize(item.file)}
-                  </span>
-                )}
-                {item.error && (
-                  <span className="uds-file-upload__list-error">
-                    <XMarkOctagonFillIcon aria-hidden />
-                    {item.error}
-                  </span>
-                )}
-              </div>
-              {!item.loading && !item.readonly && (
-                <Tooltip content="">
-                  <Button
-                    icon
-                    onClick={(e) => onRemove(item.file, e)}
-                    variant="tertiary"
-                  >
-                    <TrashIcon aria-hidden />
-                  </Button>
-                </Tooltip>
-              )}
-            </div>
-          </li>
-        ))}
-      </ul>
-    </Card>
-  ),
-);
-FileUploadList.displayName = 'FileUpload.List';
-
 export function formatFileSize(file: File): string | null {
   if (!file.size) {
     return null;
@@ -231,7 +132,7 @@ export function formatFileSize(file: File): string | null {
   return `${megaBytes.toFixed(2)} MB`;
 }
 
-function Icon({
+export function Icon({
   file,
   showError,
   loading,
@@ -274,7 +175,7 @@ function Icon({
   }
 }
 
-const downloadFile = (file: File): void => {
+export const downloadFile = (file: File): void => {
   const a = document.createElement('a');
   const url = URL.createObjectURL(file);
   a.href = url;
@@ -289,7 +190,7 @@ interface FileNameProps {
   href?: string;
 }
 
-const FileName = ({ file, href }: FileNameProps) => {
+export const FileName = ({ file, href }: FileNameProps) => {
   if (href) {
     return <Link href={href}>{file.name}</Link>;
   }

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -124,91 +124,6 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
 );
 FileUploadItem.displayName = 'FileUpload.Item';
 
-export function formatFileSize(file: File): string | null {
-  if (!file.size) {
-    return null;
-  }
-  const megaBytes = file.size / (1024 * 1024);
-
-  return `${megaBytes.toFixed(2)} MB`;
-}
-
-function Icon({
-  file,
-  showError,
-  loading,
-}: {
-  file: File;
-  showError: boolean;
-  loading?: boolean;
-}) {
-  const extension = file.name.substring(file.name.lastIndexOf('.') + 1);
-
-  if (loading) {
-    return <Spinner aria-label="spinner" />;
-  }
-
-  if (showError) {
-    return <FileXMarkIcon aria-hidden />;
-  }
-
-  switch (extension) {
-    case 'jpg':
-    case 'jpeg':
-    case 'png':
-    case 'gif':
-    case 'webp':
-      return <FileImageIcon aria-hidden />;
-    case 'pdf':
-      return <FilePdfIcon aria-hidden />;
-    case 'txt':
-      return <FileTextIcon aria-hidden />;
-    case 'csv':
-      return <FileCsvIcon aria-hidden />;
-    case 'xls':
-    case 'xlsx':
-      return <FileExcelIcon aria-hidden />;
-    case 'doc':
-    case 'docx':
-      return <FileWordIcon aria-hidden />;
-    default:
-      return <FileIcon aria-hidden />;
-  }
-}
-
-const downloadFile = (file: File): void => {
-  const a = document.createElement('a');
-  const url = URL.createObjectURL(file);
-  a.href = url;
-  a.download = file.name;
-  a.click();
-
-  URL.revokeObjectURL(url);
-};
-
-interface FileNameProps {
-  file: File;
-  href?: string;
-}
-
-const FileName = ({ file, href }: FileNameProps) => {
-  if (href) {
-    return <Link href={href}>{file.name}</Link>;
-  }
-
-  return (
-    <Link
-      download={file.name}
-      onClick={(event) => {
-        event.preventDefault();
-        downloadFile(file);
-      }}
-    >
-      {file.name}
-    </Link>
-  );
-};
-
 export interface FileUploadListItem {
   /**
    * Either a native File or file metadata.
@@ -306,3 +221,88 @@ export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
   ),
 );
 FileUploadList.displayName = 'FileUpload.List';
+
+export function formatFileSize(file: File): string | null {
+  if (!file.size) {
+    return null;
+  }
+  const megaBytes = file.size / (1024 * 1024);
+
+  return `${megaBytes.toFixed(2)} MB`;
+}
+
+function Icon({
+  file,
+  showError,
+  loading,
+}: {
+  file: File;
+  showError: boolean;
+  loading?: boolean;
+}) {
+  const extension = file.name.substring(file.name.lastIndexOf('.') + 1);
+
+  if (loading) {
+    return <Spinner aria-label="spinner" />;
+  }
+
+  if (showError) {
+    return <FileXMarkIcon aria-hidden />;
+  }
+
+  switch (extension) {
+    case 'jpg':
+    case 'jpeg':
+    case 'png':
+    case 'gif':
+    case 'webp':
+      return <FileImageIcon aria-hidden />;
+    case 'pdf':
+      return <FilePdfIcon aria-hidden />;
+    case 'txt':
+      return <FileTextIcon aria-hidden />;
+    case 'csv':
+      return <FileCsvIcon aria-hidden />;
+    case 'xls':
+    case 'xlsx':
+      return <FileExcelIcon aria-hidden />;
+    case 'doc':
+    case 'docx':
+      return <FileWordIcon aria-hidden />;
+    default:
+      return <FileIcon aria-hidden />;
+  }
+}
+
+const downloadFile = (file: File): void => {
+  const a = document.createElement('a');
+  const url = URL.createObjectURL(file);
+  a.href = url;
+  a.download = file.name;
+  a.click();
+
+  URL.revokeObjectURL(url);
+};
+
+interface FileNameProps {
+  file: File;
+  href?: string;
+}
+
+const FileName = ({ file, href }: FileNameProps) => {
+  if (href) {
+    return <Link href={href}>{file.name}</Link>;
+  }
+
+  return (
+    <Link
+      download={file.name}
+      onClick={(event) => {
+        event.preventDefault();
+        downloadFile(file);
+      }}
+    >
+      {file.name}
+    </Link>
+  );
+};

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -2,8 +2,7 @@ import { Paragraph, Tooltip } from '@digdir/designsystemet-react';
 import type { Size } from '@digdir/designsystemet-react';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
-import type { MouseEvent } from 'react';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, MouseEvent } from 'react';
 import {
   FileCsvIcon,
   FileExcelIcon,
@@ -18,6 +17,7 @@ import {
 } from '@udir-design/icons';
 import { Button } from '../button';
 import { Card } from '../card';
+import { Divider } from '../divider';
 import { Link } from '../link';
 import { Spinner } from '../spinner';
 
@@ -39,7 +39,7 @@ export interface FileUploadItemProps extends Omit<
    */
   error?: string;
   /**
-   * Props for the delete button.
+   * Callback when the remove button is clicked.
    */
   onRemove: (file: File, event: MouseEvent<HTMLButtonElement>) => void;
   /**
@@ -208,3 +208,101 @@ const FileName = ({ file, href }: FileNameProps) => {
     </Link>
   );
 };
+
+export interface FileUploadListItem {
+  /**
+   * Either a native File or file metadata.
+   */
+  file: File;
+  /**
+   * href to file location.
+   */
+  href?: string;
+  /**
+   * Error message relating to the item.
+   */
+  error?: string;
+  /**
+   * Toggle loading state.
+   *
+   * @default false
+   */
+  loading?: boolean;
+  /**
+   * @default false
+   */
+  readonly?: boolean;
+}
+
+export interface FileUploadListProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'data-color'
+> {
+  'data-size'?: Size;
+  /**
+   * List of file items to display.
+   */
+  items: FileUploadListItem[];
+  /**
+   * Callback when the remove button is clicked.
+   */
+  onRemove: (file: File, event: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
+  ({ items, onRemove, className, 'data-size': size, ...rest }, ref) => (
+    <Card
+      ref={ref}
+      className={cl('uds-file-upload__list', className)}
+      data-size={size}
+      {...rest}
+    >
+      <ul>
+        {items.map((item, index) => (
+          <li
+            key={item.file.name}
+            className="uds-file-upload__list-item"
+            aria-busy={item.loading || undefined}
+          >
+            {index > 0 && <Divider />}
+            <div className="uds-file-upload__list-row">
+              <div className="uds-file-upload__list-icon">
+                <Icon
+                  file={item.file}
+                  showError={Boolean(item.error)}
+                  loading={item.loading}
+                />
+              </div>
+              <div className="uds-file-upload__list-content">
+                <FileName file={item.file} href={item.href} />
+                {!item.loading && (
+                  <span className="uds-file-upload__list-size">
+                    {formatFileSize(item.file)}
+                  </span>
+                )}
+                {item.error && (
+                  <span className="uds-file-upload__list-error">
+                    <XMarkOctagonFillIcon aria-hidden />
+                    {item.error}
+                  </span>
+                )}
+              </div>
+              {!item.loading && !item.readonly && (
+                <Tooltip content="">
+                  <Button
+                    icon
+                    onClick={(e) => onRemove(item.file, e)}
+                    variant="tertiary"
+                  >
+                    <TrashIcon aria-hidden />
+                  </Button>
+                </Tooltip>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  ),
+);
+FileUploadList.displayName = 'FileUpload.List';

--- a/@udir-design/react/src/components/fileUpload/FileUploadList.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadList.tsx
@@ -1,0 +1,117 @@
+import { Tooltip } from '@digdir/designsystemet-react';
+import type { Size } from '@digdir/designsystemet-react';
+import cl from 'clsx/lite';
+import { forwardRef } from 'react';
+import type { HTMLAttributes, MouseEvent } from 'react';
+import { TrashIcon, XMarkOctagonFillIcon } from '@udir-design/icons';
+import { Button } from '../button';
+import { Card } from '../card';
+import { Divider } from '../divider';
+import { FileName, Icon, formatFileSize } from './FileUploadItem';
+
+export interface FileUploadListItem {
+  /**
+   * Either a native File or file metadata.
+   */
+  file: File;
+  /**
+   * Error message relating to the item.
+   */
+  error?: string;
+  /**
+   * Toggle loading state.
+   *
+   * @default false
+   */
+  loading?: boolean;
+  /**
+   * @default false
+   */
+  readonly?: boolean;
+  /**
+   * href to file location.
+   */
+  href?: string;
+}
+
+export interface FileUploadListProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'data-color'
+> {
+  'data-size'?: Size;
+  /**
+   * List of file items to display.
+   */
+  items: FileUploadListItem[];
+  /**
+   * Callback when the remove button is clicked.
+   */
+  onRemove: (file: File, event: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export const FileUploadList = forwardRef<HTMLDivElement, FileUploadListProps>(
+  (
+    {
+      items,
+      onRemove,
+      className,
+      'data-size': size,
+      ...rest
+    }: FileUploadListProps,
+    ref,
+  ) => (
+    <Card
+      ref={ref}
+      className={cl('uds-file-upload__list', className)}
+      data-size={size}
+      {...rest}
+    >
+      <ul>
+        {items.map((item, index) => (
+          <li
+            key={item.file.name}
+            className="uds-file-upload__list-item"
+            aria-busy={item.loading || undefined}
+          >
+            {index > 0 && <Divider />}
+            <div className="uds-file-upload__list-row">
+              <div className="uds-file-upload__list-icon">
+                <Icon
+                  file={item.file}
+                  showError={Boolean(item.error)}
+                  loading={item.loading}
+                />
+              </div>
+              <div className="uds-file-upload__list-content">
+                <FileName file={item.file} href={item.href} />
+                {!item.loading && (
+                  <span className="uds-file-upload__list-size">
+                    {formatFileSize(item.file)}
+                  </span>
+                )}
+                {item.error && (
+                  <span className="uds-file-upload__list-error">
+                    <XMarkOctagonFillIcon aria-hidden />
+                    {item.error}
+                  </span>
+                )}
+              </div>
+              {!item.loading && !item.readonly && (
+                <Tooltip content="">
+                  <Button
+                    icon
+                    onClick={(e) => onRemove(item.file, e)}
+                    variant="tertiary"
+                  >
+                    <TrashIcon aria-hidden />
+                  </Button>
+                </Tooltip>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  ),
+);
+FileUploadList.displayName = 'FileUpload.List';

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -752,6 +752,366 @@ exports[`Example Trigger 1`] = `
 </div>
 `;
 
+exports[`List 1`] = `
+<div>
+  <h3 data-size="2xs">
+    Vedlegg (5):
+  </h3>
+  <div
+    data-variant="default"
+    data-size="md"
+  >
+    <ul>
+      <li>
+        <div>
+          <div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+              >
+              </path>
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </div>
+          <div>
+            <a download="kandidat-12.pdf">
+              kandidat-12.pdf
+            </a>
+            <span>
+              0.29 MB
+            </span>
+          </div>
+          <button
+            data-icon="true"
+            data-variant="tertiary"
+            type="button"
+            data-tooltip="Fjern filen"
+            data-placement="top"
+            data-autoplacement="true"
+            aria-label="Fjern filen"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <hr aria-hidden="true">
+        <div>
+          <div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+              >
+              </path>
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </div>
+          <div>
+            <a download="kandidat-13.pdf">
+              kandidat-13.pdf
+            </a>
+            <span>
+              0.29 MB
+            </span>
+          </div>
+          <button
+            data-icon="true"
+            data-variant="tertiary"
+            type="button"
+            data-tooltip="Fjern filen"
+            data-placement="top"
+            data-autoplacement="true"
+            aria-label="Fjern filen"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <hr aria-hidden="true">
+        <div>
+          <div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+              >
+              </path>
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </div>
+          <div>
+            <a download="kandidat-14.pdf">
+              kandidat-14.pdf
+            </a>
+            <span>
+              0.29 MB
+            </span>
+          </div>
+          <button
+            data-icon="true"
+            data-variant="tertiary"
+            type="button"
+            data-tooltip="Fjern filen"
+            data-placement="top"
+            data-autoplacement="true"
+            aria-label="Fjern filen"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <hr aria-hidden="true">
+        <div>
+          <div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+              >
+              </path>
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </div>
+          <div>
+            <a download="kandidat-15.pdf">
+              kandidat-15.pdf
+            </a>
+            <span>
+              0.29 MB
+            </span>
+          </div>
+          <button
+            data-icon="true"
+            data-variant="tertiary"
+            type="button"
+            data-tooltip="Fjern filen"
+            data-placement="top"
+            data-autoplacement="true"
+            aria-label="Fjern filen"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <hr aria-hidden="true">
+        <div>
+          <div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v11.5c0 .69-.56 1.25-1.25 1.25h-11c-.69 0-1.25-.56-1.25-1.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h10.5V8.75zm.25-2.94 1.44 1.44h-1.44zm-.72 6.16a.75.75 0 0 1 0 1.06l-.97.97.97.97a.75.75 0 1 1-1.06 1.06l-.97-.97-.97.97a.75.75 0 1 1-1.06-1.06l.97-.97-.97-.97a.75.75 0 1 1 1.06-1.06l.97.97.97-.97a.75.75 0 0 1 1.06 0"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </div>
+          <div>
+            <a download="kandidat-16.tsx">
+              kandidat-16.tsx
+            </a>
+            <span>
+              0.82 MB
+            </span>
+            <span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="1em"
+                height="1em"
+                fill="none"
+                viewbox="0 0 24 24"
+                focusable="false"
+                role="img"
+                aria-hidden="true"
+              >
+                <path
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                  d="M7.742 2.47a.75.75 0 0 1 .53-.22h7.456a.75.75 0 0 1 .53.22l5.272 5.272c.141.14.22.331.22.53v7.456a.75.75 0 0 1-.22.53l-5.272 5.272a.75.75 0 0 1-.53.22H8.272a.75.75 0 0 1-.53-.22L2.47 16.258a.75.75 0 0 1-.22-.53V8.272a.75.75 0 0 1 .22-.53zm1.288 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+              Filformatet støttes ikke
+            </span>
+          </div>
+          <button
+            data-icon="true"
+            data-variant="tertiary"
+            type="button"
+            data-tooltip="Fjern filen"
+            data-placement="top"
+            data-autoplacement="true"
+            aria-label="Fjern filen"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="1em"
+              height="1em"
+              fill="none"
+              viewbox="0 0 24 24"
+              focusable="false"
+              role="img"
+              aria-hidden="true"
+            >
+              <path
+                fill="currentColor"
+                fill-rule="evenodd"
+                d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+                clip-rule="evenodd"
+              >
+              </path>
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
 exports[`Preview 1`] = `
 <div style="<removed>">
   <div data-size="md">

--- a/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadList.tsx
+++ b/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadList.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { FileUploadListProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for FileUpload.List
+ */
+export const FileUploadList: FunctionComponent<FileUploadListProps> = () =>
+  null;

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -209,6 +209,67 @@
   }
 }
 
+/* FileUpload.List */
+.uds-file-upload__list {
+  padding: 0;
+  overflow: hidden;
+  cursor: default;
+
+  [data-tooltip] {
+    --ds-tooltip: var(--udsc-fileUpload-removeFile-text);
+  }
+
+  > ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+.uds-file-upload__list-item {
+  > .ds-divider {
+    margin-block: 0;
+  }
+}
+
+.uds-file-upload__list-row {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-4);
+  padding: var(--ds-size-3) var(--ds-size-6);
+}
+
+.uds-file-upload__list-icon > svg {
+  width: auto;
+  height: var(--ds-size-8);
+  display: block;
+}
+
+.uds-file-upload__list-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-3);
+  flex-wrap: wrap;
+  word-break: break-all;
+}
+
+.uds-file-upload__list-size {
+  font-size: var(--ds-font-size-sm);
+  color: var(--ds-color-neutral-text-subtle);
+  white-space: nowrap;
+}
+
+.uds-file-upload__list-error {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-1);
+  font-size: var(--ds-font-size-sm);
+  color: var(--ds-color-danger-text-subtle);
+  width: 100%;
+}
+
 /* FileUpload.Item */
 .uds-file-upload__item {
   [data-tooltip] {

--- a/@udir-design/react/src/components/fileUpload/index.ts
+++ b/@udir-design/react/src/components/fileUpload/index.ts
@@ -1,15 +1,13 @@
 import { FileUpload } from './FileUpload';
 import { FileUploadDropzone } from './FileUploadDropzone';
-import { FileUploadItem, FileUploadList } from './FileUploadItem';
+import { FileUploadItem } from './FileUploadItem';
+import { FileUploadList } from './FileUploadList';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type { FileUploadProps } from './FileUploadTrigger';
 export type { FileUploadDropzoneProps } from './FileUploadDropzone';
-export type {
-  FileUploadItemProps,
-  FileUploadListItem,
-  FileUploadListProps,
-} from './FileUploadItem';
+export type { FileUploadItemProps } from './FileUploadItem';
+export type { FileUploadListItem, FileUploadListProps } from './FileUploadList';
 export {
   FileUpload,
   FileUploadDropzone,

--- a/@udir-design/react/src/components/fileUpload/index.ts
+++ b/@udir-design/react/src/components/fileUpload/index.ts
@@ -1,9 +1,19 @@
 import { FileUpload } from './FileUpload';
 import { FileUploadDropzone } from './FileUploadDropzone';
-import { FileUploadItem } from './FileUploadItem';
+import { FileUploadItem, FileUploadList } from './FileUploadItem';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type { FileUploadProps } from './FileUploadTrigger';
 export type { FileUploadDropzoneProps } from './FileUploadDropzone';
-export type { FileUploadItemProps } from './FileUploadItem';
-export { FileUpload, FileUploadDropzone, FileUploadItem, FileUploadTrigger };
+export type {
+  FileUploadItemProps,
+  FileUploadListItem,
+  FileUploadListProps,
+} from './FileUploadItem';
+export {
+  FileUpload,
+  FileUploadDropzone,
+  FileUploadItem,
+  FileUploadList,
+  FileUploadTrigger,
+};


### PR DESCRIPTION
## Hva er gjort?

Lagt til en liste visning av fileupload items.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/bc3573e7-6bfd-49d4-b80d-b02c9ae60879" />

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er eksportert fra riktig fil
- [x] Komponenten fungerer godt med `dir="rtl"`
- [ ] Komponenten er testet i test-app
- [ ] Komponenten er testet med skjermleser og/eller annet UU-verktøy
- [ ] Komponenten har tester i Storybook
- [ ] Komponenten er i bruk i en demoside
