### PR TITLE
docs: clarify the choice between Link and Button

### DIFF
--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -20,7 +20,7 @@ Knapper lar brukerne utføre en handling. Vi har variantene `primary`, `secondar
 
 - navigere til andre sider eller ut av tjenesten – bruk heller [`Link`](/docs/components-link--docs)
 
-**Tommelfingerregel:** Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en [`Link`](/docs/components-link--docs). Hvis ikke er det en `Button`, selv om resultatet er at noe åpnes eller lastes ned.
+**Knapp eller lenke?** Hvis brukeren burde kunne høyreklikke og kopiere lenkeadressen, bruk helst en [`Link`](/docs/components-link--docs), alternativt [`Button` med lenkeoppførsel](#knapp-med-lenkeoppførsel). Hvis ikke, bruk `Button` selv om resultatet er at noe åpnes eller lastes ned.
 
 ## Slik bruker du Button
 
@@ -120,9 +120,9 @@ I eksempelet over blir `aria-disabled` satt av `loading="true"`. Skjermlesere og
 
 ### Knapp med lenkeoppførsel
 
-Bruk `asChild` dersom du trenger å bruke knappen som en lenke. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten.
+Bruk `asChild` og send inn `<a href="...">` som barn dersom du trenger lenkeoppførsel med knappeutseende. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten.
 
-Tommelfingerregelen over avgjør hvilket element du skal bruke. `asChild` endrer bare utseendet: elementet er fortsatt en lenke, så høyreklikk, midtklikk og å åpne i ny fane fungerer som normalt.
+`asChild` med `<a href="...">` endrer det underliggende elementet, slik at høyreklikk, midtklikk og å åpne i ny fane fungerer som normalt.
 
 Det er likevel en avveining:
 
@@ -133,9 +133,9 @@ Et typisk eksempel er et skjema over flere sider der hvert steg har sin egen URL
 
 Velg knappeutseende når du vil at brukeren skal klikke seg videre der og da, og `Link` når det er sannsynlig at brukeren vil ta vare på adressen.
 
-Det motsatte, en handling med lenkeutseende, anbefaler vi ikke. Se [`Link`](/docs/components-link--docs).
+Det motsatte, knappeoppførsel med lenkeutseende, [anbefaler vi ikke](/docs/components-link--docs#ikke-bruk-lenke-med-knappeoppførsel)
 
-[Les mer om komposisjon](https://designsystemet.no/no/fundamentals/code/composition).
+[Les mer om å bruke `asChild` for komposisjon](https://designsystemet.no/no/fundamentals/code/composition).
 
 <Canvas of={ButtonStories.AsLink} />
 

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -20,6 +20,10 @@ Knapper lar brukerne utføre en handling. Vi har variantene `primary`, `secondar
 
 - navigere til andre sider eller ut av tjenesten – bruk heller [`Link`](/docs/components-link--docs)
 
+**Tommelfingerregel**
+
+Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en `Link`. Hvis ikke er det en `Button`, selv om resultatet er at noe åpnes eller lastes ned
+
 ## Slik bruker du Button
 
 <Canvas of={ButtonStories.Preview} withToolbar />
@@ -75,7 +79,18 @@ Vi kan bruke en `danger`-knapp sammen med én eller flere `neutral`-knapper for 
 
 ### Knapp som lenke
 
