### PR TITLE
build: remove ~2500 lines of log output about "skipping docgen"

### DIFF
--- a/@udir-design/react/.storybook/main.ts
+++ b/@udir-design/react/.storybook/main.ts
@@ -101,6 +101,7 @@ export default defineMain({
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
+      include: ['src/**/*.{ts,tsx}'],
       setDisplayName: false,
       propFilter: (prop) => {
         // Remove popovertarget prop which @digdir/designsystemet-react adds to all elements


### PR DESCRIPTION
Be explicit about what directory to process with react-docgen-typescript, which removes all log messages similar to this:

```
▲  Vite [plugin vite:react-docgen-typescript]
│  .storybook/docs/components/Origin.tsx: Skipping docgen for
│  "<repo>/@udir-design/react/.storybook/docs/components/Origin.tsx"
│  because it is not included in the active TypeScript project.
```