### PR TITLE
docs: sort "introduksjon" first within patterns root in sidebar

### DIFF
--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -53,6 +53,7 @@ export default definePreview({
           ['Retningslinjer', 'Ikoner'],
           'demo',
           'patterns',
+          ['Introduksjon'],
           'components',
         ],
       },


### PR DESCRIPTION
## Hva er gjort?
Før:
<img width="297" height="318" alt="image" src="https://github.com/user-attachments/assets/fc04db5d-3dba-4ea7-bacb-10249b1607b8" />

Etter:
<img width="297" height="318" alt="image" src="https://github.com/user-attachments/assets/460a9680-9e9a-4984-86b5-58dcbfa8ca76" />
