### PR TITLE
feat(css): add optional global baseline styles

### DIFF
--- a/@udir-design/css/README.md
+++ b/@udir-design/css/README.md
@@ -43,3 +43,47 @@ import '@udir-design/css';
 Det er foreløpig ingen dokumentasjon på hvordan man bruker komponentene uten React. Generelt sett er det ganske lett å få likt utseende som med React, men eventuell interaktivitet må implementeres selv.
 
 Enn så lenge anbefaler vi å lese [React-dokumentasjonen](https://design.udir.no), inspisere DOM-en i eksemplene, og se hvilke klasser og data-attributter som settes i forskjellige tilstander.
+
+## Grunnstiler for applikasjoner
+
+Nye applikasjoner kan velge å bruke et lite sett med globale grunnstiler:
+
+```js
+import '@udir-design/css';
+import '@udir-design/css/baseline.css';
+```
+
+Fra CSS:
+
+```css
+@import '@udir-design/css';
+@import '@udir-design/css/baseline.css';
+```
+
+Grunnstilene er valgfrie og er ikke en del av standardimporten. De gir
+forutsigbar boksstørrelse, fjerner nettleserens marg rundt `body`, bruker
+designsystemets typografi, lar skjemakontroller arve typografi og hindrer store
+bilder og videoer i å flyte ut av beholderen sin.
+
+Stilene beholder nettleserens standarder for blant annet overskrifter, avsnitt,
+lister, lenker, skjemakontroller og fokusmarkering. De fjerner heller ikke
+animasjoner eller tilpasninger for høykontrastmodus.
+
+Grunnstilene ligger i laget `ds.base`. Vanlig applikasjons-CSS som ikke ligger i
+et lag, overstyrer derfor grunnstilene uten sterkere selektorer eller
+`!important`.
+
+Fonten `Inter` må fortsatt lastes inn av applikasjonen. Se oppsettet i
+React-dokumentasjonen for anbefalt fontimport.
+
+### Bruke et annet preflight-bibliotek
+
+Importer Tailwind eller andre preflight-biblioteker etter Designsystemet og
+Udirs grunnstiler. Da får det siste biblioteket kontroll over overlappende
+grunnstiler:
+
+```css
+@import '@udir-design/css';
+@import '@udir-design/css/baseline.css';
+@import 'tailwindcss';
+```

--- a/@udir-design/css/package.json
+++ b/@udir-design/css/package.json
@@ -13,6 +13,7 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.css",
+    "./baseline.css": "./dist/baseline.css",
     "./components.css": "./dist/components.css"
   },
   "publishConfig": {

--- a/@udir-design/css/src/baseline.css
+++ b/@udir-design/css/src/baseline.css
@@ -1,0 +1,34 @@
+@layer ds.base {
+  *,
+  ::before,
+  ::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
+  body {
+    margin: 0;
+    font-family: var(--ds-font-family);
+    font-feature-settings: 'cv05' 1;
+    line-height: var(--ds-line-height-md);
+    overflow-wrap: break-word;
+  }
+
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+  }
+
+  :where(img, video) {
+    display: block;
+    max-inline-size: 100%;
+    block-size: auto;
+  }
+
+  table {
+    border-color: currentcolor;
+  }
+}

--- a/@udir-design/react/README.md
+++ b/@udir-design/react/README.md
@@ -44,9 +44,25 @@ Alternativt kan du importere stilsettet fra en CSS-fil:
 
 ### Konfigurere standard typografi
 
-Biblioteket setter ingen globale stiler. For å få konsistent typografi også på innhold som ikke bruker komponenter fra biblioteket, må du selv definere standard typografi for applikasjonen.
+Biblioteket setter ingen globale stiler. Nye applikasjoner kan velge å bruke
+Udirs grunnstiler for å få konsistent typografi også på innhold som ikke bruker
+komponenter fra biblioteket:
 
