### PR TITLE
docs: consistently use en-dash (tankestrek) in "passer ikke til" list

### DIFF
--- a/@udir-design/react/src/components/alert/Alert.mdx
+++ b/@udir-design/react/src/components/alert/Alert.mdx
@@ -16,10 +16,10 @@ Vi bruker `Alert` til å gi brukeren viktige varsler som fanger oppmerksomheten.
 
 **Passer ikke til å**
 
-- validere individuelle skjemaelementer, bruk heller komponentens egen feilmelding
-- oppsummere flere feilmeldinger i et skjema, bruk heller [`ErrorSummary`](/docs/components-errorsummary--docs)
-- vise feil som hindrer all videre bruk av tjenesten, bruk heller en feilside
-- lage visuell struktur på siden, bruk heller [`Card`](/docs/components-card--docs)
+- validere individuelle skjemaelementer – bruk heller komponentens egen feilmelding
+- oppsummere flere feilmeldinger i et skjema – bruk heller [`ErrorSummary`](/docs/components-errorsummary--docs)
+- vise feil som hindrer all videre bruk av tjenesten – bruk heller en feilside
+- lage visuell struktur på siden – bruk heller [`Card`](/docs/components-card--docs)
 
 ## Slik bruker du Alert
 

--- a/@udir-design/react/src/components/avatar/Avatar.mdx
+++ b/@udir-design/react/src/components/avatar/Avatar.mdx
@@ -13,7 +13,7 @@ import * as AvatarStories from './Avatar.stories';
 
 **Passer ikke til å**
 
-- representere handlinger, objekter eller steder, bruk heller ikoner eller andre visuelle symboler
+- representere handlinger, objekter eller steder – bruk heller ikoner eller andre visuelle symboler
 - brukes som visuell dekor
 
 ## Slik bruker du Avatar

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -18,7 +18,7 @@ Knapper lar brukerne utføre en handling. Vi har variantene `primary`, `secondar
 
 **Passer ikke til å**
 
-- navigere til andre sider eller ut av tjenesten, bruk heller [`Link`](/docs/components-link--docs)
+- navigere til andre sider eller ut av tjenesten – bruk heller [`Link`](/docs/components-link--docs)
 
 ## Slik bruker du Button
 

--- a/@udir-design/react/src/components/card/Card.mdx
+++ b/@udir-design/react/src/components/card/Card.mdx
@@ -16,7 +16,7 @@ Vi bruker `Card` til å fremheve informasjon eller oppgaver som hører sammen. `
 **Passer ikke til å**
 
 - vise lange tekstblokker eller detaljerte forklaringer
-- vise viktige meldinger som bør presenteres som varsler (bruk heller [`Alert`](/docs/components-alert--docs))
+- vise viktige meldinger som bør presenteres som varsler – bruk heller [`Alert`](/docs/components-alert--docs)
 
 ## Slik bruker du Card
 

--- a/@udir-design/react/src/components/checkbox/Checkbox.mdx
+++ b/@udir-design/react/src/components/checkbox/Checkbox.mdx
@@ -24,8 +24,8 @@ Vi bruker `Checkbox` (avmerkingsboks) når brukeren skal kunne velge ett eller f
 
 **Passer ikke til å**
 
