### PR TITLE
feat: omit deprecated props from component types

### DIFF
--- a/@udir-design/react/demo-pages/page-demo/login/Login.tsx
+++ b/@udir-design/react/demo-pages/page-demo/login/Login.tsx
@@ -24,7 +24,7 @@ export function Login() {
         autoComplete="email"
         className={styles.userField}
       />
-      <Tooltip content="Trykk for å få hjelp" type="describedby">
+      <Tooltip content="Trykk for å få hjelp">
         <Link href="#">Glemt passord?</Link>
       </Tooltip>
       <Button className={styles.userButton}>Opprett ny bruker</Button>

--- a/@udir-design/react/src/components/dialog/Dialog.stories.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.stories.tsx
@@ -60,13 +60,6 @@ const meta = preview.meta({
       },
     },
   },
-  argTypes: {
-    asChild: {
-      description:
-        '**@deprecated** Will be removed in the next major version. Should always be a `<dialog>` element.',
-      control: false,
-    },
-  },
   play: async (ctx) => defaultPlay(ctx.canvasElement),
 });
 

--- a/@udir-design/react/src/components/dialog/Dialog.tsx
+++ b/@udir-design/react/src/components/dialog/Dialog.tsx
@@ -15,7 +15,7 @@ import type {
 } from 'react';
 import './dialog.css';
 
