### PR TITLE
ci: fix workflow update-oxfmt.yml

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,6 +3,6 @@ ab1bb1e4090baaacce98cc1d89e2c619a6c0d2b9
 # style: format files with prettier 3.9.5
 56c8bfbd29e5f4a1bc5eab77c72f7da2456a9c55
 # style: format files with oxfmt 0.60.0
-66011356e9316201834b750f3d333b1730ce3277
+22ba59684bc9da7574cd7449cb505a39868d4d30
 # style: format pnpm-workspace.yaml with double quotes
 c2b52bf49733e89489c171d3102fbe0ece734941

--- a/.github/workflows/update-oxfmt.yml
+++ b/.github/workflows/update-oxfmt.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.oxfmt_run.outputs.has_changes == 1
         run: |
           git commit --all -m "style: format files with oxfmt ${{ steps.oxfmt_info.outputs.version }}"
-          echo "# $(git show -s --format='%s')\n$(git rev-parse HEAD)" >> .git-blame-ignore-revs
+          printf '# %s\n%s\n' "$(git show -s --format='%s')" "$(git rev-parse HEAD)" >> .git-blame-ignore-revs
           git commit --all -m "chore: update .git-blame-ignore-revs"
 
       - name: Create or update pull request

--- a/.github/workflows/update-oxfmt.yml
+++ b/.github/workflows/update-oxfmt.yml
@@ -32,7 +32,12 @@ jobs:
           pnpm update -r --latest oxfmt && pnpm dedupe
           git commit --all -m "build: update oxfmt to ${{ steps.oxfmt_info.outputs.version }}"
           pnpm fmt
-          echo has_changes="$(git diff --stat --exit-code)" >> "$GITHUB_OUTPUT"
+          git diff --stat
+          if git diff --quiet; then
+            echo "has_changes=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=1" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit changes and update .git-blame-ignore-revs
         if: steps.oxfmt_run.outputs.has_changes == 1


### PR DESCRIPTION
This workflow "worked" (in its earlier form update-prettier.yml) because the formatting was stable, and so the "update and format" step's output `has_changes` was empty. As soon as there were actual formatting changes, a couple logic errors appeared:
- We tried to set it to the **output** of `git diff --stat --exit-code`, which is NOT the same as the exit code. This led to the workflow failing with e.g.
  ```
  Error: Unable to process file command 'output' successfully.
  Error: Invalid format ' @udir-design/react/.storybook/utils/sourceCodeUrl.ts | 12 +++++-------'
  ```
  - This is now fixed by actually using the exit code, which is what we were trying to compare against in the conditional `if: steps.oxfmt_run.outputs.has_changes == 1`
- the `.git-blame-ignore-revs` update logic was never actually run, since it was either skipped (has_changes not equal 1) or the workflow had already failed. When it started running it revealed a bug where we added a literal `\n` instead of a line break, which would have resulted in only adding a line comment instead of an actual ignore line.
  - fixed by using `printf` instead of `echo`

Additionally, the existing `.git-blame-ignore-revs` entry for oxfmt 0.60.0 pointed to an orphaned commit, likely caused by a rebase when working on #909. This has been updated to the correct commit sha.