### PR TITLE
ci: use dependabot for action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    # "/" covers .github/workflows; the glob covers our composite actions.
+    directories:
+      - /
+      - /.github/actions/*
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '23:00'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      # Matches the repo's conventional-commit convention: ci(deps): ...
+      prefix: ci
+      include: scope

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,15 +21,9 @@ jobs:
           # Setup the committers identity.
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-      - name: Update GitHub Actions
-        run: pnpm update '!*' '*/*' '!@*'
-      - name: Commit actions update if necessary
-        id: commit-actions
-        run: |
-          if ! git diff --quiet --exit-code; then
-            git commit --all -m "ci(deps): update patch and minor versions of github actions"
-            echo "committed=true" >> "$GITHUB_OUTPUT"
-          fi
+      # Note: GitHub Actions dependencies are updated by Dependabot
+      # (.github/dependabot.yml), because the automatic GITHUB_TOKEN is not
+      # allowed to push changes to files under .github/workflows.
       - name: Update npm dependencies
         run: pnpm update -r && pnpm dedupe
       - name: Commit npm update if necessary
@@ -40,7 +34,7 @@ jobs:
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create or update pull request
-        if: steps.commit-actions.outputs.committed == 'true' || steps.commit-npm.outputs.committed == 'true'
+        if: steps.commit-npm.outputs.committed == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: build/update-patch-and-minor-deps

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -42,11 +42,3 @@ jobs:
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           title: 'build: update patch and minor versions of dependencies'
           body: Updates dependencies within existing version ranges
-          # When GITHUB_TOKEN is used when creating the PR, GitHub doesn't allow
-          # further workflows to run automatically to prevent recursion.
-          # To circumvent this, the PR is created as a draft. When we manually
-          # set the PR to "ready for review", the standard CI workflow will be run.
-          # The alternatives to this is creating a machine user and an associated PAT,
-          # or creating a GitHub App. See:
-          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          draft: always-true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -191,6 +191,3 @@ trustPolicyExclude:
   # tinyexec@1.2.2 is safe according to https://github.com/tinylibs/tinyexec/issues/136
   # and https://socket.dev/npm/package/tinyexec/overview/1.2.2
   - tinyexec@1.2.2
-
-update:
-  githubActions: true


### PR DESCRIPTION
## Hva er gjort?

- [ci: go back to Dependabot for GitHub Actions updates](https://github.com/Utdanningsdirektoratet/designsystem/commit/1e2c58927a5a9a962ce4bf2a4e37b1797a7c0951)
  
  A workflow isn't allowed to touch anything in `.github` for security reasons, so the update-deps
  workflow wasn't allowed to push the changes it made after pnpm had updated actions.

- [ci: don't create update PR as draft, since GitHub now has a "Approve workflows to run" button](https://github.com/Utdanningsdirektoratet/designsystem/commit/07d81f174fb7104155f7fe66832cd96eaf17bc13)

