### PR TITLE
feat: new component RichText

### DIFF
--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -98,6 +98,7 @@
     "chromatic": "catalog:",
     "clsx": "catalog:",
     "diffable-html": "catalog:",
+    "dompurify": "catalog:",
     "dpdm": "catalog:",
     "eslint-plugin-storybook": "catalog:",
     "fuse.js": "catalog:",

--- a/@udir-design/react/src/components/alpha.ts
+++ b/@udir-design/react/src/components/alpha.ts
@@ -4,4 +4,5 @@
 
 export * from './fileUpload';
 export * from './formSummary';
+export * from './richText';
 export * from './suggestion';

--- a/@udir-design/react/src/components/richText/RichText.mdx
+++ b/@udir-design/react/src/components/richText/RichText.mdx
@@ -1,0 +1,122 @@
+import { Meta, Canvas, Controls, Unstyled } from '@storybook/addon-docs/blocks';
+import { Table } from '@udir-design/react/beta';
+import * as RichTextStories from './RichText.stories';
+
+<Meta of={RichTextStories} />
+
+# RichText
+
+`RichText` gir Udirs typografi,
+avstander og komponentstiler til semantisk HTML. Den er for eksempel nyttig for å vise innhold fra en CMS-løsning som har et riktekstredigeringsverktøy. Sanitering av innholdet må gjøres av applikasjonen før det sendes til `RichText`.
+
+## Slik bruker du RichText
+
+<Canvas
+  of={RichTextStories.Preview}
+  story={{ inline: false, height: '1000px' }}
+/>
+<Controls of={RichTextStories.Preview} />
+
+### Støttet innhold
+
+`RichText` støtter følgende HTML-elementer:
+
+<Unstyled>
+  <Table border tintedColumnHeader style={{ maxWidth: 'fit-content' }}>
+    <caption className="ds-sr-only">
+      HTML-elementer som støttes av RichText
+    </caption>
+    <Table.Head>
+      <Table.Row>
+        <Table.HeaderCell scope="col">Innholdstype</Table.HeaderCell>
+        <Table.HeaderCell scope="col">HTML-elementer</Table.HeaderCell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>Overskrifter</Table.Cell>
+        <Table.Cell>
+          <code>h2</code>, <code>h3</code>, <code>h4</code>, <code>h5</code>,{' '}
+          <code>h6</code>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Tekst</Table.Cell>
+        <Table.Cell>
+          <code>p</code>, <code>br</code>, <code>strong</code>, <code>em</code>,{' '}
+          <code>span</code>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Lenker</Table.Cell>
+        <Table.Cell>
+          <code>a</code>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Lister</Table.Cell>
+        <Table.Cell>
+          <code>ul</code>, <code>ol</code>, <code>li</code>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Sitater og skillelinjer</Table.Cell>
+        <Table.Cell>
+          <code>blockquote</code>, <code>hr</code>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Bilder</Table.Cell>
+        <Table.Cell>
+          <code>img</code>, <code>picture</code>, <code>source</code>,{' '}
+          <code>figure</code>, <code>figcaption</code>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Containers</Table.Cell>
+        <Table.Cell>
+          <code>div</code>, <code>section</code>, <code>article</code>
+        </Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table>
+</Unstyled>
+
+<br />
+
+Sidens `h1` skal ligge utenfor `RichText`. Innholdet skal ha en logisk
+overskriftstruktur uten å hoppe over nivåer.
+
+### Bruk med React
+
+`RichText` kan motta React-elementer som `children` eller HTML i `dangerouslySetInnerHTML`.
+
+```tsx
+import { RichText } from '@udir-design/react/alpha';
+
+<RichText dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />;
+```
+
+`dangerouslySetInnerHTML` skal bare brukes med innhold som applikasjonen har
+sanitert. Applikasjonen må også validere URL-protokoller i lenker og bilder.
+
+Når designsystemkomponenter som `Alert` eller `Card` brukes som `children`,
+beholder de sin egen typografi og sine egne avstander. `RichText`-stilene stopper
+ved komponenter med klasser som starter med `ds-` eller `uds-`.
+
+### Bruk uten React
+
+Bruk klassen `.uds-rich-text` på et element som omslutter HTML-en.
+
+```html
+<div class="uds-rich-text">
+  <h2>Overskrift</h2>
+  <p>Brødtekst fra publiseringsløsningen.</p>
+</div>
+```
+
+## Eksempel
+
+Eksempelet under simulerer et riktekstredigeringsverktøy hvor innholdet blir sanitert før det sendes til `RichText`. Her er det også mulighet for å sammenligne innholdet før og etter sanitering. HTML-en saniteres med [DOMPurify](https://github.com/cure53/dompurify).
+
+<Canvas of={RichTextStories.InteractiveComparison} />

--- a/@udir-design/react/src/components/richText/RichText.stories.tsx
+++ b/@udir-design/react/src/components/richText/RichText.stories.tsx
@@ -1,0 +1,317 @@
+import DOMPurify from 'dompurify';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import preview from '.storybook/preview';
+import { Field } from 'src/components/field';
+import { Textarea } from 'src/components/textarea';
+import { ToggleGroup } from 'src/components/toggleGroup';
+import { Label } from 'src/components/typography/label';
+import { RichText } from './RichText';
+
+const meta = preview.meta({
+  component: RichText,
+  tags: ['udir'],
+  parameters: {
+    componentOrigin: {
+      originator: 'self',
+    },
+    layout: 'padded',
+  },
+});
+
+export const Preview = meta.story({
+  render: (args) => (
+    <RichText {...args} data-testid="rich-text">
+      <article>
+        <div>
+          <h2>Fra idé til ferdig resultat</h2>
+          <p data-testid="paragraph">
+            Et <strong>godt resultat</strong> starter med en{' '}
+            <em>tydelig plan</em>. <a href="#steg">Se stegene i planen</a>.
+          </p>
+        </div>
+        <section>
+          <h3>Dette trenger du</h3>
+          <ul>
+            <li>et tydelig mål</li>
+            <li>
+              en enkel plan
+              <ul>
+                <li>oppgaver og tidsfrister</li>
+              </ul>
+            </li>
+          </ul>
+          <h4 id="steg">Steg for steg</h4>
+          <ol>
+            <li>Beskriv hva du vil oppnå</li>
+            <li>Del arbeidet inn i mindre oppgaver</li>
+          </ol>
+          <blockquote>
+            <p>En enkel plan gjør det lettere å komme i gang.</p>
+          </blockquote>
+          <hr data-testid="divider" />
+          <h5>Når arbeidet er ferdig</h5>
+          <figure>
+            <picture>
+              <source media="(min-width: 40rem)" srcSet="/img/feiring.svg" />
+              <img alt="Illustrasjon av en feiring" src="/img/feiring.svg" />
+            </picture>
+            <figcaption>Marker at målet er nådd.</figcaption>
+          </figure>
+        </section>
+        <div>
+          <h6>Mer informasjon</h6>
+          <p data-testid="last-paragraph">
+            Ta vare på planen slik at du kan bruke den som utgangspunkt senere.
+          </p>
+        </div>
+      </article>
+    </RichText>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const richText = canvas.getByTestId('rich-text');
+    const heading = canvas.getByRole('heading', {
+      level: 2,
+      name: 'Fra idé til ferdig resultat',
+    });
+    const sectionHeading = canvas.getByRole('heading', {
+      level: 3,
+      name: 'Dette trenger du',
+    });
+    await step('Forwards native props and applies the root class', async () => {
+      expect(richText).toHaveClass('uds-rich-text');
+    });
+
+    await step('Styles semantic content through neutral wrappers', async () => {
+      expect(getComputedStyle(heading).marginTop).toBe('0px');
+      expect(
+        Number.parseFloat(getComputedStyle(sectionHeading).marginTop),
+      ).toBeGreaterThan(0);
+      expect(getComputedStyle(canvas.getByTestId('paragraph')).marginTop).toBe(
+        '0px',
+      );
+      expect(
+        getComputedStyle(canvas.getByTestId('last-paragraph')).marginBottom,
+      ).toBe('0px');
+    });
+
+    await step('Renders every supported styled element', async () => {
+      for (const selector of [
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'p',
+        'strong',
+        'em',
+        'a',
+        'ul',
+        'ol',
+        'li',
+        'blockquote',
+        'hr',
+        'figure',
+        'picture',
+        'source',
+        'img',
+        'figcaption',
+        'div',
+        'section',
+        'article',
+      ]) {
+        expect(richText.querySelector(selector)).not.toBeNull();
+      }
+    });
+  },
+});
+
+const editableHtml = `<h2>Tilpasset opplæring</h2>
+<p>Skolen skal <strong>tilpasse opplæringen</strong> slik at alle elever får et tilfredsstillende utbytte.</p>
+<h3>Aktuelle tiltak</h3>
+<ul>
+  <li>varierte arbeidsmåter</li>
+  <li>tilpassede læremidler</li>
+</ul>
+<p><a href="https://www.udir.no/">Les mer om tilpasset opplæring på Udir.no</a>.</p>`;
+
+const sanitizeOptions = {
+  ALLOWED_TAGS: [
+    'a',
+    'article',
+    'blockquote',
+    'br',
+    'div',
+    'em',
+    'figcaption',
+    'figure',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'hr',
+    'img',
+    'li',
+    'ol',
+    'p',
+    'picture',
+    'section',
+    'source',
+    'span',
+    'strong',
+    'ul',
+  ],
+  ALLOWED_ATTR: [
+    'class',
+    'alt',
+    'height',
+    'href',
+    'id',
+    'media',
+    'rel',
+    'sizes',
+    'src',
+    'srcset',
+    'target',
+    'title',
+    'width',
+  ],
+  ALLOW_ARIA_ATTR: false,
+  ALLOW_DATA_ATTR: false,
+};
+
+export const InteractiveComparison = meta.story({
+  parameters: {
+    customStyles: {
+      width: '100%',
+    },
+  },
+  render: () => {
+    const [html, setHtml] = useState(editableHtml);
+    const [previewMode, setPreviewMode] = useState('styled');
+    const cleanHtml = DOMPurify.sanitize(html, sanitizeOptions);
+
+    return (
+      <div
+        style={{
+          display: 'grid',
+          gap: 'var(--ds-size-8)',
+          width: '100%',
+        }}
+      >
+        <Field>
+          <Label htmlFor="rich-text-html">Riktekstredigeringsverktøy</Label>
+          <Field.Description>
+            Legg inn tekst som kan formateres med HTML. Forhåndsvisning av
+            innholdet vises under.
+          </Field.Description>
+          <Textarea
+            id="rich-text-html"
+            rows={10}
+            spellCheck={false}
+            value={html}
+            onChange={(event) => setHtml(event.target.value)}
+          />
+        </Field>
+
+        <ToggleGroup
+          aria-label="Velg forhåndsvisning"
+          value={previewMode}
+          onChange={setPreviewMode}
+        >
+          <ToggleGroup.Item value="styled">Med RichText</ToggleGroup.Item>
+          <ToggleGroup.Item value="unstyled">Uten RichText</ToggleGroup.Item>
+        </ToggleGroup>
+
+        <section
+          aria-live="polite"
+          aria-label="Forhåndsvisning"
+          style={{
+            padding: 'var(--ds-size-8)',
+            border:
+              'var(--ds-border-width-default) solid var(--ds-color-border-subtle)',
+            borderRadius: 'var(--ds-border-radius-default)',
+          }}
+        >
+          {previewMode === 'styled' ? (
+            <RichText
+              data-testid="rich-text-preview"
+              dangerouslySetInnerHTML={{ __html: cleanHtml }}
+            />
+          ) : (
+            <iframe
+              data-testid="plain-html-preview"
+              onLoad={(event) => {
+                const iframe = event.currentTarget;
+                const contentHeight =
+                  iframe.contentDocument?.documentElement.scrollHeight;
+                if (contentHeight) iframe.style.height = `${contentHeight}px`;
+              }}
+              sandbox="allow-same-origin"
+              srcDoc={cleanHtml}
+              style={{ border: 0, display: 'block', width: '100%' }}
+              title="HTML uten RichText-stiler"
+            />
+          )}
+        </section>
+      </div>
+    );
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const editor = canvas.getByRole('textbox', {
+      name: 'Riktekstredigeringsverktøy',
+    });
+    const styledToggle = canvas.getByRole('radio', { name: 'Med RichText' });
+    const unstyledToggle = canvas.getByRole('radio', {
+      name: 'Uten RichText',
+    });
+
+    await step('Shows the RichText preview by default', async () => {
+      expect(styledToggle).toBeChecked();
+      expect(canvas.getByTestId('rich-text-preview')).toHaveClass(
+        'uds-rich-text',
+      );
+      expect(
+        canvas.queryByTitle('HTML uten RichText-stiler'),
+      ).not.toBeInTheDocument();
+    });
+
+    await step('Updates and sanitizes the selected preview', async () => {
+      const unsafeHtml =
+        '<h2>Oppdatert innhold</h2><img src="test.jpg" alt="Test" onerror="alert(1)"><script>alert(1)</script>';
+
+      await userEvent.clear(editor);
+      await userEvent.type(editor, unsafeHtml);
+
+      const richTextPreview = canvas.getByTestId('rich-text-preview');
+      expect(
+        within(richTextPreview).getByText('Oppdatert innhold'),
+      ).toBeVisible();
+      expect(richTextPreview.querySelector('script')).not.toBeInTheDocument();
+      expect(
+        richTextPreview.querySelector('[onerror]'),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(canvas.getByText('Uten RichText', { exact: true }));
+      expect(unstyledToggle).toBeChecked();
+
+      const plainPreview = canvas.getByTitle<HTMLIFrameElement>(
+        'HTML uten RichText-stiler',
+      );
+      await waitFor(() =>
+        expect(plainPreview.contentDocument?.body.innerHTML).toBe(
+          richTextPreview.innerHTML,
+        ),
+      );
+      expect(
+        plainPreview.contentDocument?.querySelector('script'),
+      ).not.toBeInTheDocument();
+      expect(
+        plainPreview.contentDocument?.querySelector('[onerror]'),
+      ).not.toBeInTheDocument();
+    });
+  },
+});

--- a/@udir-design/react/src/components/richText/RichText.tsx
+++ b/@udir-design/react/src/components/richText/RichText.tsx
@@ -1,0 +1,18 @@
+import cl from 'clsx/lite';
+import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+import './richText.css';
+
+export type RichTextProps = HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Presents semantic HTML with Udir's editorial styles.
+ * Consumers are responsible for sanitizing HTML before rendering it.
+ */
+export const RichText = forwardRef<HTMLDivElement, RichTextProps>(
+  function RichText({ className, ...rest }, ref) {
+    return (
+      <div className={cl('uds-rich-text', className)} ref={ref} {...rest} />
+    );
+  },
+);

--- a/@udir-design/react/src/components/richText/__snapshots__/RichText.stories.tsx.snap
+++ b/@udir-design/react/src/components/richText/__snapshots__/RichText.stories.tsx.snap
@@ -1,0 +1,150 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Interactive Comparison 1`] = `
+<div style="<removed>">
+  <ds-field>
+    <label for="<removed>">
+      Riktekstredigeringsverktøy
+    </label>
+    <div
+      data-field="description"
+      id="<removed>"
+    >
+      Legg inn tekst som kan formateres med HTML. Forhåndsvisning av innholdet vises under.
+    </div>
+    <textarea
+      id="<removed>"
+      rows="10"
+      spellcheck="false"
+      aria-describedby="<removed>"
+      style="<removed>"
+    >
+      &lt;h2>Oppdatert innhold&lt;/h2>&lt;img src="test.jpg" alt="Test" onerror="alert(1)">&lt;script>alert(1)&lt;/script>
+    </textarea>
+  </ds-field>
+  <fieldset
+    data-toggle-group="Velg forhåndsvisning"
+    data-variant="secondary"
+    aria-label="Velg forhåndsvisning"
+  >
+    <label data-variant="tertiary">
+      <input
+        type="radio"
+        value="styled"
+        checked
+        name="togglegroup-name-_r_0_"
+      >
+      Med RichText
+    </label>
+    <label data-variant="tertiary">
+      <input
+        type="radio"
+        value="unstyled"
+        name="togglegroup-name-_r_0_"
+      >
+      Uten RichText
+    </label>
+  </fieldset>
+  <section
+    aria-live="polite"
+    aria-label="Forhåndsvisning"
+    style="<removed>"
+  >
+    <iframe
+      sandbox="allow-same-origin"
+      srcdoc="<h2>Oppdatert innhold</h2><img src=&quot;test.jpg&quot; alt=&quot;Test&quot;>"
+      title="HTML uten RichText-stiler"
+      style="<removed>"
+    >
+    </iframe>
+  </section>
+</div>
+`;
+
+exports[`Preview 1`] = `
+<div>
+  <article>
+    <div>
+      <h2>
+        Fra idé til ferdig resultat
+      </h2>
+      <p>
+        Et
+        <strong>
+          godt resultat
+        </strong>
+        starter med en
+        <em>
+          tydelig plan
+        </em>
+        .
+        <a href="#steg">
+          Se stegene i planen
+        </a>
+        .
+      </p>
+    </div>
+    <section>
+      <h3>
+        Dette trenger du
+      </h3>
+      <ul>
+        <li>
+          et tydelig mål
+        </li>
+        <li>
+          en enkel plan
+          <ul>
+            <li>
+              oppgaver og tidsfrister
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <h4 id="<removed>">
+        Steg for steg
+      </h4>
+      <ol>
+        <li>
+          Beskriv hva du vil oppnå
+        </li>
+        <li>
+          Del arbeidet inn i mindre oppgaver
+        </li>
+      </ol>
+      <blockquote>
+        <p>
+          En enkel plan gjør det lettere å komme i gang.
+        </p>
+      </blockquote>
+      <hr>
+      <h5>
+        Når arbeidet er ferdig
+      </h5>
+      <figure>
+        <picture>
+          <source
+            media="(min-width: 40rem)"
+            srcset="/img/feiring.svg"
+          >
+          <img
+            alt="Illustrasjon av en feiring"
+            src="/img/feiring.svg"
+          >
+        </picture>
+        <figcaption>
+          Marker at målet er nådd.
+        </figcaption>
+      </figure>
+    </section>
+    <div>
+      <h6>
+        Mer informasjon
+      </h6>
+      <p>
+        Ta vare på planen slik at du kan bruke den som utgangspunkt senere.
+      </p>
+    </div>
+  </article>
+</div>
+`;

--- a/@udir-design/react/src/components/richText/index.ts
+++ b/@udir-design/react/src/components/richText/index.ts
@@ -1,0 +1,1 @@
+export * from './RichText';

--- a/@udir-design/react/src/components/richText/richText.css
+++ b/@udir-design/react/src/components/richText/richText.css
@@ -1,0 +1,180 @@
+.uds-rich-text {
+  --dsc-rich-text-block-spacing: var(--ds-size-5);
+  --dsc-rich-text-list-item-spacing: var(--ds-size-3);
+  --dsc-rich-text-nested-list-item-spacing: var(--ds-size-2);
+  color: var(--ds-color-text-default);
+}
+
+@scope (.uds-rich-text) to (
+  :is(
+    [class^='ds-'],
+    [class*=' ds-'],
+    [class^='uds-'],
+    [class*=' uds-']
+  )
+) {
+  :is(h1, h2, h3, h4, h5, h6) {
+    @composes ds-heading from '@digdir/designsystemet-css/heading.css';
+
+    margin-block-end: var(--ds-size-4);
+  }
+
+  h1 {
+    font-size: var(--ds-heading-lg-font-size);
+    font-weight: var(--ds-heading-lg-font-weight);
+    letter-spacing: var(--ds-heading-lg-letter-spacing);
+    line-height: var(--ds-heading-lg-line-height);
+    margin-block-start: var(--ds-size-10);
+  }
+
+  h2 {
+    font-size: var(--ds-heading-md-font-size);
+    font-weight: var(--ds-heading-md-font-weight);
+    letter-spacing: var(--ds-heading-md-letter-spacing);
+    line-height: var(--ds-heading-md-line-height);
+    margin-block-start: var(--ds-size-9);
+  }
+
+  h3 {
+    font-size: var(--ds-heading-sm-font-size);
+    font-weight: var(--ds-heading-sm-font-weight);
+    letter-spacing: var(--ds-heading-sm-letter-spacing);
+    line-height: var(--ds-heading-sm-line-height);
+    margin-block-start: var(--ds-size-8);
+  }
+
+  h4 {
+    font-size: var(--ds-heading-xs-font-size);
+    font-weight: var(--ds-heading-xs-font-weight);
+    letter-spacing: var(--ds-heading-xs-letter-spacing);
+    line-height: var(--ds-heading-xs-line-height);
+    margin-block-start: var(--ds-size-7);
+  }
+
+  :is(h5, h6) {
+    font-size: var(--ds-heading-2xs-font-size);
+    font-weight: var(--ds-heading-2xs-font-weight);
+    letter-spacing: var(--ds-heading-2xs-letter-spacing);
+    line-height: var(--ds-heading-2xs-line-height);
+    margin-block-start: var(--ds-size-6);
+  }
+
+  :is(p, ul, ol, blockquote) {
+    font-size: var(--ds-body-md-font-size);
+    font-weight: var(--ds-body-md-font-weight);
+    letter-spacing: var(--ds-body-md-letter-spacing);
+    line-height: var(--ds-body-md-line-height);
+  }
+
+  p {
+    margin-block-end: var(--dsc-rich-text-block-spacing);
+    margin-block-start: 0;
+  }
+
+  a {
+    @composes ds-link from '@digdir/designsystemet-css/link.css';
+
+    --dsc-link-color--active: var(--ds-color-text-subtle);
+    --dsc-link-color--hover: var(--ds-color-text-subtle);
+    --dsc-link-color: var(--ds-color-text-default);
+  }
+
+  a:where(:visited) {
+    color: var(--dsc-link-color--visited);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    a:where(:hover) {
+      color: var(--dsc-link-color--hover);
+      text-decoration-thickness: var(
+        --dsc-link-text-decoration-thickness--hover
+      );
+    }
+  }
+
+  a:focus-visible {
+    outline: var(--_ds--focus, var(--dsc-focus-outline));
+    outline-offset: var(--_ds--focus, var(--ds-border-width-focus));
+    box-shadow: var(--_ds--focus, var(--dsc-focus-boxShadow));
+    text-decoration: none;
+  }
+
+  a:focus-visible * {
+    --_ds--focus: ;
+  }
+
+  a:where(:active) {
+    color: var(--dsc-link-color--active);
+    background: var(--dsc-link-background--active);
+  }
+
+  :is(ul, ol) {
+    @composes ds-list from '@digdir/designsystemet-css/list.css';
+
+    margin-block-end: var(--dsc-rich-text-block-spacing);
+  }
+
+  :is(ul, ol) > li + li {
+    margin-block-start: var(--dsc-rich-text-list-item-spacing);
+  }
+
+  :is(ul, ol) > li > :is(ul, ol) > li + li {
+    margin-block-start: var(--dsc-rich-text-nested-list-item-spacing);
+  }
+
+  :is(ul, ol) > li::before {
+    position: absolute;
+    content: '\200B';
+  }
+
+  blockquote {
+    margin-block: var(--ds-size-7);
+    margin-inline: 0;
+    padding-inline-start: var(--ds-size-5);
+    border-inline-start: var(--ds-border-width-highlight) solid
+      var(--ds-color-border-default);
+  }
+
+  figure {
+    margin-block: var(--ds-size-7);
+    margin-inline: 0;
+  }
+
+  hr {
+    @composes ds-divider from '@digdir/designsystemet-css/divider.css';
+  }
+
+  :is(img, picture) {
+    display: block;
+    max-inline-size: 100%;
+    block-size: auto;
+  }
+
+  figcaption {
+    margin-block-start: var(--ds-size-2);
+    color: var(--ds-color-text-subtle);
+    font-size: var(--ds-body-sm-font-size);
+    font-weight: var(--ds-body-sm-font-weight);
+    letter-spacing: var(--ds-body-sm-letter-spacing);
+    line-height: var(--ds-body-sm-line-height);
+  }
+
+  /* Remove margins at the outer edge through two neutral CMS wrappers. */
+  :scope > :first-child,
+  :scope > :is(div, section, article):first-child > :first-child,
+  :scope
+    > :is(div, section, article):first-child
+    > :is(div, section, article):first-child
+    > :first-child {
+    margin-block-start: 0;
+  }
+
+  :scope > :last-child,
+  :scope > :is(div, section, article):last-child > :last-child,
+  :scope
+    > :is(div, section, article):last-child
+    > :is(div, section, article):last-child
+    > :last-child {
+    margin-block-end: 0;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     diffable-html:
       specifier: ^6.0.1
       version: 6.0.1
+    dompurify:
+      specifier: ^3.4.13
+      version: 3.4.13
     dpdm:
       specifier: ^4.3.0
       version: 4.3.0
@@ -615,6 +618,9 @@ importers:
       diffable-html:
         specifier: 'catalog:'
         version: 6.0.1
+      dompurify:
+        specifier: 'catalog:'
+        version: 3.4.13
       dpdm:
         specifier: 'catalog:'
         version: 4.3.0
@@ -3138,6 +3144,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -4438,6 +4447,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -9871,6 +9883,9 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/yargs-parser@21.0.3': {}
@@ -11088,6 +11103,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.13:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@2.8.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -127,6 +127,7 @@ catalog:
   oxlint: ^1.77.0
   oxlint-tsgolint: ^7.0.2001
   react-router: ^8.3.0
+  dompurify: ^3.4.13
 
 catalogMode: strict
 

--- a/test-apps/vite-vanilla/src/index.html
+++ b/test-apps/vite-vanilla/src/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="no">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite Vanilla App</title>
+    <title>Vanilla HTML med Udir designsystem</title>
     <link
       rel="preload stylesheet"
       as="style"
@@ -12,35 +12,69 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div
-      id="app"
-      class="ds-card uds-prose"
-      data-color="accent"
-      data-variant="tinted"
-    >
-      <h1 class="ds-heading" data-size="md">Vanilla html/css/js med Vite</h1>
-      <p>
-        Eksempel på bruk av Udirs designsystem-biblioteker uten React, med Vite
-        som bundler.
-      </p>
-      <button type="button" class="ds-button">
-        <svg>
-          <use id="icon-pencil" />
-        </svg>
-        Knapp med SVG-ikon
-      </button>
-      <div class="symbol-box">
-        <span>Datamaskinsymbol</span>
-        <img id="symbol-computer" alt="" />
-      </div>
-      <span>Inline SVG-ikon</span>
-      <a class="ds-link" href="/underside">
-        <svg>
-          <use id="icon-arrow-link" /></svg
-        ><span>Lenke med SVG-ikon</span>
-      </a>
-      <div class="idea-box">Du kan også bruke ikoner og symboler i CSS</div>
-    </div>
+    <main id="app">
+      <section
+        id="component-demo"
+        class="ds-card uds-prose"
+        data-color="accent"
+        data-variant="tinted"
+      >
+        <h1 class="ds-heading" data-size="md">Vanilla HTML med Vite</h1>
+        <p>
+          Eksempel på bruk av Udirs designsystem-biblioteker uten React, med
+          Vite som bundler.
+        </p>
+        <button type="button" class="ds-button">
+          <svg>
+            <use id="icon-pencil" />
+          </svg>
+          Knapp med SVG-ikon
+        </button>
+        <div class="symbol-box">
+          <span>Datamaskinsymbol</span>
+          <img id="symbol-computer" alt="" />
+        </div>
+        <span>Inline SVG-ikon</span>
+        <a class="ds-link" href="/underside">
+          <svg>
+            <use id="icon-arrow-link" /></svg
+          ><span>Lenke med SVG-ikon</span>
+        </a>
+        <div class="idea-box">Du kan også bruke ikoner og symboler i CSS</div>
+      </section>
+
+      <article class="uds-rich-text">
+        <div>
+          <h2>Fra idé til ferdig resultat</h2>
+          <p>
+            Et <strong>godt resultat</strong> starter med en
+            <em>tydelig plan</em>. <a href="#steg">Se stegene i planen</a>.
+          </p>
+        </div>
+        <section>
+          <h3>Dette trenger du</h3>
+          <ul>
+            <li>et tydelig mål</li>
+            <li>
+              en enkel plan
+              <ul>
+                <li>oppgaver og tidsfrister</li>
+              </ul>
+            </li>
+          </ul>
+          <h4 id="steg">Steg for steg</h4>
+          <ol>
+            <li>Beskriv hva du vil oppnå</li>
+            <li>Del arbeidet inn i mindre oppgaver</li>
+          </ol>
+          <blockquote>
+            <p>En enkel plan gjør det lettere å komme i gang.</p>
+          </blockquote>
+          <hr />
+          <p>Ta vare på planen slik at du kan bruke den igjen senere.</p>
+        </section>
+      </article>
+    </main>
     <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/test-apps/vite-vanilla/src/index.js
+++ b/test-apps/vite-vanilla/src/index.js
@@ -18,7 +18,7 @@ document
   .getElementById('icon-arrow-link')
   ?.setAttribute('href', `${ArrowRightUrl}#icon`);
 
-const container = document.getElementById('app');
+const container = document.getElementById('component-demo');
 if (container) {
   container.innerHTML += `
 <a class="ds-link" href="#">

--- a/test-apps/vite-vanilla/src/style.css
+++ b/test-apps/vite-vanilla/src/style.css
@@ -1,15 +1,21 @@
 html {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
+  min-height: 100%;
   background-color: var(--ds-color-neutral-background-default);
 }
 
 body {
+  margin: 0;
+  padding: var(--ds-size-8);
   background: transparent;
   font-family: 'Inter', sans-serif;
   font-feature-settings: 'cv05' 1; /* Enable lowercase l with tail */
+}
+
+#app {
+  display: grid;
+  gap: var(--ds-size-12);
+  max-width: 64rem;
+  margin-inline: auto;
 }
 
 .symbol-box {


### PR DESCRIPTION
## Hva er gjort?

Ny komponent! Tar inn sanitert html og legger på Udir-stil. 

I første utkast bruker css `@scope` som er [baseline 2026](https://caniuse.com/css-cascade-scope). Det brukes slik at det er mulig å legge inn `.ds`- og `.uds`-klasser uten at de vil få overskrevet stil. En fallback burde vurderes, men kan være ganske komplisert. En annen løsning er å ikke støtte sistnevnte feature. 

## Sjekkliste

<!--  Slett det som ikke er relevant  -->

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er eksportert fra riktig fil
- [x] Komponenten fungerer godt med `dir="rtl"`
- [x] Komponenten er testet i test-app
- [x] Komponenten har tester i Storybook
- [ ] Komponenten er i bruk i en demoside