-Bruk `asChild` dersom du trenger å bruke knappen som en lenke. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten. Knapp som lenke kan gi tydeligere visuell prioritet når navigasjonen er en viktig handling.
+Bruk `asChild` dersom du trenger å bruke knappen som en lenke. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten.
+
+Tommelfingerregelen over avgjør hvilket element du skal bruke. `asChild` endrer bare utseendet: elementet er fortsatt en lenke, så høyreklikk, midtklikk og å åpne i ny fane fungerer som normalt.
+
+Det er likevel en avveining:
+
+- Knappeutseendet gir tydeligere visuell prioritet, og passer når navigasjonen er en viktig handling på siden.
+- Knappeutseendet lover ikke lenkeoppførsel, så færre brukere tenker på å kopiere lenkeadressen eller åpne i ny fane. Funksjonaliteten er der, men den er mindre synlig.
+
+Et typisk eksempel er et skjema over flere sider der hvert steg har sin egen URL. Forrige og Neste er da ekte lenker, men vi gir dem knappeutseende, for eksempel `secondary` og `primary`, fordi det å komme videre er en viktig handling på siden. Har ikke stegene egne URL-er, er Forrige og Neste vanlige knapper.
+
+Velg knappeutseende når du vil at brukeren skal klikke seg videre der og da, og `Link` når det er sannsynlig at brukeren vil ta vare på adressen.
 
 [Les mer om komposisjon](https://www.designsystemet.no/grunnleggende/for-utviklere/komposisjon).
 

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -77,7 +77,7 @@ Vi kan bruke en `danger`-knapp sammen med én eller flere `neutral`-knapper for 
 
 ## Eksempler
 
-### Knapp som lenke
+### Knapp med lenkeoppførsel
 
 Bruk `asChild` dersom du trenger å bruke knappen som en lenke. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten.
 
@@ -91,6 +91,8 @@ Det er likevel en avveining:
 Et typisk eksempel er et skjema over flere sider der hvert steg har sin egen URL. Forrige og Neste er da ekte lenker, men vi gir dem knappeutseende, for eksempel `secondary` og `primary`, fordi det å komme videre er en viktig handling på siden. Har ikke stegene egne URL-er, er Forrige og Neste vanlige knapper.
 
 Velg knappeutseende når du vil at brukeren skal klikke seg videre der og da, og `Link` når det er sannsynlig at brukeren vil ta vare på adressen.
+
+Det motsatte, en handling med lenkeutseende, anbefaler vi ikke. Se [`Link`](/docs/components-link--docs).
 
 [Les mer om komposisjon](https://www.designsystemet.no/grunnleggende/for-utviklere/komposisjon).
 

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -20,9 +20,7 @@ Knapper lar brukerne utføre en handling. Vi har variantene `primary`, `secondar
 
 - navigere til andre sider eller ut av tjenesten – bruk heller [`Link`](/docs/components-link--docs)
 
-**Tommelfingerregel**
-
-Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en `Link`. Hvis ikke er det en `Button`, selv om resultatet er at noe åpnes eller lastes ned
+**Tommelfingerregel:** Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en [`Link`](/docs/components-link--docs). Hvis ikke er det en `Button`, selv om resultatet er at noe åpnes eller lastes ned.
 
 ## Slik bruker du Button
 

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -75,27 +75,6 @@ Vi kan bruke en `danger`-knapp sammen med én eller flere `neutral`-knapper for 
 
 ## Eksempler
 
-### Knapp med lenkeoppførsel
-
-Bruk `asChild` dersom du trenger å bruke knappen som en lenke. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten.
-
-Tommelfingerregelen over avgjør hvilket element du skal bruke. `asChild` endrer bare utseendet: elementet er fortsatt en lenke, så høyreklikk, midtklikk og å åpne i ny fane fungerer som normalt.
-
-Det er likevel en avveining:
-
-- Knappeutseendet gir tydeligere visuell prioritet, og passer når navigasjonen er en viktig handling på siden.
-- Knappeutseendet lover ikke lenkeoppførsel, så færre brukere tenker på å kopiere lenkeadressen eller åpne i ny fane. Funksjonaliteten er der, men den er mindre synlig.
-
-Et typisk eksempel er et skjema over flere sider der hvert steg har sin egen URL. Forrige og Neste er da ekte lenker, men vi gir dem knappeutseende, for eksempel `secondary` og `primary`, fordi det å komme videre er en viktig handling på siden. Har ikke stegene egne URL-er, er Forrige og Neste vanlige knapper.
-
-Velg knappeutseende når du vil at brukeren skal klikke seg videre der og da, og `Link` når det er sannsynlig at brukeren vil ta vare på adressen.
-
-Det motsatte, en handling med lenkeutseende, anbefaler vi ikke. Se [`Link`](/docs/components-link--docs).
-
-[Les mer om komposisjon](https://www.designsystemet.no/grunnleggende/for-utviklere/komposisjon).
-
-<Canvas of={ButtonStories.AsLink} />
-
 ### Knapp med kun ikon
 
 Knapper med kun ikon bruker vi bare for godt kjente ikoner, som Lukk og Slett. Knappen må da ha en tilgjengelig tekst som forklarer hva den gjør, for eksempel med `aria-label` eller i en `Tooltip` som i eksempelet under.
@@ -138,6 +117,27 @@ I eksempelet over blir `aria-disabled` satt av `loading="true"`. Skjermlesere og
 </SimpleAlert>
 
 ## Retningslinjer
+
+### Knapp med lenkeoppførsel
+
+Bruk `asChild` dersom du trenger å bruke knappen som en lenke. Vurder først om det er mer hensiktsmessig å bruke [`Link`](/docs/components-link--docs)-komponenten.
+
+Tommelfingerregelen over avgjør hvilket element du skal bruke. `asChild` endrer bare utseendet: elementet er fortsatt en lenke, så høyreklikk, midtklikk og å åpne i ny fane fungerer som normalt.
+
+Det er likevel en avveining:
+
+- Knappeutseendet gir tydeligere visuell prioritet, og passer når navigasjonen er en viktig handling på siden.
+- Knappeutseendet lover ikke lenkeoppførsel, så færre brukere tenker på å kopiere lenkeadressen eller åpne i ny fane. Funksjonaliteten er der, men den er mindre synlig.
+
+Et typisk eksempel er et skjema over flere sider der hvert steg har sin egen URL. Forrige og Neste er da ekte lenker, men vi gir dem knappeutseende, for eksempel `secondary` og `primary`, fordi det å komme videre er en viktig handling på siden. Har ikke stegene egne URL-er, er Forrige og Neste vanlige knapper.
+
+Velg knappeutseende når du vil at brukeren skal klikke seg videre der og da, og `Link` når det er sannsynlig at brukeren vil ta vare på adressen.
+
+Det motsatte, en handling med lenkeutseende, anbefaler vi ikke. Se [`Link`](/docs/components-link--docs).
+
+[Les mer om komposisjon](https://www.designsystemet.no/grunnleggende/for-utviklere/komposisjon).
+
+<Canvas of={ButtonStories.AsLink} />
 
 ### Plassering av knapper
 

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -135,7 +135,7 @@ Velg knappeutseende når du vil at brukeren skal klikke seg videre der og da, og
 
 Det motsatte, en handling med lenkeutseende, anbefaler vi ikke. Se [`Link`](/docs/components-link--docs).
 
-[Les mer om komposisjon](https://www.designsystemet.no/grunnleggende/for-utviklere/komposisjon).
+[Les mer om komposisjon](https://designsystemet.no/no/fundamentals/code/composition).
 
 <Canvas of={ButtonStories.AsLink} />
 

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -20,9 +20,7 @@ Komponenten er basert på [anchor HTML-elementet](https://developer.mozilla.org/
 
 - utføre handlinger – bruk heller [`Button`](/docs/components-button--docs)
 
-**Tommelfingerregel**
-
-Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en `Link`. Hvis ikke er det en `Button`, selv om resultatet er at noe åpnes eller lastes ned
+**Tommelfingerregel:** Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en `Link`. Hvis ikke er det en [`Button`](/docs/components-button--docs), selv om resultatet er at noe åpnes eller lastes ned.
 
 ## Slik bruker du Link
 

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -13,12 +13,16 @@ Komponenten er basert på [anchor HTML-elementet](https://developer.mozilla.org/
 **Passer til å**
 
 - lenke til en annen side
-- åpne en fil
+- åpne eller laste ned en fil som ligger på en URL
 - navigere til en annen del av samme side
 
 **Passer ikke til å**
 
 - utføre handlinger – bruk heller [`Button`](/docs/components-button--docs)
+
+**Tommelfingerregel**
+
+Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en `Link`. Hvis ikke er det en `Button`, selv om resultatet er at noe åpnes eller lastes ned
 
 ## Slik bruker du Link
 

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -20,7 +20,7 @@ Komponenten er basert på [anchor HTML-elementet](https://developer.mozilla.org/
 
 - utføre handlinger – bruk heller [`Button`](/docs/components-button--docs)
 
-**Tommelfingerregel:** Hvis "Kopier lenkeadresse" ville gitt brukeren noe nyttig, er det en `Link`. Hvis ikke er det en [`Button`](/docs/components-button--docs), selv om resultatet er at noe åpnes eller lastes ned.
+**Knapp eller lenke?** Hvis brukeren burde kunne høyreklikke og kopiere lenkeadressen, bruk helst en `Link`, alternativt [`Button` med lenkeoppførsel](/docs/components-button--docs#knapp-med-lenkeoppførsel). Hvis ikke, bruk [`Button`](/docs/components-button--docs) selv om resultatet er at noe åpnes eller lastes ned.
 
 ## Slik bruker du Link
 
@@ -61,9 +61,7 @@ Plasser teksten i `<span>` for å få anbefalt mellomrom uten understrek mellom 
 
 ### Ikke bruk lenke med knappeoppførsel
 
-Ikke bruk `asChild` for å gi en handling lenkeutseende. Lenkeutseendet lover brukeren at adressen kan kopieres, åpnes i ny fane eller lagres, og det kan ikke en handling innfri. Skal handlingen være nedtonet, bruk `tertiary`-varianten av [`Button`](/docs/components-button--docs).
-
-Unntaket er handlinger som må stå midt inne i en tekst. En knapp bryter tekstflyten, og da er lenkeutseende det eneste alternativet systemet har.
+Ikke bruk `Link` med `asChild` og et `button`-barn for å gi lenkeutseende med knappeoppførsel. Lenkeutseendet lover brukeren at adressen kan kopieres, åpnes i ny fane eller lagres, og det kan ikke en `button` innfri. Skal handlingen være nedtonet, bruk `tertiary`-varianten av [`Button`](/docs/components-button--docs).
 
 ### Sett noreferrer på eksterne lenker
 

--- a/@udir-design/react/src/components/link/Link.mdx
+++ b/@udir-design/react/src/components/link/Link.mdx
@@ -61,6 +61,12 @@ Plasser teksten i `<span>` for å få anbefalt mellomrom uten understrek mellom 
 
 ## Retningslinjer
 
+### Ikke bruk lenke med knappeoppførsel
+
+Ikke bruk `asChild` for å gi en handling lenkeutseende. Lenkeutseendet lover brukeren at adressen kan kopieres, åpnes i ny fane eller lagres, og det kan ikke en handling innfri. Skal handlingen være nedtonet, bruk `tertiary`-varianten av [`Button`](/docs/components-button--docs).
+
+Unntaket er handlinger som må stå midt inne i en tekst. En knapp bryter tekstflyten, og da er lenkeutseende det eneste alternativet systemet har.
+
 ### Sett noreferrer på eksterne lenker
 
 Når du lenker til en ekstern side utenfor Udir, bør du alltid sette `rel="noreferrer"` på `Link`-elementet. Dette beskytter brukerne mot enkelte sikkerhetsrisikoer og personvernproblemer som kan oppstå når de klikker på eksterne lenker. Les mer om dette hos MDN:


### PR DESCRIPTION
## Hva er gjort?

Dokumentasjonen sa ikkje noko om korleis ein vel mellom `Link` og `Button` når handlinga også kan sjåast som navigering. Denne PR-en legg til ein tommelfingerregel og ryddar i korleis vi omtaler dei to "blandingane" (button-styling med lenke-oppførsel og omvendt).

- Ny tommelfingerregel i begge dokumenta
- `Knapp som lenke` heiter no `Knapp med lenkeoppførsel`, og er flytta frå å vere første eksempel til å vere første punkt under retningslinjer. Det gamle namnet var tvitydig, og kunne lesast både som "ein knapp som fungerer som ei lenke" (rett) og "ein knapp som ser ut som ei lenke" (feil).
- Avsnittet skil no mellom semantikk og stil, og har fått eit eksempel med skjema over fleire sider der kvart steg har sin eigen URL.
- Ny retningslinje i `Link`: ikkje gi ei handling lenkeutsjånad

### Bakgrunn

Spørsmålet kom opp i arbeidet med nedlastingslenka i `FileUpload.Item` (DESIGN-702). Eg undersøkte korleis andre gjer det:

- [Designsystemet.no](https://www.designsystemet.no/no/components/docs/link/overview) har alt ein seksjon "Lenke eller knapp?" med same kriterium som tommelfingerregelen vår: lenke når brukaren blir sendt til ein ny URL, knapp når ei handling skal utførast. Dei viser det med "Logg inn", som kan vere begge deler. Vi spissar altså noko som finst frå før.
- [Designsystemet.no](https://www.designsystemet.no/no/components/docs/button/overview) og [Aksel](https://aksel.nav.no/komponenter/core/button) omtaler berre lenker med knappeutsjånad, ikkje det motsette. [USWDS](https://designsystem.digital.gov/components/button/) har ein eigen variant for handlingar med lenkeutsjånad og tilrår han for nedtona handlingar, medan [GOV.UK](https://design-system.service.gov.uk/components/button/) ikkje har noko tilsvarande.

### Oppfølging

~~`Button asChild` med ein `<a>` blir ikkje aktivert med mellomrom, berre med Enter, sidan elementet er ei lenke. Dette er stadfesta i nettlesar. Både [USWDS](https://designsystem.digital.gov/components/button/) og [GOV.UK](https://design-system.service.gov.uk/components/button/) har lagt inn støtte for mellomrom i sine tilsvarande knappar. Burde vi gjere dette?~~
EDIT: diskutert med Digdir, og konkluderte med at det var ein dårleg idé.

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog