### PR TITLE
docs: fix removing uploaded files in the form demo

### DIFF
--- a/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
+++ b/@udir-design/react/demo-pages/form-demo/pages/DocumentationPage.tsx
@@ -23,7 +23,8 @@ export const DocumentationPage = ({
   const removeFile = (fileToRemove: File) => {
     setValue(
       'documentation',
-      uploadedFiles.filter((file) => file.name === fileToRemove.name),
+      uploadedFiles.filter((file) => file !== fileToRemove),
+      { shouldValidate: true },
     );
   };
 


### PR DESCRIPTION
`removeFile` in `DocumentationPage` filtered with `===`, so it kept the file that was meant to be removed and dropped all the others. Compare by reference instead of by name, matching the `FileUpload` stories, and validate on removal so the error reappears when the last file is gone.