### PR TITLE
feat(FileUpload): add FileUpload.List with default and compact variants

### DIFF
--- a/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
@@ -77,13 +77,15 @@ export const DocumentationPage = ({
             Vedlegg ({uploadedFiles.length}):
           </Heading>
 
-          {uploadedFiles.map((file, index) => (
-            <FileUpload.Item
-              key={index}
-              file={file}
-              onRemove={() => removeFile(file)}
-            />
-          ))}
+          <FileUpload.List>
+            {uploadedFiles.map((file, index) => (
+              <FileUpload.Item
+                key={index}
+                file={file}
+                onRemove={() => removeFile(file)}
+              />
+            ))}
+          </FileUpload.List>
         </>
       )}
 
@@ -93,14 +95,16 @@ export const DocumentationPage = ({
             Vedlegg med feil:
           </Heading>
 
-          {rejected.map(({ file, errors }, index) => (
-            <FileUpload.Item
-              key={index}
-              file={file}
-              onRemove={() => removeRejected(file)}
-              error={ErrorMessages.get(errors[0].code)}
-            />
-          ))}
+          <FileUpload.List>
+            {rejected.map(({ file, errors }, index) => (
+              <FileUpload.Item
+                key={index}
+                file={file}
+                onRemove={() => removeRejected(file)}
+                error={ErrorMessages.get(errors[0].code)}
+              />
+            ))}
+          </FileUpload.List>
         </>
       )}
       <Field>

--- a/@udir-design/react/src/components/fileUpload/FileUpload.mdx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.mdx
@@ -53,11 +53,38 @@ Dersom du ønsker å begrense antall filer implementeres dette selv. Om brukeren
 
 ### Vedlegg
 
-Delkomponenten `FileUpload.Item` brukes til å vise status for filer som er lastet opp. Du kan bruke `error` til å vise feilmeldinger, for eksempel dersom filformatet ikke er riktig. Teksten under filnavnet kan settes med `description`, for eksempel til en kort beskrivelse av filen. Hvis `description` ikke er satt, vises filstørrelsen automatisk. Du kan skjule teksten helt ved å sette `description` til `null`.
+Filer som er lastet opp vises med `FileUpload.List` og én `FileUpload.Item` per fil. `FileUpload.List` viser vedleggene som en liste (`<ul>` med `<li>`), slik at skjermlesere kan lese ut hvor mange filer som er lastet opp og hvor i lista brukeren befinner seg. Derfor må `FileUpload.Item` alltid ligge inni en `FileUpload.List`.
+
+```tsx
+<FileUpload.List>
+  {files.map((file, index) => (
+    <FileUpload.Item
+      key={index}
+      file={file}
+      onRemove={() => removeFile(file)}
+    />
+  ))}
+</FileUpload.List>
+```
 
 Filnavnet er en [`Link`](/docs/components-link--docs) med `download`-attributtet, slik at brukeren kan laste ned en kopi av filen ved å klikke på navnet.
 
+Vi viser filstørrelsen automatisk. Dersom du vil vise noe annet i stedet for filstørrelsen, for eksempel en kort beskrivelse av filen, kan du sette `description`. Du kan fjerne filstørrelsen ved å sette `description` til `null`.
+
+Du kan bruke `error` til å vise feilmeldinger, for eksempel dersom filformatet ikke er riktig.
+
 <Canvas of={FileUploadStories.ExampleItems} />
+
+### Visningsvarianter
+
+`FileUpload.List` har to visninger, som du velger med `variant`:
+
+- `default` viser hver fil som sitt eget kort.
+- `compact` samler filene i ett kort, med linjer mellom hver fil. Denne visningen egner seg godt når mange filer skal vises.
+
+Visningene støtter det samme, så du kan bytte mellom dem uten å endre på `FileUpload.Item`.
+
+<Canvas of={FileUploadStories.CompactList} />
 
 ### Tilstand for lasting
 

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -6,8 +6,10 @@ import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Heading } from 'src/components/typography/heading';
+import { Prose } from '../typography/prose';
 import { FileUploadDropzone } from './docs/FakeFileUploadDropzone';
 import { FileUploadItem } from './docs/FakeFileUploadItem';
+import { FileUploadList } from './docs/FakeFileUploadList';
 import { FileUploadTrigger } from './docs/FakeFileUploadTrigger';
 import { FileUpload } from './index';
 
