### PR TITLE
build: set oxlint options in config

### DIFF
--- a/@internal/ci/bin/diff-runtime-deps.ts
+++ b/@internal/ci/bin/diff-runtime-deps.ts
@@ -83,7 +83,7 @@ function readPkgJsonFromGit(
 
 // ─── Entry point ──────────────────────────────────────────────────────────────
 
-(async () => {
+await (async () => {
   const yargsInstance = yargs(hideBin(process.argv));
   const options = await yargsInstance
     .version(false)

--- a/@internal/ci/bin/semantic-release.ts
+++ b/@internal/ci/bin/semantic-release.ts
@@ -5,7 +5,7 @@ import yargs, { Options } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { semanticRelease } from '../src/semantic-release.js';
 
-(async () => {
+await (async () => {
   const yargsInstance = yargs(hideBin(process.argv));
   const options = await yargsInstance
     .version(false) // disable default --version option in yargs

--- a/@internal/ci/package.json
+++ b/@internal/ci/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "oxlint --max-warnings 0",
+    "lint": "oxlint",
     "test:unit": "vitest run",
     "typecheck": "tsc --build"
   },

--- a/@udir-design/css/package.json
+++ b/@udir-design/css/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "postcss src/*.css --dir dist/",
-    "lint": "oxlint --max-warnings 0"
+    "lint": "oxlint"
   },
   "dependencies": {
     "@digdir/designsystemet-css": "catalog:",

--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -31,7 +31,7 @@
     "generate-css": "tsx generate-css.ts",
     "inject": "echo 'Dummy script to trigger pnpm injected dependency sync'",
     "clean": "rimraf ./dist && mkdir ./dist",
-    "lint": "oxlint --max-warnings 0"
+    "lint": "oxlint"
   },
   "dependencies": {
     "@navikt/aksel-icons": "catalog:"

--- a/@udir-design/icons/tsconfig.json
+++ b/@udir-design/icons/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "./dist",
-    "moduleResolution": "Node",
+    "module": "esnext",
     "composite": true
   },
   "include": ["./src"]

--- a/@udir-design/react/oxlint.config.ts
+++ b/@udir-design/react/oxlint.config.ts
@@ -136,5 +136,11 @@ export default defineConfig({
         ]),
       },
     },
+    {
+      files: ['**/*.{spec,test}.ts'],
+      rules: {
+        'typescript/no-deprecated': 'allow',
+      },
+    },
   ],
 });

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "build": "vite build",
     "inject": "echo 'Dummy script to trigger pnpm injected dependency sync'",
-    "lint": "oxlint --type-aware --max-warnings 0",
+    "lint": "oxlint",
     "lint:cycles": "pnpm dpdm --no-warning --no-tree --exit-code circular:1 ./src/alpha.ts",
     "typecheck": "tsc --build",
     "dev": "storybook dev --port 6005",

--- a/@udir-design/symbols/package.json
+++ b/@udir-design/symbols/package.json
@@ -51,7 +51,7 @@
     "postbuild": "pnpm run copy:svgs",
     "fetch-new:symbols": "node --env-file=../../.env.local --import tsx config/figma/index.ts",
     "generate:pngs": "node config/svg-to-png.js",
-    "lint": "oxlint --type-aware --max-warnings 0"
+    "lint": "oxlint"
   },
   "devDependencies": {
     "@babel/types": "catalog:",

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -3,12 +3,16 @@ import {
   JS_TS_FILES,
   TS_FILES,
   TS_TSX_FILES,
+  coreRulesForTypeScript,
   importOrder,
   noUnusedVars,
-  coreRulesForTypeScript,
 } from './oxlint.shared.ts';
 
 export default defineConfig({
+  options: {
+    typeAware: true,
+    denyWarnings: true,
+  },
   // Built-in plugins enabled repo-wide. `oxc` adds Oxlint-specific rules that
   // have no ESLint counterpart; its correctness rules fire automatically via
   // `categories.correctness` below, and a few high-value non-correctness rules

--- a/test-apps/nextjs/oxlint.config.ts
+++ b/test-apps/nextjs/oxlint.config.ts
@@ -3,6 +3,10 @@ import { TS_FILES, coreRulesForTypeScript } from '../../oxlint.shared.ts';
 
 // Standalone config (no `extends`), so `categories`/`env` are declared here.
 export default defineConfig({
+  options: {
+    typeAware: true,
+    denyWarnings: true,
+  },
   plugins: ['nextjs', 'typescript'],
   categories: {
     correctness: 'off',

--- a/test-apps/nextjs/package.json
+++ b/test-apps/nextjs/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "oxlint --max-warnings 0",
+    "lint": "oxlint",
     "typecheck": "tsc --build",
     "pretest:e2e": "pnpm exec playwright install --with-deps chromium",
     "test:e2e": "playwright test"

--- a/test-apps/nextjs/turbo.json
+++ b/test-apps/nextjs/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "lint": {
+      "dependsOn": ["^build"]
+    },
     "build": {
       "outputs": [".next/**", "!.next/cache/**"]
     },

--- a/test-apps/vite-vanilla/package.json
+++ b/test-apps/vite-vanilla/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "oxlint --max-warnings 0"
+    "lint": "oxlint"
   },
   "dependencies": {
     "@digdir/designsystemet-css": "catalog:",

--- a/test-apps/vite/package.json
+++ b/test-apps/vite/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "oxlint --type-aware --max-warnings 0",
+    "lint": "oxlint",
     "typecheck": "tsc --build"
   },
   "dependencies": {


### PR DESCRIPTION
## Hva er gjort?

Skrur på options for type-aware linting og `denyWarnings` (samme som `maxWarnings: 0`) i oxlint config, og forenkler lint-script i package.json

Tillater også bruk av deprecated i testar i React-prosjektet, sidan det begynte å feile i ein anna PR etter rebase (det er jo fint å fortsette å teste funksjonalitet som er deprecated) 