### PR TITLE
docs: add cluster card example

### DIFF
--- a/@udir-design/react/src/components/card/Card.mdx
+++ b/@udir-design/react/src/components/card/Card.mdx
@@ -80,6 +80,12 @@ Eksempel på hvordan andre komponenter kan brukes til å komponere et `Card`.
 
 <Canvas of={CardStories.Composed} />
 
+### Lenkeliste
+
+Eksempelet viser hvordan `Card` kan brukes til å gruppere relaterte lenker. Dette passer godt når flere navigasjonsvalg skal presenteres samlet, for eksempel snarveier til temasider eller undersider.
+
+<Canvas of={CardStories.Cluster} />
+
 ## Retningslinjer
 
 `Card` er en fleksibel komponent som brukes til å strukturere og presentere innhold på en tydelig og visuelt avgrenset måte. Kortet kan inneholde ulike typer innhold, som tekst, media og lenker, og brukes ofte i oversikter, navigasjon eller for å fremheve enkeltemner.

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -1,7 +1,7 @@
 import type { Color } from '@digdir/designsystemet-react/colors';
 import type { ComponentType } from 'react';
 import { Fragment } from 'react/jsx-runtime';
-import { PlusIcon, TrashFillIcon } from '@udir-design/icons';
+import { ArrowRightIcon, PlusIcon, TrashFillIcon } from '@udir-design/icons';
 import preview from '.storybook/preview';
 import { Button } from 'src/components/button';
 import { Field } from 'src/components/field';