-Dette kan gjøres slik:
+```bash
+npm add @udir-design/css@beta
+```
+
+Importer grunnstilene etter komponentstilene:
+
+```ts
+import '@udir-design/react/style.css';
+import '@udir-design/css/baseline.css';
+```
+
+Grunnstilene er valgfrie og beholder nettleserens semantiske standardstiler. Se
+`@udir-design/css` for mer informasjon om innhold og kaskadelag.
+
+Du kan alternativt definere typografien selv:
 
 ```css
 body {

--- a/test-apps/vite-vanilla/src/index.html
+++ b/test-apps/vite-vanilla/src/index.html
@@ -40,6 +40,32 @@
         ><span>Lenke med SVG-ikon</span>
       </a>
       <div class="idea-box">Du kan også bruke ikoner og symboler i CSS</div>
+      <section
+        class="baseline-comparison"
+        aria-labelledby="baseline-comparison-heading"
+      >
+        <h2 id="baseline-comparison-heading">Globale grunnstiler</h2>
+        <p>
+          Begge rutene viser identiske, semantiske HTML-elementer. Høyre side
+          bruker designsystemets tema og grunnstiler.
+        </p>
+        <div class="baseline-comparison__grid">
+          <figure>
+            <figcaption>Uten grunnstiler</figcaption>
+            <iframe
+              data-baseline-preview="browser"
+              title="Vanlig HTML med nettleserens standardstiler"
+            ></iframe>
+          </figure>
+          <figure>
+            <figcaption>Med Udirs grunnstiler</figcaption>
+            <iframe
+              data-baseline-preview="udir"
+              title="Vanlig HTML med Udirs grunnstiler"
+            ></iframe>
+          </figure>
+        </div>
+      </section>
     </div>
     <script type="module" src="index.js"></script>
   </body>

--- a/test-apps/vite-vanilla/src/index.js
+++ b/test-apps/vite-vanilla/src/index.js
@@ -1,12 +1,16 @@
 import '@udir-design/theme';
 import '@digdir/designsystemet-css';
 import '@udir-design/css/components.css';
+import '@udir-design/css/baseline.css';
 import '@udir-design/icons/style.css';
 import '@udir-design/icons/css/lightBulb.css';
 
+import digdirBaseCss from '@digdir/designsystemet-css/base.css?inline';
+import baselineCss from '@udir-design/css/baseline.css?inline';
 import ArrowRightUrl from '@udir-design/icons/svg/ArrowRight.svg?no-inline';
 import PencilWritingUrl from '@udir-design/icons/svg/PencilWriting.svg?no-inline';
 import DatamaskinFillUrl from '@udir-design/symbols/svg/DatamaskinFill.svg?url';
+import themeCss from '@udir-design/theme?inline';
 
 document
   .getElementById('icon-pencil')
@@ -28,3 +32,86 @@ if (container) {
   ><span>Lenke lagt til dynamisk med JavaScript</span>
 </a>`;
 }
+
+const previewMarkup = `
+  <main class="preview-content">
+    <h1>Vanlig HTML</h1>
+    <p>Tekst, <a href="#input">lenke</a> og liste bruker dokumentets typografi.</p>
+    <ul>
+      <li>Første punkt</li>
+      <li>Andre punkt</li>
+    </ul>
+    <table>
+      <caption>Semantisk tabell</caption>
+      <thead>
+        <tr>
+          <th scope="col">Element</th>
+          <th scope="col">Resultat</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Tabell</td>
+          <td>Beholder nettleserens oppsett</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="measure">100 % bredde med padding og kant</div>
+    <img
+      alt="Bred testillustrasjon"
+      width="640"
+      height="80"
+      src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='80'%3E%3Crect width='640' height='80' fill='%23c8e6d4'/%3E%3Ctext x='16' y='48' font-family='sans-serif' font-size='24'%3E640 px bredt bilde%3C/text%3E%3C/svg%3E"
+    />
+    <form>
+      <label for="input">Tekstfelt</label>
+      <input id="input" value="Sammenlign typografien" />
+      <label for="select">Valg</label>
+      <select id="select">
+        <option>Beholder opprinnelig utseende</option>
+      </select>
+      <label for="textarea">Flere linjer</label>
+      <textarea id="textarea">Sammenlign typografien</textarea>
+      <button type="button">Vanlig knapp</button>
+    </form>
+    <dialog>
+      <p>Dialogen beholder nettleserens plassering og utseende.</p>
+    </dialog>
+  </main>
+`;
+
+const previewCss = `
+  .preview-content {
+    padding-inline: 0.5rem;
+  }
+
+  .measure {
+    inline-size: 100%;
+    margin-block: 1rem;
+    border: 4px solid currentcolor;
+    padding: 1rem;
+  }
+
+  form {
+    display: grid;
+    gap: 0.5rem;
+    margin-block-start: 1rem;
+  }
+`;
+
+const previewDocument = (css = '') => `
+<!doctype html>
+<html lang="nb">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://altinncdn.no/fonts/inter/v4/inter.css" />
+    <style>${css}\n${previewCss}</style>
+  </head>
+  <body>${previewMarkup}</body>
+</html>`;
+
+document.querySelector('[data-baseline-preview="browser"]').srcdoc =
+  previewDocument();
+document.querySelector('[data-baseline-preview="udir"]').srcdoc =
+  previewDocument(`${themeCss}\n${digdirBaseCss}\n${baselineCss}`);