@@ -15,6 +17,7 @@ const meta = preview.meta({
   component: FileUploadTrigger,
   subcomponents: {
     'FileUpload.Dropzone': FileUploadDropzone,
+    'FileUpload.List': FileUploadList,
     'FileUpload.Item': FileUploadItem,
   },
   tags: ['udir'],
@@ -167,13 +170,15 @@ export const ExampleDropZone = meta.story({
             <Heading level={3} data-size="2xs">
               Vedlegg ({files.length}):
             </Heading>
-            {files.map((file, index) => (
-              <FileUpload.Item
-                key={index}
-                file={file}
-                onRemove={() => removeFile(file)}
-              />
-            ))}
+            <FileUpload.List>
+              {files.map((file, index) => (
+                <FileUpload.Item
+                  key={index}
+                  file={file}
+                  onRemove={() => removeFile(file)}
+                />
+              ))}
+            </FileUpload.List>
           </>
         )}
         {rejected.length > 0 && (
@@ -181,14 +186,16 @@ export const ExampleDropZone = meta.story({
             <Heading level={3} data-size="2xs">
               Vedlegg med feil:
             </Heading>
-            {rejected.map(({ file, errors }, index) => (
-              <FileUpload.Item
-                key={index}
-                file={file}
-                onRemove={() => removeRejected(file)}
-                error={ErrorMessages.get(errors[0].code)}
-              />
-            ))}
+            <FileUpload.List>
+              {rejected.map(({ file, errors }, index) => (
+                <FileUpload.Item
+                  key={index}
+                  file={file}
+                  onRemove={() => removeRejected(file)}
+                  error={ErrorMessages.get(errors[0].code)}
+                />
+              ))}
+            </FileUpload.List>
           </>
         )}
       </>
@@ -287,13 +294,15 @@ export const TooManyFiles = meta.story({
               <Heading level={3} data-size="2xs">
                 Vedlegg ({files.length}):
               </Heading>
-              {files.map((file, index) => (
-                <FileUpload.Item
-                  key={index}
-                  file={file}
-                  onRemove={() => removeFile(file)}
-                />
-              ))}
+              <FileUpload.List>
+                {files.map((file, index) => (
+                  <FileUpload.Item
+                    key={index}
+                    file={file}
+                    onRemove={() => removeFile(file)}
+                  />
+                ))}
+              </FileUpload.List>
             </>
           )}
         </div>
@@ -349,7 +358,9 @@ export const ExampleTrigger = meta.story({
               <Heading level={3} data-size="2xs">
                 Vedlegg (1):
               </Heading>
-              <FileUpload.Item file={file} onRemove={() => setFile(null)} />
+              <FileUpload.List>
+                <FileUpload.Item file={file} onRemove={() => setFile(null)} />
+              </FileUpload.List>
             </>
           )}
         </div>
@@ -378,7 +389,7 @@ export const ExampleTrigger = meta.story({
 
 export const ExampleItems = meta.story({
   parameters: { docs: advancedCodeDocs },
-  render: (args) => {
+  render: () => {
     const dummyFiles: File[] = [
       new File(['abc'.repeat(100000)], 'eksempel1.pdf'),
       new File(['abc'.repeat(10000)], 'eksempel2.docx'),
@@ -420,16 +431,18 @@ export const ExampleItems = meta.story({
               <Heading level={3} data-size="2xs">
                 Vedlegg ({files.length}):
               </Heading>
-              {files.map((file, index) => (
-                <FileUpload.Item
-                  key={index}
-                  file={file}
-                  description={`Filopplasting ${index + 1}`}
-                  readonly={index === 2 && true}
-                  loading={index === 3 && true}
-                  onRemove={() => removeFile(file)}
-                />
-              ))}
+              <FileUpload.List>
+                {files.map((file, index) => (
+                  <FileUpload.Item
+                    key={index}
+                    file={file}
+                    description={`Filopplasting ${index + 1}`}
+                    readonly={index === 2 && true}
+                    loading={index === 3 && true}
+                    onRemove={() => removeFile(file)}
+                  />
+                ))}
+              </FileUpload.List>
             </>
           )}
           {rejected.length > 0 && (
@@ -441,15 +454,16 @@ export const ExampleItems = meta.story({
               >
                 Vedlegg med feil:
               </Heading>
-              {rejected.map((file, index) => (
-                <FileUpload.Item
-                  {...args}
-                  key={index}
-                  file={file}
-                  onRemove={() => removeRejected(file)}
-                  error={'Filformatet støttes ikke'}
-                />
-              ))}
+              <FileUpload.List>
+                {rejected.map((file, index) => (
+                  <FileUpload.Item
+                    key={index}
+                    file={file}
+                    onRemove={() => removeRejected(file)}
+                    error={'Filformatet støttes ikke'}
+                  />
+                ))}
+              </FileUpload.List>
             </>
           )}
         </div>
@@ -489,13 +503,26 @@ export const ExampleItems = meta.story({
       await expect(busyItem).toBeInTheDocument();
     });
 
-    await step('Error item has aria-invalid set', async () => {
-      const invalidItem = canvasElement.querySelector('[aria-invalid="true"]');
+    await step('Error item is marked as invalid', async () => {
+      const invalidItem = canvasElement.querySelector('[data-invalid]');
       await expect(invalidItem).toBeInTheDocument();
     });
 
     await step('Description is shown for normal items', async () => {
       await expect(canvas.getByText('Filopplasting 1')).toBeInTheDocument();
+    });
+
+    await step('Files are exposed as lists of cards', async () => {
+      const [files, rejected] = canvas.getAllByRole('list');
+      await expect(within(files).getAllByRole('listitem')).toHaveLength(4);
+      await expect(within(rejected).getAllByRole('listitem')).toHaveLength(1);
+
+      /* Both variants render the same cards; the compact variant only
+         collapses them together in CSS. */
+      await expect(files).not.toHaveClass('ds-card');
+      for (const item of within(files).getAllByRole('listitem')) {
+        await expect(item).toHaveClass('ds-card');
+      }
     });
 
     await step('Clicking remove deletes the file from the list', async () => {
@@ -547,11 +574,13 @@ export const Upload = meta.story({
               <Heading level={3} data-size="2xs">
                 Vedlegg (1):
               </Heading>
-              <FileUpload.Item
-                loading={loading}
-                file={file}
-                onRemove={() => setFile(null)}
-              />
+              <FileUpload.List>
+                <FileUpload.Item
+                  loading={loading}
+                  file={file}
+                  onRemove={() => setFile(null)}
+                />
+              </FileUpload.List>
             </>
           )}
         </div>
@@ -578,10 +607,96 @@ export const Upload = meta.story({
       await expect(await canvas.findByText('rapport.pdf')).toBeInTheDocument();
     });
 
+    await step('A single file is still exposed as a list', async () => {
+      const list = canvas.getByRole('list');
+      await expect(within(list).getAllByRole('listitem')).toHaveLength(1);
+    });
+
     await step('Item shows loading spinner after upload', async () => {
       await expect(
         canvas.getByRole('img', { name: 'spinner' }),
       ).toBeInTheDocument();
+    });
+  },
+});
+
+export const CompactList = meta.story({
+  parameters: { docs: advancedCodeDocs },
+  args: {
+    'data-size': 'md',
+  },
+  render: (args) => {
+    const dummyFiles = [
+      { file: new File(['abc'.repeat(100000)], 'kandidat-12.pdf') },
+      { file: new File(['abc'.repeat(100000)], 'kandidat-13.pdf') },
+      { file: new File(['abc'.repeat(100000)], 'kandidat-14.pdf') },
+      { file: new File(['abc'.repeat(100000)], 'kandidat-15.pdf') },
+      {
+        file: new File(['abc'.repeat(288000)], 'kandidat-16.tsx'),
+        error: 'Filformatet støttes ikke',
+      },
+    ];
+
+    const [files, setFiles] = useState(dummyFiles);
+
+    const removeFile = (fileToRemove: File) => {
+      setFiles((prev) => prev.filter(({ file }) => file !== fileToRemove));
+    };
+
+    return (
+      <Prose>
+        <Heading level={3} data-size="2xs">
+          Vedlegg ({files.length}):
+        </Heading>
+        <FileUpload.List variant="compact" data-size={args['data-size']}>
+          {files.map(({ file, error }, index) => (
+            <FileUpload.Item
+              key={index}
+              file={file}
+              error={error}
+              onRemove={() => removeFile(file)}
+            />
+          ))}
+        </FileUpload.List>
+      </Prose>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Files are exposed as a list', async () => {
+      const list = canvas.getByRole('list');
+      await expect(list.tagName).toBe('UL');
+      await expect(within(list).getAllByRole('listitem')).toHaveLength(5);
+    });
+
+    await step(
+      'Compact variant renders one card with the files as blocks',
+      async () => {
+        const list = canvas.getByRole('list');
+        await expect(list).not.toHaveClass('ds-card');
+
+        const [first, second] = within(list).getAllByRole('listitem');
+        await expect(first).toHaveClass('ds-card');
+        await expect(second).toHaveClass('ds-card');
+
+        /* Every item keeps its own card border, but the border between two
+           items is dropped so they read as one card divided by lines. */
+        await expect(getComputedStyle(first).borderBlockStartWidth).not.toBe(
+          '0px',
+        );
+        await expect(getComputedStyle(second).borderBlockStartWidth).toBe(
+          '0px',
+        );
+      },
+    );
+
+    await step('Clicking remove deletes the file from the list', async () => {
+      const [removeButton] = canvas.getAllByRole('button');
+      await userEvent.click(removeButton);
+      await expect(
+        canvas.queryByText('kandidat-12.pdf'),
+      ).not.toBeInTheDocument();
     });
   },
 });

--- a/@udir-design/react/src/components/fileUpload/FileUpload.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.tsx
@@ -1,5 +1,6 @@
 import { FileUploadDropzone } from './FileUploadDropzone';
 import { FileUploadItem } from './FileUploadItem';
+import { FileUploadList } from './FileUploadList';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type FileUpload = {
@@ -20,20 +21,36 @@ export type FileUpload = {
   Dropzone: typeof FileUploadDropzone;
   /**
    * Component that previews a file
-   * uploaded by the user
+   * uploaded by the user.
+   *
+   * Must be placed inside a `FileUpload.List`.
    *
    * @example
    * <FileUpload.Item />
    */
   Item: typeof FileUploadItem;
+  /**
+   * Component that groups uploaded files as a list.
+   *
+   * Use `variant` to switch between one card per file (`default`) and a single
+   * card with the files divided by lines (`compact`).
+   *
+   * @example
+   * <FileUpload.List variant="compact">
+   *   <FileUpload.Item file={file} onRemove={handleRemove} />
+   * </FileUpload.List>
+   */
+  List: typeof FileUploadList;
 };
 
 export const FileUpload: FileUpload = {
   Trigger: FileUploadTrigger,
   Dropzone: FileUploadDropzone,
   Item: FileUploadItem,
+  List: FileUploadList,
 };
 
 FileUpload.Trigger.displayName = 'FileUpload.Trigger';
 FileUpload.Dropzone.displayName = 'FileUpload.Dropzone';
 FileUpload.Item.displayName = 'FileUpload.Item';
+FileUpload.List.displayName = 'FileUpload.List';

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -16,7 +16,6 @@ import {
   XMarkOctagonFillIcon,
 } from '@udir-design/icons';
 import { Button } from '../button';
-import { Card } from '../card';
 import { Link } from '../link';
 import { Spinner } from '../spinner';
 
@@ -25,13 +24,14 @@ import { Spinner } from '../spinner';
  */
 
 export interface FileUploadItemProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
+  HTMLAttributes<HTMLLIElement>,
   'data-color'
 > {
   'data-size'?: Size;
   /**
-   * Data shown below the file name. Falls back to the formatted file size if not provided.
-   * Set to `null` to hide the description entirely.
+   * Data shown with the file name: below it in the `default` list variant, inline in `compact`.
+   * Falls back to the formatted file size if not provided.
+   * Set to `null` to hide it entirely.
    */
   description?: ReactNode;
   /**
@@ -62,8 +62,8 @@ export interface FileUploadItemProps extends Omit<
   href?: string;
 }
 
-export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
-  (
+export const FileUploadItem = forwardRef<HTMLLIElement, FileUploadItemProps>(
+  function FileUploadItem(
     {
       file,
       error,
@@ -77,24 +77,27 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
       ...rest
     }: FileUploadItemProps,
     ref,
-  ) => {
+  ) {
+    /* Composes Digdir's card class rather than the `Card` component, so the
+       item stays a plain element without React-only behaviour. `FileUpload.List`
+       restyles these cards in CSS to build the `compact` variant. */
     return (
-      <Card
-        className={cl('uds-file-upload__item', className)}
-        aria-invalid={Boolean(error)}
+      <li
+        className={cl('ds-card', 'uds-file-upload__item', className)}
+        data-invalid={Boolean(error) || undefined}
         aria-busy={Boolean(loading) || undefined}
         data-size={size}
         ref={ref}
         {...rest}
       >
-        <div>
-          <div>
+        <div className="uds-file-upload__item-row">
+          <div className="uds-file-upload__item-icon">
             <Icon file={file} showError={Boolean(error)} loading={loading} />
           </div>
-          <div>
+          <div className="uds-file-upload__item-content">
             <FileName file={file} href={href} />
             <Paragraph data-size="sm">
-              {/* Loading text in css */}
+              {/* Loading text in css. Always rendered so the ::before can hook onto it. */}
               {!loading &&
                 description !== null &&
                 (description ?? formatFileSize(file))}
@@ -116,7 +119,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
         <div
           aria-relevant="additions removals"
           aria-live="polite"
-          className="error"
+          className="uds-file-upload__item-error"
         >
           {Boolean(error) && (
             <Paragraph>
@@ -125,7 +128,7 @@ export const FileUploadItem = forwardRef<HTMLDivElement, FileUploadItemProps>(
             </Paragraph>
           )}
         </div>
-      </Card>
+      </li>
     );
   },
 );
@@ -144,7 +147,7 @@ export function formatFileSize(file: File): string | null {
   return `${(file.size / MB).toFixed(2)} MB`;
 }
 
-function Icon({
+export function Icon({
   file,
   showError,
   loading,
@@ -187,7 +190,7 @@ function Icon({
   }
 }
 
-const downloadFile = (file: File): void => {
+export const downloadFile = (file: File): void => {
   const a = document.createElement('a');
   const url = URL.createObjectURL(file);
   a.href = url;
@@ -202,7 +205,7 @@ interface FileNameProps {
   href?: string;
 }
 
-const FileName = ({ file, href }: FileNameProps) => {
+export const FileName = ({ file, href }: FileNameProps) => {
   if (href) {
     return <Link href={href}>{file.name}</Link>;
   }

--- a/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadItem.tsx
@@ -2,8 +2,7 @@ import { Paragraph, Tooltip } from '@digdir/designsystemet-react';
 import type { Size } from '@digdir/designsystemet-types';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
-import type { MouseEvent, ReactNode } from 'react';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, MouseEvent, ReactNode } from 'react';
 import {
   FileCsvIcon,
   FileExcelIcon,
@@ -44,7 +43,7 @@ export interface FileUploadItemProps extends Omit<
    */
   error?: string;
   /**
-   * Props for the delete button.
+   * Callback when the remove button is clicked.
    */
   onRemove: (file: File, event: MouseEvent<HTMLButtonElement>) => void;
   /**

--- a/@udir-design/react/src/components/fileUpload/FileUploadList.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUploadList.tsx
@@ -1,0 +1,60 @@
+import type { Size } from '@digdir/designsystemet-types';
+import cl from 'clsx/lite';
+import { forwardRef } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
+
+export type FileUploadListVariant = 'default' | 'compact';
+
+export interface FileUploadListProps extends Omit<
+  HTMLAttributes<HTMLUListElement>,
+  'data-color'
+> {
+  'data-size'?: Size;
+  /**
+   * Visual style of the list.
+   *
+   * - `default` shows every file as its own card.
+   * - `compact` collapses the files into a single card, divided by lines.
+   *   Useful when many files are uploaded.
+   *
+   * @default 'default'
+   */
+  variant?: FileUploadListVariant;
+  /**
+   * One or more `FileUpload.Item` components.
+   */
+  children: ReactNode;
+}
+
+export const FileUploadList = forwardRef<HTMLUListElement, FileUploadListProps>(
+  function FileUploadList(
+    {
+      variant = 'default',
+      className,
+      'data-size': size,
+      ...rest
+    }: FileUploadListProps,
+    ref,
+  ) {
+    return (
+      <ul
+        ref={ref}
+        /* WebKit only exposes a list if it renders visible markers, has an
+           explicit role, or sits inside <nav>. None apply here: `list-style:
+           none` removes the markers, and the items are `display: block` (via
+           `.ds-card`), which stops WebKit from creating list item markers at
+           all. So this role is not redundant, but required, and removing
+           `list-style: none` would not be an alternative fix.
+           Confirmed with VoiceOver in Safari. See `determineListRoleWithCleanChildren`:
+           https://github.com/WebKit/WebKit/blob/32b2458357b3abec6f510df7d367e7d288dd2f99/Source/WebCore/accessibility/AccessibilityNodeObject.cpp#L432-L489 */
+        // oxlint-disable-next-line jsx-a11y/no-redundant-roles
+        role="list"
+        className={cl('uds-file-upload__list', className)}
+        data-variant={variant}
+        data-size={size}
+        {...rest}
+      />
+    );
+  },
+);
+FileUploadList.displayName = 'FileUpload.List';

--- a/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
+++ b/@udir-design/react/src/components/fileUpload/__snapshots__/FileUpload.stories.tsx.snap
@@ -1,5 +1,315 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Compact List 1`] = `
+<div>
+  <h3 data-size="2xs">
+    Vedlegg (4):
+  </h3>
+  <ul
+    role="list"
+    data-variant="compact"
+    data-size="md"
+  >
+    <li>
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="kandidat-13.pdf">
+            kandidat-13.pdf
+          </a>
+          <p data-size="sm">
+            0.29 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+      </div>
+    </li>
+    <li>
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="kandidat-14.pdf">
+            kandidat-14.pdf
+          </a>
+          <p data-size="sm">
+            0.29 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+      </div>
+    </li>
+    <li>
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="kandidat-15.pdf">
+            kandidat-15.pdf
+          </a>
+          <p data-size="sm">
+            0.29 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+      </div>
+    </li>
+    <li data-invalid="true">
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v11.5c0 .69-.56 1.25-1.25 1.25h-11c-.69 0-1.25-.56-1.25-1.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h10.5V8.75zm.25-2.94 1.44 1.44h-1.44zm-.72 6.16a.75.75 0 0 1 0 1.06l-.97.97.97.97a.75.75 0 1 1-1.06 1.06l-.97-.97-.97.97a.75.75 0 1 1-1.06-1.06l.97-.97-.97-.97a.75.75 0 1 1 1.06-1.06l.97.97.97-.97a.75.75 0 0 1 1.06 0"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="kandidat-16.tsx">
+            kandidat-16.tsx
+          </a>
+          <p data-size="sm">
+            0.82 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+        <p>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M7.742 2.47a.75.75 0 0 1 .53-.22h7.456a.75.75 0 0 1 .53.22l5.272 5.272c.141.14.22.331.22.53v7.456a.75.75 0 0 1-.22.53l-5.272 5.272a.75.75 0 0 1-.53.22H8.272a.75.75 0 0 1-.53-.22L2.47 16.258a.75.75 0 0 1-.22-.53V8.272a.75.75 0 0 1 .22-.53zm1.288 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+          Filformatet støttes ikke
+        </p>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`Example Drop Zone 1`] = `
 <div>
   <label
@@ -56,76 +366,81 @@ exports[`Example Drop Zone 1`] = `
 <h3 data-size="2xs">
   Vedlegg (1):
 </h3>
-<div aria-invalid="false">
-  <div>
+<ul
+  role="list"
+  data-variant="default"
+>
+  <li>
     <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
+      <div>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+          >
+          </path>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </div>
+      <div>
+        <a download="eksempel1.pdf">
+          eksempel1.pdf
+        </a>
+        <p data-size="sm">
+          0.29 MB
+        </p>
+      </div>
+      <button
+        data-icon="true"
+        data-variant="tertiary"
+        type="button"
+        data-tooltip="Fjern filen"
+        data-placement="top"
+        data-autoplacement="true"
+        aria-label="Fjern filen"
       >
-        <path
-          fill="currentColor"
-          d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
+          height="1em"
+          fill="none"
+          viewbox="0 0 24 24"
+          focusable="false"
+          role="img"
+          aria-hidden="true"
         >
-        </path>
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+            clip-rule="evenodd"
+          >
+          </path>
+        </svg>
+      </button>
     </div>
-    <div>
-      <a download="eksempel1.pdf">
-        eksempel1.pdf
-      </a>
-      <p data-size="sm">
-        0.29 MB
-      </p>
-    </div>
-    <button
-      data-icon="true"
-      data-variant="tertiary"
-      type="button"
-      data-tooltip="Fjern filen"
-      data-placement="top"
-      data-autoplacement="true"
-      aria-label="Fjern filen"
+    <div
+      aria-relevant="additions removals"
+      aria-live="polite"
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
-    </button>
-  </div>
-  <div
-    aria-relevant="additions removals"
-    aria-live="polite"
-  >
-  </div>
-</div>
+    </div>
+  </li>
+</ul>
 `;
 
 exports[`Example Dropzone With Explicit Size 1`] = `
@@ -187,226 +502,11 @@ exports[`Example Dropzone With Explicit Size 1`] = `
 <h3 data-size="2xs">
   Vedlegg (1):
 </h3>
-<div aria-invalid="false">
-  <div>
-    <div>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
-        >
-        </path>
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
-    </div>
-    <div>
-      <a download="eksempel1.pdf">
-        eksempel1.pdf
-      </a>
-      <p data-size="sm">
-        0.29 MB
-      </p>
-    </div>
-    <button
-      data-icon="true"
-      data-variant="tertiary"
-      type="button"
-      data-tooltip="Fjern filen"
-      data-placement="top"
-      data-autoplacement="true"
-      aria-label="Fjern filen"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="1em"
-        height="1em"
-        fill="none"
-        viewbox="0 0 24 24"
-        focusable="false"
-        role="img"
-        aria-hidden="true"
-      >
-        <path
-          fill="currentColor"
-          fill-rule="evenodd"
-          d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-          clip-rule="evenodd"
-        >
-        </path>
-      </svg>
-    </button>
-  </div>
-  <div
-    aria-relevant="additions removals"
-    aria-live="polite"
-  >
-  </div>
-</div>
-`;
-
-exports[`Example Items 1`] = `
-<style>
-  .file-upload-example-items-main {
-          display: flex;
-          flex-direction: column;
-          gap: var(--ds-size-3);
-        }
-</style>
-<div>
-  <h3 data-size="2xs">
-    Vedlegg (3):
-  </h3>
-  <div aria-invalid="false">
-    <div>
-      <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
-          >
-          </path>
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </div>
-      <div>
-        <a download="eksempel2.docx">
-          eksempel2.docx
-        </a>
-        <p data-size="sm">
-          Filopplasting 1
-        </p>
-      </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        data-tooltip="Fjern filen"
-        data-placement="top"
-        data-autoplacement="true"
-        aria-label="Fjern filen"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
-  <div aria-invalid="false">
-    <div>
-      <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </div>
-      <div>
-        <a download="eksempel3.png">
-          eksempel3.png
-        </a>
-        <p data-size="sm">
-          Filopplasting 2
-        </p>
-      </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        data-tooltip="Fjern filen"
-        data-placement="top"
-        data-autoplacement="true"
-        aria-label="Fjern filen"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
-  <div aria-invalid="false">
+<ul
+  role="list"
+  data-variant="default"
+>
+  <li>
     <div>
       <div>
         <svg
@@ -434,54 +534,11 @@ exports[`Example Items 1`] = `
         </svg>
       </div>
       <div>
-        <a download="eksempel4.pdf">
-          eksempel4.pdf
+        <a download="eksempel1.pdf">
+          eksempel1.pdf
         </a>
         <p data-size="sm">
-          Filopplasting 3
-        </p>
-      </div>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
-  <h3
-    data-size="2xs"
-    style="<removed>"
-  >
-    Vedlegg med feil:
-  </h3>
-  <div aria-invalid="true">
-    <div>
-      <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v11.5c0 .69-.56 1.25-1.25 1.25h-11c-.69 0-1.25-.56-1.25-1.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h10.5V8.75zm.25-2.94 1.44 1.44h-1.44zm-.72 6.16a.75.75 0 0 1 0 1.06l-.97.97.97.97a.75.75 0 1 1-1.06 1.06l-.97-.97-.97.97a.75.75 0 1 1-1.06-1.06l.97-.97-.97-.97a.75.75 0 1 1 1.06-1.06l.97.97.97-.97a.75.75 0 0 1 1.06 0"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </div>
-      <div>
-        <a download="eksempel5.tsx">
-          eksempel5.tsx
-        </a>
-        <p data-size="sm">
-          0.82 MB
+          0.29 MB
         </p>
       </div>
       <button
@@ -517,29 +574,302 @@ exports[`Example Items 1`] = `
       aria-relevant="additions removals"
       aria-live="polite"
     >
-      <p>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M7.742 2.47a.75.75 0 0 1 .53-.22h7.456a.75.75 0 0 1 .53.22l5.272 5.272c.141.14.22.331.22.53v7.456a.75.75 0 0 1-.22.53l-5.272 5.272a.75.75 0 0 1-.53.22H8.272a.75.75 0 0 1-.53-.22L2.47 16.258a.75.75 0 0 1-.22-.53V8.272a.75.75 0 0 1 .22-.53zm1.288 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-        Filformatet støttes ikke
-      </p>
     </div>
-  </div>
+  </li>
+</ul>
+`;
+
+exports[`Example Items 1`] = `
+<style>
+  .file-upload-example-items-main {
+          display: flex;
+          flex-direction: column;
+          gap: var(--ds-size-3);
+        }
+</style>
+<div>
+  <h3 data-size="2xs">
+    Vedlegg (3):
+  </h3>
+  <ul
+    role="list"
+    data-variant="default"
+  >
+    <li>
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel2.docx">
+            eksempel2.docx
+          </a>
+          <p data-size="sm">
+            Filopplasting 1
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+      </div>
+    </li>
+    <li>
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel3.png">
+            eksempel3.png
+          </a>
+          <p data-size="sm">
+            Filopplasting 2
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+      </div>
+    </li>
+    <li>
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel4.pdf">
+            eksempel4.pdf
+          </a>
+          <p data-size="sm">
+            Filopplasting 3
+          </p>
+        </div>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+      </div>
+    </li>
+  </ul>
+  <h3
+    data-size="2xs"
+    style="<removed>"
+  >
+    Vedlegg med feil:
+  </h3>
+  <ul
+    role="list"
+    data-variant="default"
+  >
+    <li data-invalid="true">
+      <div>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v11.5c0 .69-.56 1.25-1.25 1.25h-11c-.69 0-1.25-.56-1.25-1.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h10.5V8.75zm.25-2.94 1.44 1.44h-1.44zm-.72 6.16a.75.75 0 0 1 0 1.06l-.97.97.97.97a.75.75 0 1 1-1.06 1.06l-.97-.97-.97.97a.75.75 0 1 1-1.06-1.06l.97-.97-.97-.97a.75.75 0 1 1 1.06-1.06l.97.97.97-.97a.75.75 0 0 1 1.06 0"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel5.tsx">
+            eksempel5.tsx
+          </a>
+          <p data-size="sm">
+            0.82 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
+      </div>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
+        <p>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M7.742 2.47a.75.75 0 0 1 .53-.22h7.456a.75.75 0 0 1 .53.22l5.272 5.272c.141.14.22.331.22.53v7.456a.75.75 0 0 1-.22.53l-5.272 5.272a.75.75 0 0 1-.53.22H8.272a.75.75 0 0 1-.53-.22L2.47 16.258a.75.75 0 0 1-.22-.53V8.272a.75.75 0 0 1 .22-.53zm1.288 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+          Filformatet støttes ikke
+        </p>
+      </div>
+    </li>
+  </ul>
 </div>
 `;
 
@@ -600,71 +930,76 @@ exports[`Example Trigger 1`] = `
   <h3 data-size="2xs">
     Vedlegg (1):
   </h3>
-  <div aria-invalid="false">
-    <div>
+  <ul
+    role="list"
+    data-variant="default"
+  >
+    <li>
       <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
-            clip-rule="evenodd"
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
           >
-          </path>
-        </svg>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel1.png">
+            eksempel1.png
+          </a>
+          <p data-size="sm">
+            0.29 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
       </div>
-      <div>
-        <a download="eksempel1.png">
-          eksempel1.png
-        </a>
-        <p data-size="sm">
-          0.29 MB
-        </p>
-      </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        data-tooltip="Fjern filen"
-        data-placement="top"
-        data-autoplacement="true"
-        aria-label="Fjern filen"
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
+      </div>
+    </li>
+  </ul>
 </div>
 `;
 
@@ -923,211 +1258,216 @@ exports[`Too Many Files 1`] = `
   <h3 data-size="2xs">
     Vedlegg (3):
   </h3>
-  <div aria-invalid="false">
-    <div>
+  <ul
+    role="list"
+    data-variant="default"
+  >
+    <li>
       <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel1.pdf">
+            eksempel1.pdf
+          </a>
+          <p data-size="sm">
+            0.29 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
         >
-          <path
-            fill="currentColor"
-            d="M7.7 14.835q.336 0 .532.189a.63.63 0 0 1 .203.49.65.65 0 0 1-.203.497q-.196.182-.532.182h-.693v-1.358zM12.002 14.87q.323 0 .518.182a.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.609v-3.15z"
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
           >
-          </path>
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-6.112 8.283a2.04 2.04 0 0 0-.938-.203H5.957V19h1.05v-1.862H7.7q.54 0 .938-.203.4-.203.623-.567a1.6 1.6 0 0 0 .224-.854q0-.49-.224-.854a1.47 1.47 0 0 0-.623-.567m4.288 0a2 2 0 0 0-.924-.203h-1.659V19h1.66q.531 0 .923-.203.4-.21.616-.581.224-.37.224-.861v-1.827a1.6 1.6 0 0 0-.224-.861 1.47 1.47 0 0 0-.616-.574M14.8 19v-5.11h3.29v.98h-2.254v1.134h2.072v.98H15.85V19z"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
       </div>
-      <div>
-        <a download="eksempel1.pdf">
-          eksempel1.pdf
-        </a>
-        <p data-size="sm">
-          0.29 MB
-        </p>
-      </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        data-tooltip="Fjern filen"
-        data-placement="top"
-        data-autoplacement="true"
-        aria-label="Fjern filen"
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
-  <div aria-invalid="false">
-    <div>
-      <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
-          >
-          </path>
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </div>
+    </li>
+    <li>
       <div>
-        <a download="eksempel2.docx">
-          eksempel2.docx
-        </a>
-        <p data-size="sm">
-          8.79 KB
-        </p>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              d="M12.47 18q-.153.16-.468.16t-.476-.16q-.154-.17-.154-.47v-2.17q0-.308.154-.469t.476-.16.476.16.154.47v2.17q0 .3-.161.468M7.595 14.87a.73.73 0 0 1 .518.182.62.62 0 0 1 .196.476v1.827q0 .3-.196.483a.73.73 0 0 1-.518.182h-.61v-3.15z"
+            >
+            </path>
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M5.25 4.5c0-.69.56-1.25 1.25-1.25H14a.75.75 0 0 1 .53.22l4 4c.141.14.22.331.22.53v4.25H21a.75.75 0 0 1 .75.75v7a.75.75 0 0 1-.75.75H3a.75.75 0 0 1-.75-.75v-7a.75.75 0 0 1 .75-.75h2.25zm9.25 4.25c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v7.5h10.5v-3.5zm.25-2.94 1.44 1.44h-1.44zm-3.637 13.071q.378.19.889.19.517 0 .889-.19.378-.195.58-.539.21-.35.21-.812v-2.17q0-.462-.21-.805a1.35 1.35 0 0 0-.58-.539 1.9 1.9 0 0 0-.89-.196q-.51 0-.888.196a1.4 1.4 0 0 0-.588.54 1.55 1.55 0 0 0-.203.804v2.17q0 .462.203.812.21.343.588.54m-2.594-4.788a2 2 0 0 0-.924-.203h-1.66V19h1.66q.531 0 .924-.203.398-.21.616-.58.224-.372.224-.862v-1.827a1.6 1.6 0 0 0-.224-.86 1.47 1.47 0 0 0-.616-.575m7.918 4.977q-.511 0-.896-.189a1.5 1.5 0 0 1-.602-.539 1.55 1.55 0 0 1-.21-.812v-2.17q0-.469.21-.812.217-.343.602-.532.385-.196.896-.196.518 0 .896.196.385.189.595.532.217.344.217.812h-1.05q0-.308-.175-.469-.168-.16-.483-.16t-.49.16q-.168.16-.168.47v2.17q0 .3.168.468.175.16.49.161.315 0 .483-.16.175-.17.175-.47h1.05q0 .462-.217.812-.21.343-.595.54-.378.188-.896.188"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel2.docx">
+            eksempel2.docx
+          </a>
+          <p data-size="sm">
+            8.79 KB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
       </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        data-tooltip="Fjern filen"
-        data-placement="top"
-        data-autoplacement="true"
-        aria-label="Fjern filen"
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
-  <div aria-invalid="false">
-    <div>
-      <div>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
       </div>
+    </li>
+    <li>
       <div>
-        <a download="eksempel3.png">
-          eksempel3.png
-        </a>
-        <p data-size="sm">
-          2.86 MB
-        </p>
+        <div>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M6.5 3.25c-.69 0-1.25.56-1.25 1.25v15c0 .69.56 1.25 1.25 1.25h11c.69 0 1.25-.56 1.25-1.25V8a.75.75 0 0 0-.22-.53l-4-4a.75.75 0 0 0-.53-.22zm10.75 15.763V8.75H14.5c-.69 0-1.25-.56-1.25-1.25V4.75h-6.5v14.5h1.855l3.777-5.666a.75.75 0 0 1 1.248 0zm-6.842.237h5.197l-2.599-3.898zm5.781-12L14.75 5.81v1.44zM10 9.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5m-2.25.75a2.25 2.25 0 1 1 4.5 0 2.25 2.25 0 0 1-4.5 0"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </div>
+        <div>
+          <a download="eksempel3.png">
+            eksempel3.png
+          </a>
+          <p data-size="sm">
+            2.86 MB
+          </p>
+        </div>
+        <button
+          data-icon="true"
+          data-variant="tertiary"
+          type="button"
+          data-tooltip="Fjern filen"
+          data-placement="top"
+          data-autoplacement="true"
+          aria-label="Fjern filen"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            fill="none"
+            viewbox="0 0 24 24"
+            focusable="false"
+            role="img"
+            aria-hidden="true"
+          >
+            <path
+              fill="currentColor"
+              fill-rule="evenodd"
+              d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
+              clip-rule="evenodd"
+            >
+            </path>
+          </svg>
+        </button>
       </div>
-      <button
-        data-icon="true"
-        data-variant="tertiary"
-        type="button"
-        data-tooltip="Fjern filen"
-        data-placement="top"
-        data-autoplacement="true"
-        aria-label="Fjern filen"
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="1em"
-          height="1em"
-          fill="none"
-          viewbox="0 0 24 24"
-          focusable="false"
-          role="img"
-          aria-hidden="true"
-        >
-          <path
-            fill="currentColor"
-            fill-rule="evenodd"
-            d="M4.5 6.25a.75.75 0 0 0 0 1.5h.805l.876 11.384a1.75 1.75 0 0 0 1.745 1.616h8.148a1.75 1.75 0 0 0 1.745-1.616l.876-11.384h.805a.75.75 0 0 0 0-1.5h-2.75V6A2.75 2.75 0 0 0 14 3.25h-4A2.75 2.75 0 0 0 7.25 6v.25zm5.5-1.5c-.69 0-1.25.56-1.25 1.25v.25h6.5V6c0-.69-.56-1.25-1.25-1.25zm-3.19 3 .867 11.27c.01.13.118.23.249.23h8.148c.13 0 .24-.1.25-.23l.866-11.27zm3.19 2a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75m4 0a.75.75 0 0 1 .75.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 .75-.75"
-            clip-rule="evenodd"
-          >
-          </path>
-        </svg>
-      </button>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
+      </div>
+    </li>
+  </ul>
 </div>
 `;
 
@@ -1185,48 +1525,50 @@ exports[`Upload 1`] = `
   <h3 data-size="2xs">
     Vedlegg (1):
   </h3>
-  <div
-    aria-invalid="false"
-    aria-busy="true"
+  <ul
+    role="list"
+    data-variant="default"
   >
-    <div>
+    <li aria-busy="true">
       <div>
-        <svg
-          aria-label="spinner"
-          role="img"
-          viewbox="0 0 50 50"
-        >
-          <circle
-            cx="25"
-            cy="25"
-            r="20"
-            fill="none"
-            stroke-width="5"
+        <div>
+          <svg
+            aria-label="spinner"
+            role="img"
+            viewbox="0 0 50 50"
           >
-          </circle>
-          <circle
-            cx="25"
-            cy="25"
-            r="20"
-            fill="none"
-            stroke-width="5"
-          >
-          </circle>
-        </svg>
+            <circle
+              cx="25"
+              cy="25"
+              r="20"
+              fill="none"
+              stroke-width="5"
+            >
+            </circle>
+            <circle
+              cx="25"
+              cy="25"
+              r="20"
+              fill="none"
+              stroke-width="5"
+            >
+            </circle>
+          </svg>
+        </div>
+        <div>
+          <a download="rapport.pdf">
+            rapport.pdf
+          </a>
+          <p data-size="sm">
+          </p>
+        </div>
       </div>
-      <div>
-        <a download="rapport.pdf">
-          rapport.pdf
-        </a>
-        <p data-size="sm">
-        </p>
+      <div
+        aria-relevant="additions removals"
+        aria-live="polite"
+      >
       </div>
-    </div>
-    <div
-      aria-relevant="additions removals"
-      aria-live="polite"
-    >
-    </div>
-  </div>
+    </li>
+  </ul>
 </div>
 `;

--- a/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadList.tsx
+++ b/@udir-design/react/src/components/fileUpload/docs/FakeFileUploadList.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { FileUploadListProps } from '..';
+
+/**
+ * This component only exists to add relevant html props for FileUpload.List
+ */
+export const FileUploadList: FunctionComponent<FileUploadListProps> = () =>
+  null;

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -121,8 +121,8 @@
     }
   }
 
-  /* 
-  * Override opacity for label and description when disabled, 
+  /*
+  * Override opacity for label and description when disabled,
   * to ensure they are still readable since disabled button is used for readOnly.
   */
   > label,
@@ -203,54 +203,130 @@
   }
 }
 
+/* FileUpload.List */
+.uds-file-upload__list {
+  /* Icon size and the matching indent used to align the error message with the
+     file name. Overridden by the compact variant below. */
+  --udsc-fileUpload-item-icon-size: var(--ds-size-10);
+  --udsc-fileUpload-item-icon-gap: var(--ds-size-3);
+
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+
+  &[data-variant='default'] {
+    gap: var(--ds-size-3);
+
+    > .uds-file-upload__item {
+      max-width: 30rem;
+
+      &[data-invalid] {
+        --dsc-card-border-color: var(--ds-color-danger-border-strong);
+      }
+    }
+  }
+
+  /* Collapses the item cards into what reads as a single card, with the files
+     divided by lines. Each item keeps its own card border; dropping the border
+     between them leaves exactly one line, so no card styling is duplicated. */
+  &[data-variant='compact'] {
+    --udsc-fileUpload-item-icon-size: var(--ds-size-8);
+    --udsc-fileUpload-item-icon-gap: var(--ds-size-4);
+
+    > .uds-file-upload__item {
+      /* Must be set on the item, not the list: the item is itself a `.ds-card`,
+         which declares `--dsc-card-padding` locally and would shadow an
+         inherited value. */
+      --dsc-card-padding: var(--ds-size-3) var(--ds-size-6);
+
+      border-radius: 0;
+
+      &:not(:first-child) {
+        border-block-start-width: 0;
+      }
+
+      &:first-child {
+        border-start-start-radius: var(--dsc-card-border-radius);
+        border-start-end-radius: var(--dsc-card-border-radius);
+      }
+
+      &:last-child {
+        border-end-start-radius: var(--dsc-card-border-radius);
+        border-end-end-radius: var(--dsc-card-border-radius);
+      }
+    }
+
+    .uds-file-upload__item-error > p {
+      font-size: var(--ds-font-size-minus-1);
+    }
+  }
+}
+
 /* FileUpload.Item */
 .uds-file-upload__item {
+  word-break: break-all;
+
   [data-tooltip] {
     --ds-tooltip: var(--udsc-fileUpload-removeFile-text);
   }
-  padding: var(--ds-size-6);
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  max-width: 30rem;
-  word-break: break-all;
 
   /* Uploading text in the paragraph after link */
   &[aria-busy='true'] .ds-link + .ds-paragraph::before {
     content: var(--udsc-fileUpload-uploading-text);
   }
+}
 
-  > div {
-    display: flex;
-    align-items: center;
-    width: 100%;
-  }
+.uds-file-upload__item-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
 
-  > div > div > svg {
-    width: auto;
-    height: var(--ds-size-10);
-    margin-inline-end: var(--ds-size-3);
-    align-self: center;
-  }
-
-  &[aria-invalid='true'] {
-    --dsc-card-border-color: var(--ds-color-danger-border-strong);
-
-    > div:last-of-type > p {
-      padding-inline-start: var(--ds-size-12);
-      color: var(--ds-color-danger-text-subtle);
-      display: flex;
-      gap: var(--ds-size-2);
-      margin-block-start: var(--ds-size-1);
-      align-items: center;
-    }
-  }
-
-  > div > .ds-button {
+  > .ds-button {
     margin-inline-start: auto;
   }
+}
 
-  > * + * {
-    margin-block-start: 0;
+.uds-file-upload__item-icon > svg {
+  width: auto;
+  height: var(--udsc-fileUpload-item-icon-size);
+  margin-inline-end: var(--udsc-fileUpload-item-icon-gap);
+  display: block;
+  align-self: center;
+}
+
+.uds-file-upload__item-content {
+  min-width: 0;
+  flex: 1;
+}
+
+.uds-file-upload__item-error {
+  margin-block-start: 0;
+
+  > p {
+    padding-inline-start: calc(
+      var(--udsc-fileUpload-item-icon-size) +
+        var(--udsc-fileUpload-item-icon-gap)
+    );
+    color: var(--ds-color-danger-text-subtle);
+    display: flex;
+    gap: var(--ds-size-2);
+    margin-block-start: var(--ds-size-1);
+    align-items: center;
+  }
+}
+
+/* Variant: compact — one card for the whole list, description inline */
+.uds-file-upload__list[data-variant='compact'] .uds-file-upload__item-content {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-3);
+  flex-wrap: wrap;
+
+  > .ds-paragraph {
+    color: var(--ds-color-neutral-text-subtle);
+    white-space: nowrap;
   }
 }

--- a/@udir-design/react/src/components/fileUpload/index.ts
+++ b/@udir-design/react/src/components/fileUpload/index.ts
@@ -1,9 +1,20 @@
 import { FileUpload } from './FileUpload';
 import { FileUploadDropzone } from './FileUploadDropzone';
 import { FileUploadItem } from './FileUploadItem';
+import { FileUploadList } from './FileUploadList';
 import { FileUploadTrigger } from './FileUploadTrigger';
 
 export type { FileUploadProps } from './FileUploadTrigger';
 export type { FileUploadDropzoneProps } from './FileUploadDropzone';
 export type { FileUploadItemProps } from './FileUploadItem';
-export { FileUpload, FileUploadDropzone, FileUploadItem, FileUploadTrigger };
+export type {
+  FileUploadListProps,
+  FileUploadListVariant,
+} from './FileUploadList';
+export {
+  FileUpload,
+  FileUploadDropzone,
+  FileUploadItem,
+  FileUploadList,
+  FileUploadTrigger,
+};


### PR DESCRIPTION
Closes #856 

## Hva er gjort?

New component FileUpload.List with `default` and `compact` variants

`FileUpload.List` groups uploaded files as a list (`<ul>` with `<li>`), so screen readers can announce how many files are uploaded and where in the list the user is.

The `variant` prop selects the presentation:

- `default` shows every file as its own card (how FileUpload.Item looked before)
- `compact` collapses the files into a single card, divided by lines. Useful when many files are uploaded.

⚠️ Important – breaking changes for consumers of the alpha `FileUpload`:

- `FileUpload.Item` must now be placed inside a `FileUpload.List`.
- Errors are marked with `data-invalid` instead of `aria-invalid`, since the latter is not a valid attribute for `role="listitem"`. Update CSS or test selectors that target `[aria-invalid]`.
- `FileUpload.Item` renders an `<li>`, so its ref and props are typed as `HTMLLIElement` rather than `HTMLDivElement`.