-- velge gjensidig utelukkende alternativer, bruk heller [`Radio`](/docs/components-radio--docs), [`Select`](/docs/components-select--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
-- velge mellom flere enn 7 svaralternativer, bruk heller [`Suggestion`](/docs/components-suggestion--docs) eller [`Select`](/docs/components-select--docs)
+- velge gjensidig utelukkende alternativer – bruk heller [`Radio`](/docs/components-radio--docs), [`Select`](/docs/components-select--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
+- velge mellom flere enn 7 svaralternativer – bruk heller [`Suggestion`](/docs/components-suggestion--docs) eller [`Select`](/docs/components-select--docs)
 
 ## Slik bruker du Checkbox
 

--- a/@udir-design/react/src/components/chip/Chip.mdx
+++ b/@udir-design/react/src/components/chip/Chip.mdx
@@ -16,7 +16,7 @@ import * as ChipStories from './Chip.stories';
 **Passar ikkje til å**
 
 - indikere varsel for tal eller status (bruk heller [`Badge`](/docs/components-badge--docs))
-- merke innhald med kategori/emne som ikkje er interaktivt. Bruk heller [`Tag`](/docs/components-tag--docs)-komponenten dersom kategori/emne ikkje er klikkbart
+- merke innhald med kategori/emne som ikkje er interaktivt – bruk heller [`Tag`](/docs/components-tag--docs)-komponenten dersom kategori/emne ikkje er klikkbart
 - brukast i menyar
 
 ## Slik brukar du Chip

--- a/@udir-design/react/src/components/chip/Chip.mdx
+++ b/@udir-design/react/src/components/chip/Chip.mdx
@@ -15,7 +15,7 @@ import * as ChipStories from './Chip.stories';
 
 **Passar ikkje til å**
 
-- indikere varsel for tal eller status (bruk heller [`Badge`](/docs/components-badge--docs))
+- indikere varsel for tal eller status – bruk heller [`Badge`](/docs/components-badge--docs)
 - merke innhald med kategori/emne som ikkje er interaktivt – bruk heller [`Tag`](/docs/components-tag--docs)-komponenten dersom kategori/emne ikkje er klikkbart
 - brukast i menyar
 

--- a/@udir-design/react/src/components/chip/Chip.mdx
+++ b/@udir-design/react/src/components/chip/Chip.mdx
@@ -78,7 +78,7 @@ Du kan bruke alle identitetsfargane på `Chip`.
 
 ## Retningslinjer
 
-Unngå å plassere `Chip` vertikalt. Skal du vise alternativ under kvarandre, bruk heller [`Checkbox`](/docs/components-checkbox--docs) eller [`Radio`](/docs/components-radio--docs). En gruppe med flere `Chip` kan brytast over fleire linjer.
+Unngå å plassere `Chip` vertikalt. Skal du vise alternativ under kvarandre – bruk heller [`Checkbox`](/docs/components-checkbox--docs) eller [`Radio`](/docs/components-radio--docs). En gruppe med flere `Chip` kan brytast over fleire linjer.
 
 <ChipEx1 />
 

--- a/@udir-design/react/src/components/demoBanner/DemoBanner.mdx
+++ b/@udir-design/react/src/components/demoBanner/DemoBanner.mdx
@@ -14,7 +14,7 @@ import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/Cs
 
 **Passer ikke til å**
 
-- Markere hvilket utviklingsmiljø brukeren er i - bruk heller [`Tag` i `Header`](/docs/components-header--docs#utviklingsmilj%C3%B8)
+- Markere hvilket utviklingsmiljø brukeren er i – bruk heller [`Tag` i `Header`](/docs/components-header--docs#utviklingsmilj%C3%B8)
 
 ## Slik bruker du DemoBanner
 

--- a/@udir-design/react/src/components/details/Details.mdx
+++ b/@udir-design/react/src/components/details/Details.mdx
@@ -25,7 +25,7 @@ Med `Details` kan du presentere mye innhold på liten plass i én eller flere ra
 **Passer ikke til å**
 
 - vise innhold som alle burde se
-- gi mer informasjon om et spørsmål i et skjema - bruk heller [`ReadMore`](/docs/components-readmore--docs)
+- gi mer informasjon om et spørsmål i et skjema – bruk heller [`ReadMore`](/docs/components-readmore--docs)
 - skjule innhold fra søkeresultater eller oversikter/tabeller
 
 ## Slik bruker du Details

--- a/@udir-design/react/src/components/dialog/Dialog.mdx
+++ b/@udir-design/react/src/components/dialog/Dialog.mdx
@@ -24,7 +24,7 @@ Bruk av modal `Dialog` bør generelt begrenses, men kan være nyttig når bruker
 **Passer ikke til å**
 
 - vise omfattende eller komplekst innhold som krever langvarig interaksjon
-- gi informasjon uten å avbryte brukerens arbeidsflyt - bruk heller [`Alert`](/docs/components-alert--docs), [`Popover`](/docs/components-popover--docs) eller ikke-modal `Dialog`
+- gi informasjon uten å avbryte brukerens arbeidsflyt – bruk heller [`Alert`](/docs/components-alert--docs), [`Popover`](/docs/components-popover--docs) eller ikke-modal `Dialog`
 
 ### 2. Ikke-modal Dialog
 
@@ -38,8 +38,8 @@ På mobil kan ikke-modale dialoger være problematiske, fordi de kan dekke vikti
 
 **Passer ikke til å**
 
-- gi kritiske valg som brukeren må ta stilling til før de kan fortsette - bruk heller modal `Dialog`
-- gi bekreftelser eller varsler som krever brukerens fulle oppmerksomhet - bruk heller modal `Dialog`
+- gi kritiske valg som brukeren må ta stilling til før de kan fortsette – bruk heller modal `Dialog`
+- gi bekreftelser eller varsler som krever brukerens fulle oppmerksomhet – bruk heller modal `Dialog`
 
 ## Slik bruker du Dialog
 

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -15,8 +15,8 @@ Dropdown er en generisk nedtrekksliste. Den legger grunnmuren for å bygge menye
 
 **Passer ikke til å**
 
-- beskrive handlinger eller elementer - bruk heller [`Popover`](/docs/components-popover--docs) eller [`Tooltip`](/docs/components-tooltip--docs)
-- tilby handlinger som er primære eller ofte brukt - bruk heller [`Button`](/docs/components-button--docs)
+- beskrive handlinger eller elementer – bruk heller [`Popover`](/docs/components-popover--docs) eller [`Tooltip`](/docs/components-tooltip--docs)
+- tilby handlinger som er primære eller ofte brukt – bruk heller [`Button`](/docs/components-button--docs)
 
 ## Slik bruker du Dropdown
 

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.mdx
@@ -17,7 +17,7 @@ import * as ErrorSummaryStories from './ErrorSummary.stories';
 
 - vise systemvarsler, bruk [`Alert`](/docs/components-alert--docs)
 - vise tilbakemeldinger som ikke hindrer innsending, for eksempel advarsler eller anbefalinger
-- vise feilmeldinger for enkeltfelt, bruk heller `error`-prop for [`Textfield`](/docs/components-textfield--docs), [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs) og [`Switch`](/docs/components-switch--docs), eller kombiner [`Field`](/docs/components-field--docs) og [`ValidationMessage`](/docs/components-typography--docs#validationmessage) for andre skjemaelementer
+- vise feilmeldinger for enkeltfelt – bruk heller `error`-prop for [`Textfield`](/docs/components-textfield--docs), [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs) og [`Switch`](/docs/components-switch--docs), eller kombiner [`Field`](/docs/components-field--docs) og [`ValidationMessage`](/docs/components-typography--docs#validationmessage) for andre skjemaelementer
 
 ## Slik bruker du ErrorSummary
 

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -14,7 +14,7 @@ import * as FieldStories from './Field.stories';
 
 **Passer ikke til å**
 
-- semantisk gruppere flere felt, bruk heller [`Fieldset`](/docs/components-fieldset--docs)
+- semantisk gruppere flere felt – bruk heller [`Fieldset`](/docs/components-fieldset--docs)
 
 ## Slik bruker du Field
 

--- a/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
+++ b/@udir-design/react/src/components/formNavigation/FormNavigation.mdx
@@ -26,7 +26,7 @@ import { Unstyled } from '@storybook/addon-docs/blocks';
 
 **Passer ikke til å**
 
-- navigere utenfor skjemaer - bruk heller [`Pagination`](/docs/components-pagination--docs)
+- navigere utenfor skjemaer – bruk heller [`Pagination`](/docs/components-pagination--docs)
 
 <Canvas of={FormNavigationStories.Preview} withToolbar />
 <Controls of={FormNavigationStories.Preview} />

--- a/@udir-design/react/src/components/input/Input.mdx
+++ b/@udir-design/react/src/components/input/Input.mdx
@@ -15,7 +15,7 @@ Se også [`Textfield`](/docs/components-textfield--docs), som er en samling komp
 
 **Passer ikke til å**
 
-- skrive inn lengre tekster, bruk heller [`Textarea`](/docs/components-textarea--docs)
+- skrive inn lengre tekster – bruk heller [`Textarea`](/docs/components-textarea--docs)
 
 ## Slik bruker du Input
 

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -18,7 +18,7 @@ Komponenten er basert på [anchor HTML-elementet](https://developer.mozilla.org/
 
 **Passer ikke til å**
 
-- utføre handlinger - bruk heller [`Button`](/docs/components-button--docs)
+- utføre handlinger – bruk heller [`Button`](/docs/components-button--docs)
 
 ## Slik bruker du Link
 

--- a/@udir-design/react/src/components/list/List.mdx
+++ b/@udir-design/react/src/components/list/List.mdx
@@ -16,7 +16,7 @@ Listen kan være sortert ved å bruke `List.Ordered` og usortert ved å bruke `L
 **Passer ikke til å**
 
 - vise brukerne lengre innhold
-- sammenligne informasjon - bruk heller [`Table`](/docs/components-table--docs)
+- sammenligne informasjon – bruk heller [`Table`](/docs/components-table--docs)
 
 ## Slik bruker du List
 

--- a/@udir-design/react/src/components/pagination/Pagination.mdx
+++ b/@udir-design/react/src/components/pagination/Pagination.mdx
@@ -15,8 +15,8 @@ import * as PaginationStories from './Pagination.stories';
 
 **Passer ikke til å**
 
-- dele et skjema opp i flere steg - bruk heller [`FormNavigation`](/docs/components-formnavigation--docs)
-- vise progresjon i en prosess - bruk heller [`ProgressBar`](/docs/components-progressbar--docs)
+- dele et skjema opp i flere steg – bruk heller [`FormNavigation`](/docs/components-formnavigation--docs)
+- vise progresjon i en prosess – bruk heller [`ProgressBar`](/docs/components-progressbar--docs)
 
 ## Slik bruker du Pagination
 

--- a/@udir-design/react/src/components/popover/Popover.mdx
+++ b/@udir-design/react/src/components/popover/Popover.mdx
@@ -15,9 +15,9 @@ import * as PopoverStories from './Popover.stories';
 
 **Passer ikke til å**
 
-- beskrive et symbol eller en tastatursnarvei, bruk heller [`Tooltip`](/docs/components-tooltip--docs)
+- beskrive et symbol eller en tastatursnarvei – bruk heller [`Tooltip`](/docs/components-tooltip--docs)
 - vise store mengder innhold
-- navigere eller velge mellom alternativer, bruk heller [`Dropdown`](https://design.udir.no/beta/?path=/docs/components-dropdown--docs)
+- navigere eller velge mellom alternativer – bruk heller [`Dropdown`](https://design.udir.no/beta/?path=/docs/components-dropdown--docs)
 
 ## Slik bruker du Popover
 

--- a/@udir-design/react/src/components/progressBar/ProgressBar.mdx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.mdx
@@ -14,7 +14,7 @@ import * as ProgressBarStories from './ProgressBar.stories';
 
 **Passer ikke til å**
 
-- brukes i skjemaer med validering, bruk heller [`FormNavigation`](/docs/components-formnavigation--docs)
+- brukes i skjemaer med validering – bruk heller [`FormNavigation`](/docs/components-formnavigation--docs)
 
 ## Slik bruker du ProgressBar
 

--- a/@udir-design/react/src/components/radio/Radio.mdx
+++ b/@udir-design/react/src/components/radio/Radio.mdx
@@ -22,9 +22,9 @@ Vi bruker `Radio` (radioknapp) for å gi brukerne valg, der de kan velge mellom 
 
 **Passer ikke til å**
 
-- gi brukerne ett enkelt valg, bruk heller [`Switch`](/docs/components-switch--docs)
-- velge flere alternativer, bruk heller [`Checkbox`](/docs/components-checkbox--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
-- velge mellom veldig mange alternativer, bruk heller [`Suggestion`](/docs/components-suggestion--docs)
+- gi brukerne ett enkelt valg – bruk heller [`Switch`](/docs/components-switch--docs)
+- velge flere alternativer – bruk heller [`Checkbox`](/docs/components-checkbox--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
+- velge mellom veldig mange alternativer – bruk heller [`Suggestion`](/docs/components-suggestion--docs)
 
 ## Slik bruker du Radio
 

--- a/@udir-design/react/src/components/readMore/ReadMore.mdx
+++ b/@udir-design/react/src/components/readMore/ReadMore.mdx
@@ -17,7 +17,7 @@ import * as ReadMoreStories from './ReadMore.stories';
 **Passer ikke til å**
 
 - forklare ord og begreper i løpende tekst – bruk heller [`Popover`](/docs/components-popover--docs)
-- påkalle brukerens oppmerksomhet - bruk heller [`Details`](/docs/components-details--docs)
+- påkalle brukerens oppmerksomhet – bruk heller [`Details`](/docs/components-details--docs)
 - vise nødvendig informasjon
 - vise mye eller rikt innhold
 

--- a/@udir-design/react/src/components/search/Search.mdx
+++ b/@udir-design/react/src/components/search/Search.mdx
@@ -13,7 +13,7 @@ import * as SearchStories from './Search.stories';
 
 **Passer ikke til å**
 
-- søke i en liste med alternativer, bruk heller [`Suggestion`](/docs/components-suggestion--docs)
+- søke i en liste med alternativer – bruk heller [`Suggestion`](/docs/components-suggestion--docs)
 - søke i innhold som er lett å navigere i
 
 ## Slik bruker du Search

--- a/@udir-design/react/src/components/select/Select.mdx
+++ b/@udir-design/react/src/components/select/Select.mdx
@@ -18,8 +18,8 @@ For eksempel er det ikke mulig å overstyre formateringen av alternativene.
 **Passer ikke til å**
 
 - navigere mellom sider eller seksjoner i en applikasjon
-- velge flere alternativer, bruk heller [`Suggestion`](/docs/components-suggestion--docs) eller [`Checkbox`](/docs/components-checkbox--docs)
-- velge fra en liste med få alternativer, bruk heller [`Radio`](/docs/components-radio--docs)
+- velge flere alternativer – bruk heller [`Suggestion`](/docs/components-suggestion--docs) eller [`Checkbox`](/docs/components-checkbox--docs)
+- velge fra en liste med få alternativer – bruk heller [`Radio`](/docs/components-radio--docs)
 
 ## Slik bruker du Select
 

--- a/@udir-design/react/src/components/skeleton/Skeleton.mdx
+++ b/@udir-design/react/src/components/skeleton/Skeleton.mdx
@@ -16,7 +16,7 @@ import * as SkeletonStories from './Skeleton.stories';
 **Passer ikke til å**
 
 - vise innlasting når den tar mindre enn 1 sekund
-- indikere at systemet jobber med en oppgave som brukeren må vente på - bruk heller [`Spinner`](/docs/components-spinner--docs)
+- indikere at systemet jobber med en oppgave som brukeren må vente på – bruk heller [`Spinner`](/docs/components-spinner--docs)
 
 ## Slik bruker du Skeleton
 

--- a/@udir-design/react/src/components/spinner/Spinner.mdx
+++ b/@udir-design/react/src/components/spinner/Spinner.mdx
@@ -15,7 +15,7 @@ import * as SpinnerStories from './Spinner.stories';
 **Passer ikke til å**
 
 - indikere innlasting som tar mindre enn 1 sekund
-- fortelle brukeren at enkeltelementer på siden blir lastet inn - bruk heller [`Skeleton`](/docs/components-skeleton--docs)
+- fortelle brukeren at enkeltelementer på siden blir lastet inn – bruk heller [`Skeleton`](/docs/components-skeleton--docs)
 
 ## Slik bruker du Spinner
 

--- a/@udir-design/react/src/components/switch/Switch.mdx
+++ b/@udir-design/react/src/components/switch/Switch.mdx
@@ -22,7 +22,7 @@ Vi bruker `Switch` til å gi brukerne et valg mellom to alternativer. Bryteren k
 **Passer ikke til å**
 
 - gi flere alternativer enn to
-- brukes i skjemaer, bruk heller [`Checkbox`](/docs/components-checkbox--docs) eller [`Radio`](/docs/components-radio--docs)
+- brukes i skjemaer – bruk heller [`Checkbox`](/docs/components-checkbox--docs) eller [`Radio`](/docs/components-radio--docs)
 - gi valg som ikke lagres umiddelbart
 
 ## Slik bruker du Switch

--- a/@udir-design/react/src/components/tag/Tag.mdx
+++ b/@udir-design/react/src/components/tag/Tag.mdx
@@ -15,9 +15,9 @@ En `Tag` er en merkelapp som kan brukes til å kategorisere elementer eller komm
 
 **Passer ikke til å**
 
-- linke til andre sider – se [`Link`](/docs/components-link--docs)
+- linke til andre sider – bruk heller [`Link`](/docs/components-link--docs)
 - utføre handlinger ved klikk – bruk heller [`Button`](/docs/components-button--docs)
-- la brukeren filtrere data – se [`Chip`](/docs/components-chip--docs)
+- la brukeren filtrere data – bruk heller [`Chip`](/docs/components-chip--docs)
 
 ## Slik bruker du Tag
 

--- a/@udir-design/react/src/components/tag/Tag.mdx
+++ b/@udir-design/react/src/components/tag/Tag.mdx
@@ -15,9 +15,9 @@ En `Tag` er en merkelapp som kan brukes til å kategorisere elementer eller komm
 
 **Passer ikke til å**
 
-- linke til andre sider (se [`Link`](/docs/components-link--docs))
-- utføre handlinger ved klikk (bruk heller [`Button`](/docs/components-button--docs))
-- la brukeren filtrere data (se [`Chip`](/docs/components-chip--docs))
+- linke til andre sider – se [`Link`](/docs/components-link--docs)
+- utføre handlinger ved klikk – bruk heller [`Button`](/docs/components-button--docs)
+- la brukeren filtrere data – se [`Chip`](/docs/components-chip--docs)
 
 ## Slik bruker du Tag
 

--- a/@udir-design/react/src/components/textfield/Textfield.mdx
+++ b/@udir-design/react/src/components/textfield/Textfield.mdx
@@ -20,7 +20,7 @@ Den har innebygget `label`, `description`, `validationmessage`, `affix` og `coun
 
 **Passer ikke til å**
 
-- velge mellom forhåndsdefinerte alternativer, bruk heller [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs), [`Select`](/docs/components-select--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
+- velge mellom forhåndsdefinerte alternativer – bruk heller [`Checkbox`](/docs/components-checkbox--docs), [`Radio`](/docs/components-radio--docs), [`Select`](/docs/components-select--docs) eller [`Suggestion`](/docs/components-suggestion--docs)
 
 ## Slik bruker du Textfield
 

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
@@ -15,8 +15,8 @@ Med `ToggleGroup` kan brukerne velge mellom alternativer som påvirker innholdet
 
 **Passer ikke til å**
 
-- bruke som skjemaelement - bruk heller [`Radio`](/docs/components-radio--docs)
-- navigere mellom sider eller paneler - bruk heller [`Tabs`](/docs/components-tabs--docs) hvis det dreier seg om panelnavigasjon
+- bruke som skjemaelement – bruk heller [`Radio`](/docs/components-radio--docs)
+- navigere mellom sider eller paneler – bruk heller [`Tabs`](/docs/components-tabs--docs) hvis det dreier seg om panelnavigasjon
 
 ## Slik bruker du ToggleGroup
 

--- a/@udir-design/react/src/icons/docs/UdirPreferredIcons.ts
+++ b/@udir-design/react/src/icons/docs/UdirPreferredIcons.ts
@@ -93,7 +93,7 @@ export const guidelinesRecord: Partial<
     {
       type: 'dont',
       description:
-        'Ikke bruk til å indikere en status, bruk heller komponenten Badge',
+        'Ikke bruk til å indikere en status – bruk heller komponenten Badge',
     },
   ],
   ChevronDown: [

--- a/@udir-design/react/src/patterns/Systemvarsler/Toast.mdx
+++ b/@udir-design/react/src/patterns/Systemvarsler/Toast.mdx
@@ -26,7 +26,7 @@ I tillegg kan meldingen legge seg på toppen av fokuserbart innhold og dermed gj
 Det finnes som regel bedre alternativer enn en toast for å kommunisere med brukerne våre:
 
 - For feiltilstander er det alltid bedre å bruke en [`Alert`](/docs/components-alert--docs) der feilen oppsto. Den er en vanleg del av tekst- og fokusflyten og kan ligge der til feilen er rettet.
-- For å bekrefte innsending av skjema, bruk heller en kvitteringside.
+- For å bekrefte innsending av skjema – bruk heller en kvitteringside.
 - For å bekrefte lagring av data, bruk f.eks.
   - en [`ValidationMessage`](/docs/components-typography--docs#validationmessage) av type `success` ved lagreknappen, dersom lagring ble satt i gang av brukeren
   - en statusbar med "sist lagret \<dato og klokkeslett\>" eller "sist lagret for \<x\> sekunder siden" dersom lagring blir gjennomført automatisk av systemet


### PR DESCRIPTION
## Hva er gjort?
Endra frå diverse variantar av tankestrek, bindestrek, komma, punktum og parentes til å alltid bruke tankestrek i kontekst av "bruk heller..." i lista for "passer ikke til" på kvar komponent

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