-type DialogProps = Omit<DigdirDialogProps, 'data-color'>;
+type DialogProps = Omit<DigdirDialogProps, 'data-color' | 'asChild'>;
 
 const Dialog = DigdirDialog as ForwardRefExoticComponent<
   DialogProps & RefAttributes<ComponentRef<typeof DigdirDialog>>

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.stories.tsx
@@ -15,13 +15,6 @@ import { ErrorSummaryList } from './docs/FakeErrorSummaryList';
 
 const meta = preview.meta({
   component: FakeErrorSummary,
-  argTypes: {
-    asChild: {
-      description:
-        '**@deprecated** This is not supported anymore, as the element needs to be `ds-error-summary`',
-      control: false,
-    },
-  },
   subcomponents: {
     'ErrorSummary.Heading': ErrorSummaryHeading,
     'ErrorSummary.Item': ErrorSummaryItem,

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.tsx
@@ -21,10 +21,7 @@ type ErrorSummaryProps = Omit<DigdirErrorSummaryProps, 'asChild'>;
 const ErrorSummary = DigdirErrorSummary as ForwardRefExoticComponent<
   ErrorSummaryProps & RefAttributes<ComponentRef<typeof DigdirErrorSummary>>
 > &
-  Pick<
-    typeof DigdirErrorSummary,
-    'Heading' | 'Item' | 'Link' | 'List'
-  >;
+  Pick<typeof DigdirErrorSummary, 'Heading' | 'Item' | 'Link' | 'List'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 ErrorSummary.displayName = 'ErrorSummary';

--- a/@udir-design/react/src/components/errorSummary/ErrorSummary.tsx
+++ b/@udir-design/react/src/components/errorSummary/ErrorSummary.tsx
@@ -1,5 +1,5 @@
 import {
-  ErrorSummary,
+  ErrorSummary as DigdirErrorSummary,
   ErrorSummaryHeading,
   type ErrorSummaryHeadingProps,
   ErrorSummaryItem,
@@ -8,8 +8,23 @@ import {
   type ErrorSummaryLinkProps,
   ErrorSummaryList,
   type ErrorSummaryListProps,
-  type ErrorSummaryProps,
+  type ErrorSummaryProps as DigdirErrorSummaryProps,
 } from '@digdir/designsystemet-react';
+import type {
+  ComponentRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from 'react';
+
+type ErrorSummaryProps = Omit<DigdirErrorSummaryProps, 'asChild'>;
+
+const ErrorSummary = DigdirErrorSummary as ForwardRefExoticComponent<
+  ErrorSummaryProps & RefAttributes<ComponentRef<typeof DigdirErrorSummary>>
+> &
+  Pick<
+    typeof DigdirErrorSummary,
+    'Heading' | 'Item' | 'Link' | 'List'
+  >;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 ErrorSummary.displayName = 'ErrorSummary';

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -24,13 +24,7 @@ const meta = preview.meta({
     },
     layout: 'centered',
   },
-  argTypes: {
-    asChild: {
-      description:
-        '**@deprecated** This is not supported anymore, as the element needs to be `ds-field`.',
-      control: false,
-    },
-  },
+
 });
 
 export const Preview = meta.story({

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -24,7 +24,6 @@ const meta = preview.meta({
     },
     layout: 'centered',
   },
-
 });
 
 export const Preview = meta.story({

--- a/@udir-design/react/src/components/field/Field.tsx
+++ b/@udir-design/react/src/components/field/Field.tsx
@@ -24,7 +24,9 @@ type FieldCounterProps = Omit<DigdirFieldCounterProps, 'hint'>;
 const Field = DigdirField as ForwardRefExoticComponent<
   FieldProps & RefAttributes<ComponentRef<typeof DigdirField>>
 > &
-  Pick<typeof DigdirField, 'Affix' | 'Affixes' | 'Counter' | 'Description'>;
+  Pick<typeof DigdirField, 'Affix' | 'Affixes' | 'Description'> & {
+    Counter: typeof FieldCounter;
+  };
 
 const FieldCounter = DigdirFieldCounter as ForwardRefExoticComponent<
   FieldCounterProps & RefAttributes<ComponentRef<typeof DigdirFieldCounter>>

--- a/@udir-design/react/src/components/field/Field.tsx
+++ b/@udir-design/react/src/components/field/Field.tsx
@@ -5,8 +5,8 @@ import {
   type FieldAffixProps,
   FieldAffixes,
   type FieldAffixesProps,
-  FieldCounter,
-  type FieldCounterProps,
+  FieldCounter as DigdirFieldCounter,
+  type FieldCounterProps as DigdirFieldCounterProps,
   FieldDescription,
   type FieldDescriptionProps,
   type FieldProps as DigdirFieldProps,
@@ -17,12 +17,18 @@ import type {
   RefAttributes,
 } from 'react';
 
-type FieldProps = Omit<DigdirFieldProps, 'data-color'>;
+type FieldProps = Omit<DigdirFieldProps, 'data-color' | 'asChild'>;
+
+type FieldCounterProps = Omit<DigdirFieldCounterProps, 'hint'>;
 
 const Field = DigdirField as ForwardRefExoticComponent<
   FieldProps & RefAttributes<ComponentRef<typeof DigdirField>>
 > &
   Pick<typeof DigdirField, 'Affix' | 'Affixes' | 'Counter' | 'Description'>;
+
+const FieldCounter = DigdirFieldCounter as ForwardRefExoticComponent<
+  FieldCounterProps & RefAttributes<ComponentRef<typeof DigdirFieldCounter>>
+>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Field.displayName = 'Field';

--- a/@udir-design/react/src/components/field/docs/FakeFieldCounter.tsx
+++ b/@udir-design/react/src/components/field/docs/FakeFieldCounter.tsx
@@ -1,15 +1,7 @@
 import type { FunctionComponent } from 'react';
 import type { FieldCounterProps } from '../Field';
 
-type FieldCounterDocsProps = Omit<FieldCounterProps, 'hint'> & {
-  /**
-   * **@deprecated** The hint attribute is deprecated.
-   */
-  hint?: string;
-};
-
 /**
  * This component only exists to add relevant html props for FieldCounter
  */
-export const FieldCounter: FunctionComponent<FieldCounterDocsProps> = () =>
-  null;
+export const FieldCounter: FunctionComponent<FieldCounterProps> = () => null;

--- a/@udir-design/react/src/components/pagination/Pagination.stories.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.stories.tsx
@@ -12,13 +12,6 @@ import { PaginationList } from './docs/FakePaginationList';
 
 const meta = preview.meta({
   component: FakePagination,
-  argTypes: {
-    asChild: {
-      description:
-        '**@deprecated** This is not supported anymore, as the element needs to be `ds-pagination`',
-      control: false,
-    },
-  },
   subcomponents: {
     'Pagination.List': PaginationList,
     'Pagination.Item': PaginationItem,

--- a/@udir-design/react/src/components/pagination/Pagination.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.tsx
@@ -15,7 +15,7 @@ import type {
 } from 'react';
 import './pagination.css';
 
-type PaginationProps = Omit<DigdirPaginationProps, 'data-color'>;
+type PaginationProps = Omit<DigdirPaginationProps, 'data-color' | 'asChild'>;
 
 const Pagination = DigdirPagination as ForwardRefExoticComponent<
   PaginationProps & RefAttributes<ComponentRef<typeof DigdirPagination>>

--- a/@udir-design/react/src/components/select/Select.stories.tsx
+++ b/@udir-design/react/src/components/select/Select.stories.tsx
@@ -15,12 +15,6 @@ import { SelectOption as FakeSelectOption } from './docs/FakeSelectOption';
 
 const meta = preview.meta({
   component: FakeSelect,
-  argTypes: {
-    readOnly: {
-      description: '**@deprecated** Use `aria-readonly` instead.',
-      control: false,
-    },
-  },
   subcomponents: {
     'Select.Optgroup': FakeSelectOptgroup,
     'Select.Option': FakeSelectOption,

--- a/@udir-design/react/src/components/select/Select.tsx
+++ b/@udir-design/react/src/components/select/Select.tsx
@@ -1,11 +1,23 @@
 import {
-  Select,
+  Select as DigdirSelect,
   SelectOptgroup,
   type SelectOptgroupProps,
   SelectOption,
   type SelectOptionProps,
-  type SelectProps,
+  type SelectProps as DigdirSelectProps,
 } from '@digdir/designsystemet-react';
+import type {
+  ComponentRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from 'react';
+
+type SelectProps = Omit<DigdirSelectProps, 'readOnly'>;
+
+const Select = DigdirSelect as ForwardRefExoticComponent<
+  SelectProps & RefAttributes<ComponentRef<typeof DigdirSelect>>
+> &
+  Pick<typeof DigdirSelect, 'Optgroup' | 'Option'>;
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Select.displayName = 'Select';

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -178,7 +178,7 @@ export const OnlyIcons = meta.story({
         </ToggleGroup.Item>
       </Tooltip>
       <Tooltip content="Høyrestilt">
-        <ToggleGroup.Item value="høyrestilt" icon>
+        <ToggleGroup.Item value="høyrestilt">
           <AlignRightIcon aria-hidden />
         </ToggleGroup.Item>
       </Tooltip>

--- a/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroupItem.tsx
+++ b/@udir-design/react/src/components/toggleGroup/docs/FakeToggleGroupItem.tsx
@@ -4,11 +4,5 @@ import type { ToggleGroupItemProps } from '../';
 /**
  * This component only exists to add relevant html props for ToggleGroupItem
  */
-export const ToggleGroupItem: FunctionComponent<
-  Omit<ToggleGroupItemProps, 'icon'> & {
-    /**
-     * **@deprecated** Icon prop is deprecated
-     */
-    icon?: boolean;
-  }
-> = () => null;
+export const ToggleGroupItem: FunctionComponent<ToggleGroupItemProps> = () =>
+  null;

--- a/@udir-design/react/src/components/toggleGroup/index.ts
+++ b/@udir-design/react/src/components/toggleGroup/index.ts
@@ -1,11 +1,23 @@
 import {
-  ToggleGroupItem,
-  type ToggleGroupItemProps,
+  ToggleGroupItem as DigdirToggleGroupItem,
+  type ToggleGroupItemProps as DigdirToggleGroupItemProps,
 } from '@digdir/designsystemet-react';
+import type {
+  ComponentRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from 'react';
 import {
   ToggleGroup as ToggleGroupParent,
   type ToggleGroupProps,
 } from './ToggleGroup';
+
+type ToggleGroupItemProps = Omit<DigdirToggleGroupItemProps, 'icon'>;
+
+const ToggleGroupItem = DigdirToggleGroupItem as ForwardRefExoticComponent<
+  ToggleGroupItemProps &
+    RefAttributes<ComponentRef<typeof DigdirToggleGroupItem>>
+>;
 
 type ToggleGroup = typeof ToggleGroupParent & {
   /**

--- a/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.stories.tsx
@@ -24,18 +24,6 @@ const meta = preview.meta({
       alignItems: 'center',
     },
   },
-  argTypes: {
-    type: {
-      description:
-        '**@deprecated** This prop has no effect. The tooltip will automatically use `aria-description` if the trigger already has accessible text, and `aria-label` otherwise.',
-      control: false,
-    },
-    open: {
-      description:
-        '**@deprecated** This should not be used on Tooltip. Use a Popover instead.',
-      control: false,
-    },
-  },
   args: {
     // Children and content is required in Tooltip props, so we must set something
     children: undefined,

--- a/@udir-design/react/src/components/tooltip/Tooltip.tsx
+++ b/@udir-design/react/src/components/tooltip/Tooltip.tsx
@@ -1,4 +1,18 @@
-import { Tooltip, type TooltipProps } from '@digdir/designsystemet-react';
+import {
+  Tooltip as DigdirTooltip,
+  type TooltipProps as DigdirTooltipProps,
+} from '@digdir/designsystemet-react';
+import type {
+  ComponentRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+} from 'react';
+
+type TooltipProps = Omit<DigdirTooltipProps, 'open' | 'type'>;
+
+const Tooltip = DigdirTooltip as ForwardRefExoticComponent<
+  TooltipProps & RefAttributes<ComponentRef<typeof DigdirTooltip>>
+>;
 
 export type { TooltipProps };
 export { Tooltip };

--- a/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
@@ -182,7 +182,6 @@ exports[`Page Story 1`] = `
         data-tooltip="Trykk for å få hjelp"
         data-placement="top"
         data-autoplacement="true"
-        type="describedby"
         aria-description="Trykk for å få hjelp"
       >
         Glemt passord?


### PR DESCRIPTION
Omitted props:
- `Dialog`, `Pagination`, `Field`, `ErrorSummary`: `asChild`
- `Select`: `readOnly`
- `Tooltip`: `open`, `type`
- `FieldCounter`: `hint`
- `ToggleGroupItem`: `icon`

