### PR TITLE
chore(css): declare css layer order to guard against future reordering

### DIFF
--- a/@udir-design/css/src/index.css
+++ b/@udir-design/css/src/index.css
@@ -1,3 +1,4 @@
+@layer ds, udir;
 @import './external.css';
 @import './components.css';
 @import './icons.css';


### PR DESCRIPTION
This explicitly states the layer order necessary for our Udir overrides of components to work, instead of relying on the fact that importing `@digdir/designsystemet-css` before our own component css implicitly declares that order. So if we end up reordering the import lines in the future, or a downstream minifier for some reason starts changing the order around, it will still work.