--- a/test-apps/vite-vanilla/src/style.css
+++ b/test-apps/vite-vanilla/src/style.css
@@ -2,14 +2,46 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  min-height: 100%;
   background-color: var(--ds-color-neutral-background-default);
 }
 
 body {
   background: transparent;
-  font-family: 'Inter', sans-serif;
-  font-feature-settings: 'cv05' 1; /* Enable lowercase l with tail */
+}
+
+.baseline-comparison {
+  margin-block-start: var(--ds-size-6);
+}
+
+.baseline-comparison__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ds-size-4);
+}
+
+.baseline-comparison figure {
+  min-inline-size: 0;
+  margin: 0;
+}
+
+.baseline-comparison figcaption {
+  margin-block-end: var(--ds-size-2);
+  font-weight: 600;
+}
+
+.baseline-comparison iframe {
+  display: block;
+  inline-size: 100%;
+  block-size: 48rem;
+  border: 1px solid var(--ds-color-border-default);
+  background: white;
+}
+
+@media (max-width: 48rem) {
+  .baseline-comparison__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .symbol-box {


### PR DESCRIPTION
Adds optional global baseline styles to `@udir-design/css/baseline.css`. It includes setup documentation and a visual comparison in the vanilla Vite test app showing the difference with and without the baseline.

## Based on other css resets, what should we include and exclude?

### Included

* **Global `box-sizing: border-box`**
  Makes width and height include padding and borders, which simplifies layout calculations. Apply it to pseudo-elements too.

* **`text-size-adjust: 100%` on `html`**
  Prevents inconsistent font inflation after orientation changes without interfering with user text preferences.

* **Remove the `body` margin**
  Browsers add an `8px` margin by default. Applications usually provide their own page gutters, so this avoids unexplained double spacing.

* **Udir body typography**
  Set `font-family: var(--ds-font-family)`, `line-height: var(--ds-line-height-md)`, and Udir’s Inter feature settings so application text matches components by default.

* **Token-backed text and background colors**
  Reuse the behavior already provided by Digdir’s `ds.base`, including support for Udir light and dark color schemes.

* **Font inheritance for form controls**
  Make inputs, buttons, selects, and textareas inherit document typography while preserving native appearance and behavior.

* **Responsive raster media**
  Prevent images and video from overflowing their containers. Avoid applying the same rule globally to SVGs, since they often have intentionally controlled dimensions.

* **Table border color normalization**
  Use `currentColor` to avoid subtle Chrome and Safari differences when applications add table borders.

* **Low-specificity selectors and `ds.base`**
  Use `:where()` and the existing base layer so application CSS can override the baseline without stronger selectors or `!important`.

### Excluded

* **Universal margin removal**
  `* { margin: 0 }` removes useful spacing between headings, paragraphs, lists, figures, and blockquotes.

* **Full heading and paragraph styling**
  A baseline should establish body typography, not turn every `h1` or `p` into a design-system component.

* **Removing list markers**
  Bullets and numbering communicate structure and should only be removed locally where needed.

* **Restyling all links**
  Native links remain recognizable without component CSS. Global link colors may also fail across themes and colored surfaces.

* **`appearance: none` on controls**
  Removes native affordances from controls and requires rebuilding every state accessibly.

* **Focus-outline resets**
  Browser focus indicators are an important fallback. Branded focus styles belong in components.

* **Global reduced-motion overrides**
  Setting all animation durations close to zero can break loaders, dialogs, and state transitions. Components should handle `prefers-reduced-motion` individually.

* **Forced-color overrides**
  Browsers intentionally use system colors in high-contrast mode. Only targeted component fixes should override them.

* **Font smoothing**
  `-webkit-font-smoothing` is non-standard, platform-specific, and changes perceived font weight.

* **Global `text-wrap: balance` or `pretty`**
  These are presentation choices suited to specific headings or prose, not the whole document.

* **Smooth scrolling**
  Changes application behavior and may cause motion discomfort. Applications should opt in alongside reduced-motion handling.

* **Root stacking contexts**
  Targeting `#root` or `#__next` assumes a framework and may affect portals, overlays, and `z-index`.

* **Blanket SVG and media rules**
  Global SVG rules can break icons, logos, charts, and symbol sizing.

* **`!important`**
  A baseline should be easy to override through good cascade design.
