### PR TITLE
build: fix vite config warnings

### DIFF
--- a/@udir-design/react/.storybook/main.ts
+++ b/@udir-design/react/.storybook/main.ts
@@ -56,9 +56,9 @@ export default defineMain({
       : // When running locally we just get the branch name currently checked out
         execSync('git rev-parse --abbrev-ref HEAD').toString().trimEnd();
 
-    // Disable vite:dts plugin, since it logs "You are building a library that may not need to generate declaration files"
+    // Disable unplugin:dts plugin, since it logs "You are building a library that may not need to generate declaration files"
     cfg.plugins = cfg.plugins?.filter(
-      (p) => (p as Plugin).name !== 'unplugin:dts',
+      (p) => (p as Plugin).name !== 'unplugin-dts',
     );
 
     return mergeConfig(cfg, {

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -55,12 +55,11 @@
     "serve:typedoc": "pnpm dlx http-server --port=8090 -c-1 ./storybook-static/typedoc",
     "serve:docs": "pnpm dlx http-server ./storybook-static",
     "pretest": "pnpm exec playwright install --with-deps chromium",
-    "test": "vitest --outputFile.json test-reports/all.json",
+    "test": "vitest",
     "pretest:unit": "pnpm pretest",
-    "test:unit": "vitest --project unit --outputFile.json test-reports/unit.json",
+    "test:unit": "vitest --project unit",
     "pretest:storybook": "pnpm pretest",
-    "test:storybook": "vitest --project storybook --outputFile.json test-reports/storybook.json --outputFile.html test-reports/storybook/index.html",
-    "view-test-report:storybook": "pnpm dlx http-server ./test-reports/storybook"
+    "test:storybook": "vitest --project storybook"
   },
   "dependencies": {
     "@digdir/designsystemet-react": "catalog:",

--- a/@udir-design/react/turbo.json
+++ b/@udir-design/react/turbo.json
@@ -58,17 +58,12 @@
     },
     "test:storybook": {
       "dependsOn": ["build"],
-      "inputs": ["$TURBO_DEFAULT$"],
-      "outputs": ["test-reports/storybook.json", "test-reports/storybook/**"]
+      "inputs": ["$TURBO_DEFAULT$"]
     },
     "build:docs": {
       "dependsOn": ["build:storybook"],
       "inputs": ["$TURBO_DEFAULT$"],
       "outputs": ["storybook-static/typedoc/**"]
-    },
-    "view-test-report:storybook": {
-      "persistent": true,
-      "dependsOn": ["test:storybook"]
     },
     "inject": {
       "dependsOn": ["build"]

--- a/@udir-design/react/vite.config.ts
+++ b/@udir-design/react/vite.config.ts
@@ -6,7 +6,7 @@ import ts from 'typescript';
 import dts from 'unplugin-dts/vite';
 import type { Plugin } from 'vite';
 import { createFilter, defineConfig } from 'vite';
-import pkg from './package.json';
+import pkg from './package.json' with { type: 'json' };
 
 const resolveAlias = (alias: string): string =>
   path.resolve(import.meta.dirname, alias);
@@ -26,7 +26,7 @@ const dependenciesSubmodules = dependencies.map(
 );
 
 export default defineConfig({
-  root: __dirname,
+  root: import.meta.dirname,
   cacheDir: '../../node_modules/.vite/@udir-design/react',
   resolve: {
     tsconfigPaths: true,
@@ -49,7 +49,7 @@ export default defineConfig({
     react(),
     dts({
       entryRoot: 'src',
-      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+      tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),
       afterDiagnostic: (diagnostics) => {
         const errors = diagnostics.filter(
           (x) => x.category === ts.DiagnosticCategory.Error,

--- a/@udir-design/react/vitest.config.ts
+++ b/@udir-design/react/vitest.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
 import { coverageConfigDefaults, defineConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import viteConfig from './vite.config.js';
 
 export default defineConfig({
   test: {

--- a/@udir-design/react/vitest.config.ts
+++ b/@udir-design/react/vitest.config.ts
@@ -9,16 +9,13 @@ export default defineConfig({
     watch: false,
     reporters: [
       'default',
-      // html reporter has a bug in 4.0.15, which is fixed but not yet released
-      // https://github.com/vitest-dev/vitest/issues/9190
-      // [
-      //   'html',
-      //   {
-      //     addFileAttribute: true,
-      //     classnameTemplate: '{filename}',
-      //     outputFile: './test-reports/index.html',
-      //   },
-      // ],
+      [
+        'html',
+        {
+          addFileAttribute: true,
+          classnameTemplate: '{filename}',
+        },
+      ],
       [
         'json',
         {
@@ -27,6 +24,10 @@ export default defineConfig({
         },
       ],
     ],
+    outputFile: {
+      json: './test-reports/report.json',
+      html: './test-reports/index.html',
+    },
     coverage: {
       reportsDirectory: '../../coverage/@udir-design/react',
       reporter: [['json', { file: 'test-coverage.json' }]],

--- a/test-apps/vite/vite.config.ts
+++ b/test-apps/vite/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  root: __dirname,
+  root: import.meta.dirname,
   cacheDir: '../../node_modules/.vite/test-apps/vite',
   server: {
     port: 4200,
@@ -18,7 +18,7 @@ export default defineConfig({
     tsconfigPaths: true,
     alias: {
       '.storybook': path.resolve(
-        __dirname,
+        import.meta.dirname,
         '../../@udir-design/react/.storybook',
       ),
     },


### PR DESCRIPTION
- build: fix deprecation warnings in vite config files
- build: correctly remove warning about unplugin:dts being unnecessary in Storybook build
- chore: simplify test reporter setup