@@ -343,6 +343,66 @@ export const Horizontal = meta.story({
           </Paragraph>
         </Card.Block>
       </Card>
+    );
+  },
+});
+
+export const Cluster = meta.story({
+  render: (args) => {
+    const links = [
+      { text: 'Lesing', url: '#' },
+      { text: 'Fravær i skolen', url: '#' },
+      { text: 'Barnehagemiljø', url: '#' },
+      { text: 'God digital praksis', url: '#' },
+      { text: 'Skolemiljø', url: '#' },
+      { text: 'Kunstig intelligens i skolen', url: '#' },
+    ];
+
+    const rows = Array.from({ length: Math.ceil(links.length / 2) }, (_, i) =>
+      links.slice(i * 2, (i + 1) * 2),
+    );
+
+    return (
+      <>
+        <style>
+          {`
+.card-cluster {
+  width: 750px;
+}
+.card-cluster__row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: var(--ds-size-4);
+}
+.card-cluster__item {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  padding: var(--ds-size-4) 0 var(--ds-size-8) 0;
+  min-width: 0;
+  border-block-end: 1px solid var(--ds-color-border-subtle);
+}
+.card-cluster__row:last-child .card-cluster__item {
+  border-block-end: none;
+  padding-block-end: var(--ds-size-4);
+}
+.card-cluster__item > svg {
+  flex-shrink: 0;
+}`}
+        </style>
+        <Card {...args} className="card-cluster">
+          {rows.map((row, rowIndex) => (
+            <div key={rowIndex} className="card-cluster__row">
+              {row.map((link) => (
+                <div key={link.text} className="card-cluster__item">
+                  <ArrowRightIcon aria-hidden data-size="lg" />
+                  <LinkComponent href={link.url}>{link.text}</LinkComponent>
+                </div>
+              ))}
+            </div>
+          ))}
+        </Card>
+      </>
     );
   },
 });

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -348,65 +348,74 @@ export const Horizontal = meta.story({
 });
 
 export const Cluster = meta.story({
+  parameters: {
+    customStyles: {
+      display: 'block',
+      width: '100%',
+      maxWidth: 800,
+    },
+  },
   render: (args) => {
     const links = [
       { text: 'Lesing', url: '#' },
-      { text: 'Fravær i skolen', url: '#' },
       { text: 'Barnehagemiljø', url: '#' },
-      { text: 'God digital praksis', url: '#' },
       { text: 'Skolemiljø', url: '#' },
+      { text: 'Fravær i skolen', url: '#' },
+      { text: 'God digital praksis', url: '#' },
       { text: 'Kunstig intelligens i skolen', url: '#' },
     ];
-
-    const rows = Array.from({ length: Math.ceil(links.length / 2) }, (_, i) =>
-      links.slice(i * 2, (i + 1) * 2),
-    );
 
     return (
       <>
         <style>
           {`
-.card-cluster {
-  width: 750px;
+.card-cluster-wrapper {
+  container-type: inline-size;
 }
-.card-cluster__row {
+.card-cluster {
+  --dsc-card-content-margin-block: 0;
+  --dsc-card-padding: var(--ds-size-2) var(--ds-size-6);
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 250px), 1fr));
   column-gap: var(--ds-size-4);
 }
 .card-cluster__item {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-size-2);
-  padding: var(--ds-size-2) 0 var(--ds-size-4) 0;
-  min-width: 0;
+  padding-block: var(--ds-size-4);
   border-block-end: 1px solid var(--ds-color-border-subtle);
   text-decoration: none;
 }
-.card-cluster__row:last-child .card-cluster__item {
+.card-cluster__item:last-child {
   border-block-end: none;
-  padding-block-end: var(--ds-size-2);
+}
+@container (min-width: 564px) {
+  .card-cluster__item:nth-last-child(2) {
+    border-block-end: none;
+  }
+}
+.card-cluster__item:hover {
+  text-decoration: underline;
 }
 .card-cluster__item > svg {
   flex-shrink: 0;
+  width: var(--ds-size-6);
+  height: var(--ds-size-6);
+  align-self: flex-start;
 }`}
         </style>
-        <Card {...args} className="card-cluster">
-          {rows.map((row, rowIndex) => (
-            <div key={rowIndex} className="card-cluster__row">
-              {row.map((link) => (
-                <LinkComponent
-                  href={link.url}
-                  key={link.text}
-                  className="card-cluster__item"
-                >
-                  <ArrowRightIcon aria-hidden data-size="lg" />
-                  <span>{link.text}</span>
-                </LinkComponent>
-              ))}
-            </div>
-          ))}
-        </Card>
+        <div className="card-cluster-wrapper">
+          <Card {...args} className="card-cluster">
+            {links.map((link) => (
+              <LinkComponent
+                href={link.url}
+                key={link.text}
+                className="card-cluster__item"
+              >
+                <ArrowRightIcon aria-hidden data-size="lg" />
+                <span>{link.text}</span>
+              </LinkComponent>
+            ))}
+          </Card>
+        </div>
       </>
     );
   },

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -410,7 +410,7 @@ export const Cluster = meta.story({
                 key={link.text}
                 className="card-cluster__item"
               >
-                <ArrowRightIcon aria-hidden data-size="lg" />
+                <ArrowRightIcon aria-hidden />
                 <span>{link.text}</span>
               </LinkComponent>
             ))}

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -378,14 +378,14 @@ export const Cluster = meta.story({
   display: flex;
   align-items: center;
   gap: var(--ds-size-2);
-  padding: var(--ds-size-4) 0 var(--ds-size-8) 0;
+  padding: var(--ds-size-2) 0 var(--ds-size-4) 0;
   min-width: 0;
   border-block-end: 1px solid var(--ds-color-border-subtle);
   text-decoration: none;
 }
 .card-cluster__row:last-child .card-cluster__item {
   border-block-end: none;
-  padding-block-end: var(--ds-size-4);
+  padding-block-end: var(--ds-size-2);
 }
 .card-cluster__item > svg {
   flex-shrink: 0;

--- a/@udir-design/react/src/components/card/Card.stories.tsx
+++ b/@udir-design/react/src/components/card/Card.stories.tsx
@@ -381,6 +381,7 @@ export const Cluster = meta.story({
   padding: var(--ds-size-4) 0 var(--ds-size-8) 0;
   min-width: 0;
   border-block-end: 1px solid var(--ds-color-border-subtle);
+  text-decoration: none;
 }
 .card-cluster__row:last-child .card-cluster__item {
   border-block-end: none;
@@ -394,10 +395,14 @@ export const Cluster = meta.story({
           {rows.map((row, rowIndex) => (
             <div key={rowIndex} className="card-cluster__row">
               {row.map((link) => (
-                <div key={link.text} className="card-cluster__item">
+                <LinkComponent
+                  href={link.url}
+                  key={link.text}
+                  className="card-cluster__item"
+                >
                   <ArrowRightIcon aria-hidden data-size="lg" />
-                  <LinkComponent href={link.url}>{link.text}</LinkComponent>
-                </div>
+                  <span>{link.text}</span>
+                </LinkComponent>
               ))}
             </div>
           ))}

--- a/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
+++ b/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
@@ -17,6 +17,7 @@ exports[`Cluster 1`] = `
   padding: var(--ds-size-4) 0 var(--ds-size-8) 0;
   min-width: 0;
   border-block-end: 1px solid var(--ds-color-border-subtle);
+  text-decoration: none;
 }
 .card-cluster__row:last-child .card-cluster__item {
   border-block-end: none;
@@ -28,7 +29,7 @@ exports[`Cluster 1`] = `
 </style>
 <div data-variant="default">
   <div>
-    <div>
+    <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -46,11 +47,11 @@ exports[`Cluster 1`] = `
         >
         </path>
       </svg>
-      <a href="#">
+      <span>
         Lesing
-      </a>
-    </div>
-    <div>
+      </span>
+    </a>
+    <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -68,13 +69,13 @@ exports[`Cluster 1`] = `
         >
         </path>
       </svg>
-      <a href="#">
+      <span>
         Fravær i skolen
-      </a>
-    </div>
+      </span>
+    </a>
   </div>
   <div>
-    <div>
+    <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -92,11 +93,11 @@ exports[`Cluster 1`] = `
         >
         </path>
       </svg>
-      <a href="#">
+      <span>
         Barnehagemiljø
-      </a>
-    </div>
-    <div>
+      </span>
+    </a>
+    <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -114,13 +115,13 @@ exports[`Cluster 1`] = `
         >
         </path>
       </svg>
-      <a href="#">
+      <span>
         God digital praksis
-      </a>
-    </div>
+      </span>
+    </a>
   </div>
   <div>
-    <div>
+    <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -138,11 +139,11 @@ exports[`Cluster 1`] = `
         >
         </path>
       </svg>
-      <a href="#">
+      <span>
         Skolemiljø
-      </a>
-    </div>
-    <div>
+      </span>
+    </a>
+    <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="1em"
@@ -160,10 +161,10 @@ exports[`Cluster 1`] = `
         >
         </path>
       </svg>
-      <a href="#">
+      <span>
         Kunstig intelligens i skolen
-      </a>
-    </div>
+      </span>
+    </a>
   </div>
 </div>
 `;

--- a/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
+++ b/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
@@ -2,33 +2,41 @@
 
 exports[`Cluster 1`] = `
 <style>
-  .card-cluster {
-  width: 750px;
+  .card-cluster-wrapper {
+  container-type: inline-size;
 }
-.card-cluster__row {
+.card-cluster {
+  --dsc-card-content-margin-block: 0;
+  --dsc-card-padding: var(--ds-size-2) var(--ds-size-6);
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 250px), 1fr));
   column-gap: var(--ds-size-4);
 }
 .card-cluster__item {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-size-2);
-  padding: var(--ds-size-2) 0 var(--ds-size-4) 0;
-  min-width: 0;
+  padding-block: var(--ds-size-4);
   border-block-end: 1px solid var(--ds-color-border-subtle);
   text-decoration: none;
 }
-.card-cluster__row:last-child .card-cluster__item {
+.card-cluster__item:last-child {
   border-block-end: none;
-  padding-block-end: var(--ds-size-2);
+}
+@container (min-width: 564px) {
+  .card-cluster__item:nth-last-child(2) {
+    border-block-end: none;
+  }
+}
+.card-cluster__item:hover {
+  text-decoration: underline;
 }
 .card-cluster__item > svg {
   flex-shrink: 0;
+  width: var(--ds-size-6);
+  height: var(--ds-size-6);
+  align-self: flex-start;
 }
 </style>
-<div data-variant="default">
-  <div>
+<div>
+  <div data-variant="default">
     <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -70,30 +78,6 @@ exports[`Cluster 1`] = `
         </path>
       </svg>
       <span>
-        Fravær i skolen
-      </span>
-    </a>
-  </div>
-  <div>
-    <a href="#">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-        data-size="lg"
-      >
-        <path
-          fill="currentColor"
-          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
-        >
-        </path>
-      </svg>
-      <span>
         Barnehagemiljø
       </span>
     </a>
@@ -116,11 +100,9 @@ exports[`Cluster 1`] = `
         </path>
       </svg>
       <span>
-        God digital praksis
+        Skolemiljø
       </span>
     </a>
-  </div>
-  <div>
     <a href="#">
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -140,7 +122,29 @@ exports[`Cluster 1`] = `
         </path>
       </svg>
       <span>
-        Skolemiljø
+        Fravær i skolen
+      </span>
+    </a>
+    <a href="#">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <span>
+        God digital praksis
       </span>
     </a>
     <a href="#">

--- a/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
+++ b/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
@@ -47,7 +47,6 @@ exports[`Cluster 1`] = `
         focusable="false"
         role="img"
         aria-hidden="true"
-        data-size="lg"
       >
         <path
           fill="currentColor"
@@ -69,7 +68,6 @@ exports[`Cluster 1`] = `
         focusable="false"
         role="img"
         aria-hidden="true"
-        data-size="lg"
       >
         <path
           fill="currentColor"
@@ -91,7 +89,6 @@ exports[`Cluster 1`] = `
         focusable="false"
         role="img"
         aria-hidden="true"
-        data-size="lg"
       >
         <path
           fill="currentColor"
@@ -113,7 +110,6 @@ exports[`Cluster 1`] = `
         focusable="false"
         role="img"
         aria-hidden="true"
-        data-size="lg"
       >
         <path
           fill="currentColor"
@@ -135,7 +131,6 @@ exports[`Cluster 1`] = `
         focusable="false"
         role="img"
         aria-hidden="true"
-        data-size="lg"
       >
         <path
           fill="currentColor"
@@ -157,7 +152,6 @@ exports[`Cluster 1`] = `
         focusable="false"
         role="img"
         aria-hidden="true"
-        data-size="lg"
       >
         <path
           fill="currentColor"

--- a/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
+++ b/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
@@ -1,5 +1,173 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Cluster 1`] = `
+<style>
+  .card-cluster {
+  width: 750px;
+}
+.card-cluster__row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  column-gap: var(--ds-size-4);
+}
+.card-cluster__item {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  padding: var(--ds-size-4) 0 var(--ds-size-8) 0;
+  min-width: 0;
+  border-block-end: 1px solid var(--ds-color-border-subtle);
+}
+.card-cluster__row:last-child .card-cluster__item {
+  border-block-end: none;
+  padding-block-end: var(--ds-size-4);
+}
+.card-cluster__item > svg {
+  flex-shrink: 0;
+}
+</style>
+<div data-variant="default">
+  <div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <a href="#">
+        Lesing
+      </a>
+    </div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <a href="#">
+        Fravær i skolen
+      </a>
+    </div>
+  </div>
+  <div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <a href="#">
+        Barnehagemiljø
+      </a>
+    </div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <a href="#">
+        God digital praksis
+      </a>
+    </div>
+  </div>
+  <div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <a href="#">
+        Skolemiljø
+      </a>
+    </div>
+    <div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="1em"
+        height="1em"
+        fill="none"
+        viewbox="0 0 24 24"
+        focusable="false"
+        role="img"
+        aria-hidden="true"
+        data-size="lg"
+      >
+        <path
+          fill="currentColor"
+          d="M14.088 6.873a.75.75 0 0 1 .942.097l4.5 4.5a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06-1.06l3.22-3.22H5a.75.75 0 0 1-.75-.74V12a.75.75 0 0 1 .75-.75h12.19l-3.22-3.22a.75.75 0 0 1 .118-1.157"
+        >
+        </path>
+      </svg>
+      <a href="#">
+        Kunstig intelligens i skolen
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Composed 1`] = `
 <div data-variant="default">
   <div>

--- a/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
+++ b/@udir-design/react/src/components/card/__snapshots__/Card.stories.tsx.snap
@@ -14,14 +14,14 @@ exports[`Cluster 1`] = `
   display: flex;
   align-items: center;
   gap: var(--ds-size-2);
-  padding: var(--ds-size-4) 0 var(--ds-size-8) 0;
+  padding: var(--ds-size-2) 0 var(--ds-size-4) 0;
   min-width: 0;
   border-block-end: 1px solid var(--ds-color-border-subtle);
   text-decoration: none;
 }
 .card-cluster__row:last-child .card-cluster__item {
   border-block-end: none;
-  padding-block-end: var(--ds-size-4);
+  padding-block-end: var(--ds-size-2);
 }
 .card-cluster__item > svg {
   flex-shrink: 0;


### PR DESCRIPTION
## Hva er gjort?

Lagt til et cluster card-eksempel som viser hvordan flere lenker kan vises i et kort.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/23980246-36ec-498e-b55a-f41a6ab13196" />

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten fungerer godt med `dir="rtl"`