### PR TITLE
fix: update @digdir/* to 1.20.1 

### DIFF
--- a/@udir-design/react/.storybook/main.ts
+++ b/@udir-design/react/.storybook/main.ts
@@ -4,6 +4,14 @@ import remarkGfm from 'remark-gfm';
 import type { Plugin, UserConfig } from 'vite';
 import { createTierIndexers } from './utils/createTierIndexers.js';
 
+/** Keep in sync with the React.HTMLAttributes augmentation in src/html.ts */
+const GLOBAL_HTML_ATTRIBUTES = new Set([
+  'popover',
+  'popovertarget',
+  'focusgroup',
+  'focusgroupstart',
+]);
+
 const isFromDependency = (fileName: string) =>
   fileName.includes('node_modules');
 const isFromAllowedDependency = (fileName: string) =>
@@ -111,8 +119,12 @@ export default defineMain({
       include: ['src/**/*.{ts,tsx}'],
       setDisplayName: false,
       propFilter: (prop) => {
-        // Remove popovertarget prop which @digdir/designsystemet-react adds to all elements
-        if (prop.name === 'popovertarget') {
+        // Remove global HTML attributes that end up on every component, since they
+        // are not part of any component's own API. They come from two augmentations
+        // of React.HTMLAttributes: @digdir/designsystemet-react declares popovertarget
+        // in suggestion-input.tsx, and src/html.ts declares the rest. Both are always
+        // loaded. Document these in prose instead, see Dropdown.mdx and utilities/focusgroup.mdx.
+        if (GLOBAL_HTML_ATTRIBUTES.has(prop.name)) {
           return false;
         }
 

--- a/@udir-design/react/README.md
+++ b/@udir-design/react/README.md
@@ -75,6 +75,8 @@ Hvis du bruker TypeScript, anbefaler vi å legge til typene for `@udir-design/th
 
 Da får du typesjekking og autoutfylling for Udirs farger og størrelser (`data-color` og `data-size`) både på komponenter fra biblioteket og vanlige HTML-elementer.
 
+Du får også typer for HTML-attributter som React ikke dekker selv: `popover` og `popovertarget`, samt `focusgroup` og `focusgroupstart`.
+
 Et enkelt eksempel:
 
 ```jsonc

--- a/@udir-design/react/demo-pages/page-demo/user-table/UserTable.tsx
+++ b/@udir-design/react/demo-pages/page-demo/user-table/UserTable.tsx
@@ -41,7 +41,7 @@ export function UserTable() {
           </Popover.TriggerContext>
         </div>
         <Search className={styles.tableSearch}>
-          <Search.Input aria-label="Søk" autoComplete="off" />
+          <Search.Input aria-label="Søk" type="text" autoComplete="off" />
           <Search.Clear />
           <Search.Button />
         </Search>

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -42,9 +42,9 @@ Vi bruker `Breadcrumbs` til å hjelpe brukerne å forstå hvor de er i en hierar
 
 ## Eksempler
 
-### Sti eller tilbake-knapp basert på skjermstørrelse
+### Tilpass visningen etter skjermbredden
 
-Hvis du legger både en `Breadcrumbs.Link` og en `Breadcrumbs.List` direkte i `Breadcrumbs`, vil en tilbake-knapp vises på skjermer smalere enn 650px, og en sti vises ellers. Dette er ofte den beste løsningen fordi den gir god plass og brukervennlighet på alle skjermer.
+Hvis du legger både en `Breadcrumbs.Link` og en `Breadcrumbs.List` direkte i `Breadcrumbs`, vises bare lenken til nærmeste overordnede nivå på skjermer smalere enn 650px. På bredere skjermer vises hele stien. Dette er ofte den beste løsningen fordi den gir god plass og brukervennlighet på alle skjermer.
 
 <Canvas of={BreadcrumbsStories.Preview} />
 
@@ -54,9 +54,9 @@ Hvis du legger en `Breadcrumbs.List` direkte i `Breadcrumbs`, vil denne vises so
 
 <Canvas of={BreadcrumbsStories.ListOnly} />
 
-### Kun tilbake-knapp
+### Vis bare nærmeste nivå
 
-Hvis du legger en `Breadcrumbs.Link` direkte i `Breadcrumbs`, vil denne lenken vises som en tilbake-knapp. Dette kan for eksempel benyttes for å spare plass. Det er viktig at du er konsistent i din løsning og bruker enten tilbake-knapp eller sti.
+Hvis du legger en `Breadcrumbs.Link` direkte i `Breadcrumbs`, vises bare denne lenken til nærmeste overordnede side. Dette kan for eksempel benyttes for å spare plass. Det er viktig at du er konsistent i din løsning og bruker enten denne varianten eller hele stien.
 
 <Canvas of={BreadcrumbsStories.BackOnly} />
 

--- a/@udir-design/react/src/components/breadcrumbs/__snapshots__/Breadcrumbs.stories.tsx.snap
+++ b/@udir-design/react/src/components/breadcrumbs/__snapshots__/Breadcrumbs.stories.tsx.snap
@@ -45,10 +45,7 @@ exports[`List Only 1`] = `
 `;
 
 exports[`Long Items 1`] = `
-<ds-breadcrumbs
-  role="navigation"
-  aria-label="Du er her:"
->
+<ds-breadcrumbs role="navigation">
   <a
     href="#"
     aria-label="Tilbake til helsesertifikat for sjømat"
@@ -167,10 +164,7 @@ exports[`Placement With Header 1`] = `
   </div>
 </header>
 <div>
-  <ds-breadcrumbs
-    role="navigation"
-    aria-label="Du er her:"
-  >
+  <ds-breadcrumbs role="navigation">
     <a
       href="#"
       aria-label="Tilbake til Utdanningsløpet"

--- a/@udir-design/react/src/components/button/Button.mdx
+++ b/@udir-design/react/src/components/button/Button.mdx
@@ -108,12 +108,13 @@ Vi kan vise brukeren at en knapp laster ved å kombinere knappen med en spinner 
 
 <Canvas of={ButtonStories.Loading} />
 
-I eksempelet over blir `aria-disabled` satt av `loading="true"`. Skjermlesere og andre hjelpemidler vil bli informert om at knappen finnes, men ikke er aktiv. I motsetning til `disabled`, kan knappen fortsatt få fokus når noen navigerer med tastaturet.
+`loading="true"` setter automatisk `aria-busy="true"`, som forteller hjelpemidler at en handling pågår. Knappen kan fortsatt få fokus når noen navigerer med tastaturet. Vurder også om statusen bør komme fram på andre måter, for eksempel ved å endre knappeteksten fra «Lagre» til «Lagrer».
+
+En knapp som laster skal ikke være deaktivert, hverken med `aria-disabled` eller `disabled`.
 
 <SimpleAlert type="info" heading="Vær oppmerksom på">
-  `loading="true"` eller `aria-disabled` stopper ikke automatisk knappen fra å
-  utløse `onClick`. Du må selv passe på at callback-funksjonen ikke kjører når
-  knappen er deaktivert.
+  `loading="true"` stopper ikke knappen fra å utløse `onClick`. Du må selv passe
+  på at callback-funksjonen ikke kjører mens knappen laster.
 </SimpleAlert>
 
 ## Retningslinjer

--- a/@udir-design/react/src/components/button/Button.stories.tsx
+++ b/@udir-design/react/src/components/button/Button.stories.tsx
@@ -203,13 +203,10 @@ export const Loading = meta.story({
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
     const button = canvas.getAllByRole('button')[0];
-    await step(
-      'Button should have aria-busy and aria-disabled attributes',
-      async () => {
-        expect(button).toHaveAttribute('aria-busy', 'true');
-        expect(button).toHaveAttribute('aria-disabled', 'true');
-      },
-    );
+    await step('Button should have aria-busy attribute', async () => {
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      expect(button).not.toHaveAttribute('aria-disabled');
+    });
     await step('Button should be focusable', async () => {
       await userEvent.tab();
       expect(button).toHaveFocus();

--- a/@udir-design/react/src/components/button/__snapshots__/Button.stories.tsx.snap
+++ b/@udir-design/react/src/components/button/__snapshots__/Button.stories.tsx.snap
@@ -815,7 +815,6 @@ exports[`Icons Only Primary 1`] = `
 exports[`Loading 1`] = `
 <button
   aria-busy="true"
-  aria-disabled="true"
   data-variant="primary"
   type="button"
 >
@@ -845,7 +844,6 @@ exports[`Loading 1`] = `
 </button>
 <button
   aria-busy="true"
-  aria-disabled="true"
   data-variant="secondary"
   type="button"
 >
@@ -875,7 +873,6 @@ exports[`Loading 1`] = `
 </button>
 <button
   aria-busy="true"
-  aria-disabled="true"
   data-variant="tertiary"
   type="button"
 >

--- a/@udir-design/react/src/components/chip/Chip.stories.tsx
+++ b/@udir-design/react/src/components/chip/Chip.stories.tsx
@@ -254,6 +254,7 @@ export const Button = meta.story({
           <Search>
             <Search.Input
               aria-label="søk"
+              type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
             />

--- a/@udir-design/react/src/components/chip/__snapshots__/Chip.stories.tsx.snap
+++ b/@udir-design/react/src/components/chip/__snapshots__/Chip.stories.tsx.snap
@@ -13,24 +13,25 @@ exports[`Button 1`] = `
 }
 </style>
 <div>
-  <div>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="søk"
-      type="search"
+      type="text"
       value="Skole"
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
     >
     </button>
     <button type="submit">
       Søk
     </button>
-  </div>
+  </ds-suggestion>
   <div>
     <p>
       Hurtigsøk:

--- a/@udir-design/react/src/components/chip/__snapshots__/Chip.stories.tsx.snap
+++ b/@udir-design/react/src/components/chip/__snapshots__/Chip.stories.tsx.snap
@@ -24,7 +24,6 @@ exports[`Button 1`] = `
       type="reset"
       aria-label="Tøm"
       aria-hidden="false"
-      hidden
       tabindex="-1"
     >
     </button>

--- a/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
+++ b/@udir-design/react/src/components/dialog/__snapshots__/Dialog.stories.tsx.snap
@@ -348,7 +348,7 @@ exports[`Dialog With Suggestion 1`] = `
       </label>
       <ds-suggestion>
         <input
-          placeholder=" "
+          placeholder
           type="text"
           id="<removed>"
           list=":u-datalist1"
@@ -375,6 +375,18 @@ exports[`Dialog With Suggestion 1`] = `
           id="<removed>"
           data-is-floating="true"
         >
+          <u-option
+            data-empty
+            hidden
+            label
+            value
+            role="option"
+            aria-disabled="false"
+            aria-selected="false"
+            id="<removed>"
+          >
+            Tomt
+          </u-option>
           <u-option
             label="Sogndal"
             value="Sogndal"

--- a/@udir-design/react/src/components/dropdown/Dropdown.mdx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.mdx
@@ -91,9 +91,15 @@ Det er innebygd tilgjengelighet i `Dropdown.Trigger` med `aria-expanded={true/fa
 
 ### Tastatur
 
-På grunn av forskjellige bruksmønstre for `Dropdown` har vi ikke innebygd tastaturhåndtering. Dersom du lager en meny må du selv implementere tastaturhåndtering for å navigere i menyen. Se ["Menu and Menubar Pattern" hos w3c](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
+Uten ekstra oppsett kan fokuserbare elementer i `Dropdown.List` navigeres med <kbd>Tab</kbd>, og `Dropdown` lukkes med <kbd>Esc</kbd>.
 
-Dersom du bruker `Dropdown` uten å gjøre noe selv, vil fokuserbare elementer i `Dropdown.List` kunne navigeres med tabulator-tasten, og du kan lukke `Dropdown` med Escape-tasten.
+### Piltastnavigasjon
+
+Vil du at brukerne skal kunne flytte seg mellom elementene med piltastene, og at hele listen skal være ett tab-stopp, setter du [`focusgroup`](/docs/utilities-focusgroup--docs) på `Dropdown.List`. Bruk verdien `menu` når innholdet er en meny med handlinger.
+
+<Canvas of={DropdownStories.ArrowKeyNavigation} />
+
+Merk at verdien du oppgir også bestemmer hvilke ARIA-roller som blir satt på listen og elementene i den. Bruk derfor `menu` bare når innholdet faktisk er en meny.
 
 ## Kompatibilitet
 

--- a/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
+++ b/@udir-design/react/src/components/dropdown/Dropdown.stories.tsx
@@ -394,3 +394,64 @@ export const WithoutContext = meta.story({
     await userEvent.click(button);
   },
 });
+
+export const ArrowKeyNavigation = meta.story({
+  parameters: {
+    customStyles: { story: { height: 300 } },
+  },
+  args: {
+    placement: 'bottom-end',
+  },
+  render: (args) => {
+    return (
+      <Dropdown.TriggerContext>
+        <Dropdown.Trigger variant="secondary">
+          Handlinger
+          <MenuElipsisVerticalIcon aria-hidden />
+        </Dropdown.Trigger>
+        <Dropdown {...args}>
+          <Dropdown.List focusgroup="menu">
+            <Dropdown.Item>
+              <Dropdown.Button>Rediger</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Dropdown.Button>Dupliser</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Dropdown.Button>Flytt</Dropdown.Button>
+            </Dropdown.Item>
+            <Dropdown.Item>
+              <Dropdown.Button>Slett</Dropdown.Button>
+            </Dropdown.Item>
+          </Dropdown.List>
+        </Dropdown>
+      </Dropdown.TriggerContext>
+    );
+  },
+  play: async (ctx) => {
+    const canvas = within(ctx.canvasElement);
+    const trigger = canvas.getByRole('button', { name: /handlinger/i });
+
+    await userEvent.click(trigger);
+    const dropdown = ctx.canvasElement.querySelector('[popover]');
+    await waitFor(() => {
+      expect(dropdown?.matches(':popover-open')).toBe(true);
+    });
+
+    // We assert the focusgroup contract rather than the arrow key movement.
+    // `focusgroup` is implemented natively from Chrome 150, and native key handling
+    // ignores untrusted events, so the synthetic events from `userEvent.keyboard`
+    // never reach it. The polyfill in `@digdir/designsystemet-web` would handle them,
+    // but it stands down when the browser has native support.
+    expect(ctx.canvasElement.querySelector('ul')).toHaveAttribute(
+      'focusgroup',
+      'menu',
+    );
+    const items = canvas.getAllByRole('button', {
+      name: /rediger|dupliser|flytt|slett/i,
+    });
+    expect(items).toHaveLength(4);
+    items[0].focus();
+    expect(items[0]).toHaveFocus();
+  },
+});

--- a/@udir-design/react/src/components/dropdown/__snapshots__/Dropdown.stories.tsx.snap
+++ b/@udir-design/react/src/components/dropdown/__snapshots__/Dropdown.stories.tsx.snap
@@ -1,5 +1,75 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Arrow Key Navigation 1`] = `
+<button
+  data-variant="secondary"
+  type="button"
+  popovertarget="_r_m_"
+>
+  Handlinger
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    fill="none"
+    viewbox="0 0 24 24"
+    focusable="false"
+    role="img"
+    aria-hidden="true"
+  >
+    <path
+      fill="currentColor"
+      fill-rule="evenodd"
+      d="M10.5 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0m0 6a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0m1.5 4.5a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3"
+      clip-rule="evenodd"
+    >
+    </path>
+  </svg>
+</button>
+<div
+  id="<removed>"
+  popover="manual"
+  data-placement="bottom-end"
+  data-floating="bottom-end"
+  style="<removed>"
+>
+  <ul focusgroup="menu">
+    <li>
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Rediger
+      </button>
+    </li>
+    <li>
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Dupliser
+      </button>
+    </li>
+    <li>
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Flytt
+      </button>
+    </li>
+    <li>
+      <button
+        data-variant="tertiary"
+        type="button"
+      >
+        Slett
+      </button>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`Avatars 1`] = `
 <button
   data-variant="tertiary"

--- a/@udir-design/react/src/components/fieldset/Fieldset.mdx
+++ b/@udir-design/react/src/components/fieldset/Fieldset.mdx
@@ -61,7 +61,7 @@ Dette gjelder også på sider med mange inndatafelt, fordi det tydeliggjør at d
 
 ## Retningslinjer
 
-Når du bruker `Fieldset`, starter du med en `Fieldset.Legend` som forklarer hva feltene handler om. Det kan være et spørsmål som «Hvor bor du nå?» eller en beskrivelse som «Personopplysninger». Dette hjelper brukeren med å forstå sammenhengen mellom feltene og hva som skal fylles ut.
+`Fieldset.Legend` skal være et direkte barn av `Fieldset`. Legend-teksten forklarer hva feltene handler om. Det kan være et spørsmål som «Hvor bor du nå?» eller en beskrivelse som «Personopplysninger». Dette hjelper brukeren med å forstå sammenhengen mellom feltene og hva som skal fylles ut.
 
 ## Tekst i Fieldset
 

--- a/@udir-design/react/src/components/header/HeaderSearch.tsx
+++ b/@udir-design/react/src/components/header/HeaderSearch.tsx
@@ -1,18 +1,19 @@
 import cl from 'clsx/lite';
-import { forwardRef } from 'react';
+import { type ComponentRef, forwardRef } from 'react';
 import type { SearchProps } from '../search';
 import { Search } from '../search';
 
 export type HeaderSearchProps = SearchProps;
 
-export const HeaderSearch = forwardRef<HTMLDivElement, HeaderSearchProps>(
-  function HeaderSearch({ className, ...props }, ref) {
-    return (
-      <Search
-        className={cl('uds-header__search', className)}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
+export const HeaderSearch = forwardRef<
+  ComponentRef<typeof Search>,
+  HeaderSearchProps
+>(function HeaderSearch({ className, ...props }, ref) {
+  return (
+    <Search
+      className={cl('uds-header__search', className)}
+      ref={ref}
+      {...props}
+    />
+  );
+});

--- a/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
+++ b/@udir-design/react/src/components/header/__snapshots__/Header.stories.tsx.snap
@@ -1028,20 +1028,22 @@ exports[`Udir No 1`] = `
         </div>
       </a>
       <div>
-        <div data-show="sm">
+        <ds-suggestion data-show="sm">
           <input
-            placeholder="Søk"
             aria-label="Søk"
+            placeholder="Søk"
             type="search"
           >
           <button
-            data-icon="true"
             data-variant="tertiary"
             type="reset"
             aria-label="Tøm"
+            aria-hidden="false"
+            hidden
+            tabindex="-1"
           >
           </button>
-        </div>
+        </ds-suggestion>
         <button
           data-variant="secondary"
           type="button"
@@ -1054,20 +1056,22 @@ exports[`Udir No 1`] = `
           popover="auto"
           data-placement="none"
         >
-          <div data-hide="sm">
+          <ds-suggestion data-hide="sm">
             <input
-              placeholder="Søk"
               aria-label="Søk"
+              placeholder="Søk"
               type="search"
             >
             <button
-              data-icon="true"
               data-variant="tertiary"
               type="reset"
               aria-label="Tøm"
+              aria-hidden="false"
+              hidden
+              tabindex="-1"
             >
             </button>
-          </div>
+          </ds-suggestion>
           <nav aria-labelledby="<removed>">
             <h2 id="<removed>">
               Menynavigasjon
@@ -2058,21 +2062,23 @@ exports[`With Search 1`] = `
         </span>
       </a>
       <div>
-        <div>
+        <ds-suggestion>
           <input
-            placeholder="Søk"
             aria-label="Søk"
+            placeholder="Søk"
             type="search"
             value
           >
           <button
-            data-icon="true"
             data-variant="tertiary"
             type="reset"
             aria-label="Tøm"
+            aria-hidden="false"
+            hidden
+            tabindex="-1"
           >
           </button>
-        </div>
+        </ds-suggestion>
       </div>
     </div>
   </header>

--- a/@udir-design/react/src/components/pagination/__snapshots__/Pagination.stories.tsx.snap
+++ b/@udir-design/react/src/components/pagination/__snapshots__/Pagination.stories.tsx.snap
@@ -135,15 +135,14 @@ exports[`With Anchor 1`] = `
 }
 </style>
 <div>
-  <div>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="Søk"
       autocomplete="url"
       type="search"
       value="https://udir.design.no/pagination"
     >
-  </div>
+  </ds-suggestion>
   <ds-pagination
     aria-label="Sidenavigering"
     role="navigation"

--- a/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
+++ b/@udir-design/react/src/components/progressBar/ProgressBar.stories.tsx
@@ -99,18 +99,22 @@ export const FormExample = meta.story({
         <style>
           {`
 .progress-bar-form-example-main {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--ds-size-6);
 }
-.progress-bar-form-example-fieldset-content {
+.progress-bar-form-example-legend {
+  /* As tall as the ProgressBar, so the bar does not overhang the legend */
   display: flex;
-  width: 100%;
-  justify-content: space-between;
   align-items: flex-end;
-  margin-block-end: var(--ds-size-4);
+  min-height: var(--ds-size-12);
 }
 .progress-bar-form-example-progress-bar {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  transform: translateY(calc(var(--ds-size-4) * -1));
   width: 30%;
 }
 .progress-bar-form-example-button__group {
@@ -120,20 +124,21 @@ export const FormExample = meta.story({
 }`}
         </style>
         <div className="progress-bar-form-example-main">
-          <Fieldset id="rankings">
-            <div className="progress-bar-form-example-fieldset-content">
-              <Fieldset.Legend>
-                <Heading level={4}>Skjema</Heading>
-              </Fieldset.Legend>
-              <ProgressBar
-                className="progress-bar-form-example-progress-bar"
-                {...args}
-                tabIndex={-1}
-                ref={progressRef}
-                value={page}
-                aria-label="Skjemafremgang"
-              />
-            </div>
+          <Fieldset
+            id="rankings"
+            className="progress-bar-form-example-fieldset"
+          >
+            <Fieldset.Legend className="progress-bar-form-example-legend">
+              <Heading level={4}>Skjema</Heading>
+            </Fieldset.Legend>
+            <ProgressBar
+              className="progress-bar-form-example-progress-bar"
+              {...args}
+              tabIndex={-1}
+              ref={progressRef}
+              value={page}
+              aria-label="Skjemafremgang"
+            />
             <Table border>
               <Table.Head>
                 <Table.Row>

--- a/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
+++ b/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
@@ -3,18 +3,22 @@
 exports[`Form Example 1`] = `
 <style>
   .progress-bar-form-example-main {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--ds-size-6);
 }
-.progress-bar-form-example-fieldset-content {
+.progress-bar-form-example-legend {
+  /* As tall as the ProgressBar, so the bar does not overhang the legend */
   display: flex;
-  width: 100%;
-  justify-content: space-between;
   align-items: flex-end;
-  margin-block-end: var(--ds-size-4);
+  min-height: var(--ds-size-12);
 }
 .progress-bar-form-example-progress-bar {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  transform: translateY(calc(var(--ds-size-4) * -1));
   width: 30%;
 }
 .progress-bar-form-example-button__group {
@@ -24,48 +28,49 @@ exports[`Form Example 1`] = `
 }
 </style>
 <div>
-  <fieldset id="<removed>">
-    <div>
-      <legend>
-        <h4>
-          Skjema
-        </h4>
-      </legend>
-      <div
-        data-color="accent"
-        tabindex="-1"
+  <fieldset
+    id="<removed>"
+    aria-labelledby="<removed>"
+  >
+    <legend id="<removed>">
+      <h4>
+        Skjema
+      </h4>
+    </legend>
+    <div
+      data-color="accent"
+      tabindex="-1"
+    >
+      <span>
+        Skjemafremgang
+      </span>
+      <span>
+        Side 1 av 7
+      </span>
+      <u-progress
+        value="1"
+        max="7"
+        aria-hidden="true"
+        aria-label="..."
+        aria-valuemin="0"
+        aria-valuemax="100"
+        role="progressbar"
+        aria-busy="false"
+        aria-valuenow="14"
+        style="<removed>"
       >
-        <span>
-          Skjemafremgang
-        </span>
-        <span>
-          Side 1 av 7
-        </span>
-        <u-progress
-          value="1"
-          max="7"
-          aria-hidden="true"
-          aria-label="..."
-          aria-valuemin="0"
-          aria-valuemax="100"
-          role="progressbar"
-          aria-busy="false"
-          aria-valuenow="14"
-          style="<removed>"
-        >
-          <template shadowrootmode="open">
-            <slot>
-            </slot>
-            <style>
-              :host(:not([hidden])) { box-sizing: border-box; border: 1px solid; display: inline-block; height: .5em; width: 10em; overflow: hidden }
+        <template shadowrootmode="open">
+          <slot>
+          </slot>
+          <style>
+            :host(:not([hidden])) { box-sizing: border-box; border: 1px solid; display: inline-block; height: .5em; width: 10em; overflow: hidden }
 :host::before { content: ''; display: block; height: 100%; background: currentColor; width: var(--percentage, 0%); transition: width .2s }
 :host(:not([value])) { background: linear-gradient(90deg,currentColor 25%, transparent 50%, currentColor 75%) 50%/400% }
 @media (prefers-reduced-motion: no-preference) { :host { animation: indeterminate 2s linear infinite }  }
 @keyframes indeterminate { from { background-position-x: 100% } to { background-position-x: 0 } }
-            </style>
-          </template>
-        </u-progress>
-      </div>
+          </style>
+        </template>
+      </u-progress>
     </div>
     <table data-border="true">
       <thead>

--- a/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
+++ b/@udir-design/react/src/components/progressBar/__snapshots__/ProgressBar.stories.tsx.snap
@@ -24,12 +24,9 @@ exports[`Form Example 1`] = `
 }
 </style>
 <div>
-  <fieldset
-    id="<removed>"
-    aria-labelledby="<removed>"
-  >
+  <fieldset id="<removed>">
     <div>
-      <legend id="<removed>">
+      <legend>
         <h4>
           Skjema
         </h4>

--- a/@udir-design/react/src/components/radio/Radio.mdx
+++ b/@udir-design/react/src/components/radio/Radio.mdx
@@ -162,6 +162,5 @@ Merk at vi bruker piltastene til å velge alternativer i `Radio`-komponenten, ik
 
 - <kbd data-icon>↑</kbd> eller <kbd data-icon>←</kbd> - går til forrige valg
 - <kbd data-icon>↓</kbd> eller <kbd data-icon>→</kbd> - går til neste valg
-- <kbd>Space</kbd> - går til det første alternativet i en gruppe med
-  radioknapper, når gruppa ikke har et forhåndsvalgt alternativ.
+- <kbd>Space</kbd> - velger alternativet som har fokus.
 - <kbd>Tab</kbd> - går til hele gruppa med alternativer.

--- a/@udir-design/react/src/components/search/Search.mdx
+++ b/@udir-design/react/src/components/search/Search.mdx
@@ -36,7 +36,7 @@ import { Search } from '@udir-design/react';
   /* håndter søk */
 }}>
   <Search>
-    <Search.Input aria-label="Søk" />
+    <Search.Input aria-label="Søk" type="text" />
     <Search.Clear />
     <Search.Button />
   </Search>
@@ -48,7 +48,7 @@ import { Search } from '@udir-design/react';
 ### Varianter
 
 Du velger selv om du vil bruke `Search.Clear` og `Search.Button`. Vi anbefaler at du bruker `Search.Clear` for å gi brukeren mulighet til å fjerne søket.
-Dersom du ikke har `Search.Button` vil input feltet få et søkeikon.
+`Search.Input` har `type="search"` som standard og viser da et søkeikon. Bruk `type="text"` når du inkluderer `Search.Button` slik at søkeikonet skjules.
 Du kan endre `variant` på `Button` for å tilpasse visningen. Eksemplene nedenfor viser varianter som inkluderer ikon, primær- og sekundærknapp.
 
 <Canvas of={SearchStories.Variants} />

--- a/@udir-design/react/src/components/search/Search.spec.tsx
+++ b/@udir-design/react/src/components/search/Search.spec.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { createRef, useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertExists } from '../../utilities/helpers/assertExists';
+import { Search } from './Search';
+
+afterEach(cleanup);
+
+const ControlledSearch = ({
+  disabled = false,
+  initialValue = '',
+}: {
+  disabled?: boolean;
+  initialValue?: string;
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <>
+      <Search>
+        <Search.Input
+          aria-label="Søk"
+          type="text"
+          disabled={disabled}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+        />
+        <Search.Clear />
+      </Search>
+      <button type="button" onClick={() => setValue('Skole')}>
+        Sett verdi
+      </button>
+      <button type="button" onClick={() => setValue('')}>
+        Tøm verdi
+      </button>
+    </>
+  );
+};
+
+/**
+ * The clear button is gated by the `hidden` attribute, which the user agent
+ * stylesheet turns into `display: none`.
+ */
+const clearButtonIsVisible = (container: HTMLElement) => {
+  const clear = assertExists(
+    container.querySelector('button[type="reset"]'),
+    'Clear button not found',
+  );
+
+  return (
+    !clear.hasAttribute('hidden') && getComputedStyle(clear).display !== 'none'
+  );
+};
+
+/**
+ * u-combobox only recomputes the clear button's `hidden` attribute on real `input`
+ * events, so a value that comes from React state leaves it stale in both directions.
+ * See https://github.com/digdir/designsystemet/issues/5295 and the workaround in
+ * `useSyncedClearButton`.
+ */
+describe('Search.Clear follows the input value', () => {
+  it('is hidden while the field is empty', () => {
+    const { container } = render(<ControlledSearch />);
+
+    expect(clearButtonIsVisible(container)).toBe(false);
+  });
+
+  it('is visible when the field starts out with a value', () => {
+    const { container } = render(<ControlledSearch initialValue="Skole" />);
+
+    expect(clearButtonIsVisible(container)).toBe(true);
+  });
+
+  it('appears when the value is set from React state', () => {
+    const { container } = render(<ControlledSearch />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sett verdi' }));
+
+    expect(clearButtonIsVisible(container)).toBe(true);
+  });
+
+  it('disappears when the field is emptied from React state', () => {
+    const { container } = render(<ControlledSearch initialValue="Skole" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Tøm verdi' }));
+
+    expect(clearButtonIsVisible(container)).toBe(false);
+  });
+
+  it('stays hidden for a disabled field that has a value', () => {
+    const { container } = render(
+      <ControlledSearch disabled initialValue="Skole" />,
+    );
+
+    expect(clearButtonIsVisible(container)).toBe(false);
+  });
+
+  it('still forwards a ref to the clear button', () => {
+    const ref = createRef<HTMLButtonElement>();
+    const { container } = render(
+      <Search>
+        <Search.Input aria-label="Søk" type="text" />
+        <Search.Clear ref={ref} />
+      </Search>,
+    );
+
+    expect(ref.current).toBe(container.querySelector('button[type="reset"]'));
+  });
+});

--- a/@udir-design/react/src/components/search/Search.stories.tsx
+++ b/@udir-design/react/src/components/search/Search.stories.tsx
@@ -42,7 +42,7 @@ export const Preview = meta.story({
   render: (args) => (
     <form onSubmit={onSubmit}>
       <Search {...args}>
-        <Search.Input aria-label="Søk" />
+        <Search.Input aria-label="Søk" type="text" />
         <Search.Clear />
         <Search.Button />
       </Search>
@@ -50,7 +50,7 @@ export const Preview = meta.story({
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByRole('searchbox');
+    const input = canvas.getByRole('textbox');
 
     await step('Search input is rendered', async () => {
       expect(input).toBeInTheDocument();
@@ -123,6 +123,7 @@ export const Controlled = meta.story({
             <Search.Input
               id="search-input-controlled"
               aria-label="Søk"
+              type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
             />
@@ -183,12 +184,12 @@ export const Variants = meta.story({
         <Search.Clear />
       </Search>
       <Search {...args}>
-        <Search.Input aria-label="Søk" />
+        <Search.Input aria-label="Søk" type="text" />
         <Search.Clear />
         <Search.Button />
       </Search>
       <Search {...args}>
-        <Search.Input aria-label="Søk" />
+        <Search.Input aria-label="Søk" type="text" />
         <Search.Clear />
         <Search.Button variant="secondary" />
       </Search>
@@ -201,7 +202,7 @@ export const WithLabel = meta.story({
     <Field>
       <Label>Søk i læreplaner</Label>
       <Search {...args}>
-        <Search.Input name="cat-search" />
+        <Search.Input name="cat-search" type="text" />
         <Search.Clear />
         <Search.Button />
       </Search>
@@ -229,6 +230,7 @@ export const Form = meta.story({
           <Search {...args}>
             <Search.Input
               aria-label="Søk"
+              type="text"
               value={value}
               onChange={(e) => setValue(e.target.value)}
             />

--- a/@udir-design/react/src/components/search/Search.tsx
+++ b/@udir-design/react/src/components/search/Search.tsx
@@ -3,27 +3,54 @@ import {
   Search as DigdirSearch,
   SearchButton,
   type SearchButtonProps,
-  SearchClear,
+  SearchClear as DigdirSearchClear,
   type SearchClearProps,
   SearchInput,
   type SearchInputProps,
   type SearchProps as DigdirSearchProps,
 } from '@digdir/designsystemet-react';
-import type {
-  ComponentRef,
-  ForwardRefExoticComponent,
-  RefAttributes,
+import {
+  type ComponentRef,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  forwardRef,
 } from 'react';
+import { useSyncedClearButton } from './useSyncedClearButton';
 
 type SearchProps = Omit<DigdirSearchProps, 'data-color'>;
 
-const Search = DigdirSearch as ForwardRefExoticComponent<
+// Wrapping the root instead of casting digdir's component keeps the `Object.assign`
+// below from mutating the object `@digdir/designsystemet-react` exports, which would
+// leak our Clear to anyone importing Search from there.
+const SearchRoot = forwardRef<ComponentRef<typeof DigdirSearch>, SearchProps>(
+  function Search(props, ref) {
+    return <DigdirSearch {...props} ref={ref} />;
+  },
+);
+
+const SearchClear = forwardRef<HTMLButtonElement, SearchClearProps>(
+  function SearchClear(props, ref) {
+    const clearRef = useSyncedClearButton(ref);
+
+    return <DigdirSearchClear {...props} ref={clearRef} />;
+  },
+);
+
+const Search: ForwardRefExoticComponent<
   SearchProps & RefAttributes<ComponentRef<typeof DigdirSearch>>
-> &
-  Pick<typeof DigdirSearch, 'Clear' | 'Input' | 'Button'>;
+> & {
+  Button: typeof SearchButton;
+  Clear: typeof SearchClear;
+  Input: typeof SearchInput;
+} = Object.assign(SearchRoot, {
+  Button: SearchButton,
+  Clear: SearchClear,
+  Input: SearchInput,
+});
 
 // For some reason this fixes "ComponentSubcomponent" -> "Component.Subcomponent" in Storybook code snippets
 Search.displayName = 'Search';
+SearchClear.displayName = 'Search.Clear';
 
 export type {
   SearchButtonProps,

--- a/@udir-design/react/src/components/search/__snapshots__/Search.stories.tsx.snap
+++ b/@udir-design/react/src/components/search/__snapshots__/Search.stories.tsx.snap
@@ -15,25 +15,26 @@ exports[`Controlled 1`] = `
         }
   </style>
   <form>
-    <div>
+    <ds-suggestion>
       <input
-        placeholder
         id="<removed>"
         aria-label="Søk"
-        type="search"
+        type="text"
         value
       >
       <button
-        data-icon="true"
         data-variant="tertiary"
         type="reset"
         aria-label="Tøm"
+        aria-hidden="false"
+        hidden
+        tabindex="-1"
       >
       </button>
       <button type="submit">
         Søk
       </button>
-    </div>
+    </ds-suggestion>
     <div>
       <p data-size="sm">
         Hurtigsøk:
@@ -55,23 +56,24 @@ exports[`Controlled 1`] = `
 exports[`Form 1`] = `
 <div>
   <form>
-    <div>
+    <ds-suggestion>
       <input
-        placeholder
         aria-label="Søk"
-        type="search"
+        type="text"
       >
       <button
-        data-icon="true"
         data-variant="tertiary"
         type="reset"
         aria-label="Tøm"
+        aria-hidden="false"
+        hidden
+        tabindex="-1"
       >
       </button>
       <button type="submit">
         Søk
       </button>
-    </div>
+    </ds-suggestion>
   </form>
 </div>
 `;
@@ -85,90 +87,95 @@ exports[`Live Search 1`] = `
         }
 </style>
 <div>
-  <div>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="Søk"
       type="search"
       value
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
     >
     </button>
-  </div>
+  </ds-suggestion>
 </div>
 `;
 
 exports[`Preview 1`] = `
 <form>
-  <div>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="Søk"
-      type="search"
+      type="text"
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
     >
     </button>
     <button type="submit">
       Søk
     </button>
-  </div>
+  </ds-suggestion>
 </form>
 `;
 
 exports[`Variants 1`] = `
 <div>
-  <div>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="Søk"
       type="search"
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
     >
     </button>
-  </div>
-  <div>
+  </ds-suggestion>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="Søk"
-      type="search"
+      type="text"
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
     >
     </button>
     <button type="submit">
       Søk
     </button>
-  </div>
-  <div>
+  </ds-suggestion>
+  <ds-suggestion>
     <input
-      placeholder
       aria-label="Søk"
-      type="search"
+      type="text"
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
     >
     </button>
     <button
@@ -177,7 +184,7 @@ exports[`Variants 1`] = `
     >
       Søk
     </button>
-  </div>
+  </ds-suggestion>
 </div>
 `;
 
@@ -186,23 +193,24 @@ exports[`With Label 1`] = `
   <label for="<removed>">
     Søk i læreplaner
   </label>
-  <div>
+  <ds-suggestion>
     <input
-      placeholder
-      type="search"
+      type="text"
       name="cat-search"
       id="<removed>"
     >
     <button
-      data-icon="true"
       data-variant="tertiary"
       type="reset"
       aria-label="Tøm"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
     >
     </button>
     <button type="submit">
       Søk
     </button>
-  </div>
+  </ds-suggestion>
 </ds-field>
 `;

--- a/@udir-design/react/src/components/search/useSyncedClearButton.ts
+++ b/@udir-design/react/src/components/search/useSyncedClearButton.ts
@@ -1,0 +1,54 @@
+import {
+  type Ref,
+  type RefObject,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+
+/**
+ * Keeps the `hidden` attribute on a `<ds-suggestion>` clear button in sync with the
+ * current value of its input. Returns the ref to place on that button, and forwards
+ * the node to `forwardedRef` as well.
+ *
+ * `u-combobox` derives the attribute from the input value, but only recomputes it on
+ * connect, on real `input` events, and when the clear button blurs. A value that comes
+ * from React state is therefore stale in both directions: the button stays hidden for
+ * a field that has a value, and stays visible for a field that was emptied.
+ *
+ * Works around https://github.com/digdir/designsystemet/issues/5295. A value written
+ * straight to the DOM through a ref is still missed, since nothing re-renders — that
+ * case needs an `input` event dispatched anyway, for React's own sake.
+ *
+ * Suggestion does not need this. It owns the input value itself in single mode, and
+ * every change to it routes through u-combobox's own `setValue`, which dispatches a
+ * real `input` event. Search has no item model, so its value is the consumer's React
+ * state and never makes that round trip.
+ */
+export function useSyncedClearButton(
+  forwardedRef: Ref<HTMLButtonElement> | undefined,
+): RefObject<HTMLButtonElement | null> {
+  const clearRef = useRef<HTMLButtonElement>(null);
+
+  useImperativeHandle(
+    forwardedRef,
+    () => clearRef.current as HTMLButtonElement,
+  );
+
+  // No dependency array: the value we compare against lives in the DOM, so there is
+  // nothing to diff. Every render of the clear button is our signal to re-check it.
+  useEffect(() => {
+    const clear = clearRef.current;
+    const input = clear?.closest('ds-suggestion')?.querySelector('input');
+    if (!clear || !input) return;
+
+    // Same condition as u-combobox's own `isIdle`, so a disabled or read-only field
+    // keeps its clear button hidden.
+    const idle = !input.value || input.disabled || input.readOnly;
+    if (clear.hasAttribute('hidden') !== idle) {
+      clear.toggleAttribute('hidden', idle);
+    }
+  });
+
+  return clearRef;
+}

--- a/@udir-design/react/src/components/suggestion/Suggestion.mdx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.mdx
@@ -28,7 +28,7 @@ import { Suggestion } from '@udir-design/react/alpha';
   <Suggestion.Toggle />
   <Suggestion.Clear />
   <Suggestion.List>
-    <Suggestion.Empty>Tomt</Suggestion.Empty>
+    <Suggestion.Empty />
     <Suggestion.Option label="Sogndal" value="sogndal">
       Sogndal
     </Suggestion.Option>
@@ -64,6 +64,14 @@ Dersom du vil vise alle alternativer, uavhengig av input, kan du sette `filter={
 
 <Canvas of={SuggestionStories.CustomFilterAlt1} />
 
+### Legge til nye alternativer
+
+Bruk `creatable` for å la brukeren legge til egne alternativer. Når teksten i inputfeltet ikke finnes i listen fra før, kommer det opp et alternativ for å legge den til. Brukeren velger det med <kbd>Enter</kbd> eller ved å klikke på det.
+
+Teksten på alternativet kan tilpasses med CSS-variabelen `--dsc-suggestion-create-text`, hvor `{value}` blir erstattet med teksten brukeren har skrevet inn.
+
+<Canvas of={SuggestionStories.Creatable} />
+
 ### Asynkrone data
 
 `Suggestion` har ikke en egen `loading` state, så dette må håndereres selv.
@@ -86,4 +94,10 @@ Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtt
 
 Følgende tekstvariabler er tilgjengelige for overstyring:
 
-<CssLanguageVariables variables={['--dsc-suggestion-count-label']} />
+<CssLanguageVariables
+  variables={[
+    '--dsc-suggestion-count-label',
+    '--dsc-suggestion-create-text',
+    '--dsc-suggestion-empty-text',
+  ]}
+/>

--- a/@udir-design/react/src/components/suggestion/Suggestion.mdx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.mdx
@@ -25,6 +25,7 @@ import { Suggestion } from '@udir-design/react/alpha';
 
 <Suggestion>
   <Suggestion.Input />
+  <Suggestion.Toggle />
   <Suggestion.Clear />
   <Suggestion.List>
     <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -37,6 +38,8 @@ import { Suggestion } from '@udir-design/react/alpha';
   </Suggestion.List>
 </Suggestion>;
 ```
+
+`Suggestion.Toggle` legger til en knapp som åpner og lukker listen med alternativer. Knappen har `aria-label="Valg"` som standard. Angi en annen `aria-label` dersom teksten ikke beskriver innholdet i listen.
 
 ## Eksempler
 

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -21,6 +21,7 @@ import { SuggestionEmpty } from './docs/FakeSuggestionEmpty';
 import { SuggestionInput } from './docs/FakeSuggestionInput';
 import { SuggestionList } from './docs/FakeSuggestionList';
 import { SuggestionOption } from './docs/FakeSuggestionOption';
+import { SuggestionToggle } from './docs/FakeSuggestionToggle';
 
 const meta = preview.meta({
   component: FakeSuggestion,
@@ -30,6 +31,7 @@ const meta = preview.meta({
     'Suggestion.Input': SuggestionInput,
     'Suggestion.List': SuggestionList,
     'Suggestion.Option': SuggestionOption,
+    'Suggestion.Toggle': SuggestionToggle,
   },
   tags: ['digdir'],
   parameters: {
@@ -72,8 +74,16 @@ const meta = preview.meta({
 async function testSuggestion(el: HTMLElement) {
   /* wait for role to be added */
   const input = await waitFor(() => within(el).getByRole('combobox'));
-  /* When in test mode, open suggestion by focusing input */
-  await userEvent.click(input);
+  const toggle = within(el).queryByRole('button', { name: 'Valg' });
+
+  if (toggle) {
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(toggle);
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  } else {
+    /* When in test mode, open suggestion by focusing input */
+    await userEvent.click(input);
+  }
 }
 
 const DATA_PLACES = [
@@ -113,6 +123,7 @@ export const Preview = meta.story({
         <Label>Velg en destinasjon</Label>
         <Suggestion {...args}>
           <Suggestion.Input />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
             <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -143,6 +154,7 @@ export const ControlledSingle = meta.story({
             onSelectedChange={(item) => setValue(item?.value ?? '')}
           >
             <Suggestion.Input />
+            <Suggestion.Toggle />
             <Suggestion.Clear />
             <Suggestion.List>
               <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -212,6 +224,7 @@ export const ControlledMultiple = meta.story({
             }
           >
             <Suggestion.Input />
+            <Suggestion.Toggle />
             <Suggestion.Clear />
             <Suggestion.List>
               <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -287,6 +300,7 @@ export const ControlledIndependentLabelValue = meta.story({
             filter={false}
           >
             <Suggestion.Input />
+            <Suggestion.Toggle />
             <Suggestion.Clear />
             <Suggestion.List>
               <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -338,6 +352,7 @@ export const CustomFilterAlt1 = meta.story({
           }
         >
           <Suggestion.Input />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
             <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -373,6 +388,7 @@ export const CustomFilterAlt2 = meta.story({
           <Suggestion.Input
             onInput={({ currentTarget }) => setValue(currentTarget.value)}
           />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
             <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -411,6 +427,7 @@ export const AlwaysShowAll = meta.story({
           onSelectedChange={(item) => setValue(item?.value)}
         >
           <Suggestion.Input />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
             <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -461,6 +478,7 @@ export const FetchExternal = meta.story({
         <Label>Search for countries (in english)</Label>
         <Suggestion {...args} filter={false}>
           <Suggestion.Input onInput={handleInput} />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List singular="%d country" plural="%d countries">
             {value ? (
@@ -507,6 +525,7 @@ export const MultipleCount = meta.story({
           defaultSelected={['Oslo', 'Sogndal']}
         >
           <Suggestion.Input />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
             <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -533,6 +552,7 @@ export const DefaultValue = meta.story({
           defaultSelected={'Sogndal'}
         >
           <Suggestion.Input />
+          <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
             <Suggestion.Empty>Tomt</Suggestion.Empty>
@@ -556,6 +576,7 @@ export const InDetails = meta.story({
             <Label>Velg en destinasjon</Label>
             <Suggestion {...args} autoFocus>
               <Suggestion.Input />
+              <Suggestion.Toggle />
               <Suggestion.Clear />
               <Suggestion.List>
                 <Suggestion.Empty>Tomt</Suggestion.Empty>

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -196,6 +196,44 @@ export const Creatable = Preview.extend({
   },
 });
 
+/* Regression test only, so it leaves the list closed and is kept out of Chromatic.
+   Creatable itself has to end with the list open to snapshot the create option. */
+export const CreatableSelectionSurvivesBlur = Creatable.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Selecting an existing option after a substring search survives blur',
+      async () => {
+        const input = await waitFor(() =>
+          within(canvasElement).getByRole('combobox'),
+        );
+        await userEvent.click(input);
+        await userEvent.type(input, 'slo');
+
+        const oslo = await waitFor(() => {
+          const option = within(canvasElement)
+            .getAllByRole('option')
+            .find((o) => (o as HTMLOptionElement).value === 'Oslo');
+          if (!option) throw new Error('Oslo option not found');
+          return option;
+        });
+
+        await userEvent.click(oslo);
+        await waitFor(() => expect(input).toHaveValue('Oslo'));
+
+        /* Up to digdir 1.18 the input was reset to the typed query on blur, and
+           onSelectedChange fired again with the query as both label and value. */
+        await userEvent.click(document.body);
+        await waitFor(() =>
+          expect(input).toHaveAttribute('aria-expanded', 'false'),
+        );
+        await expect(input).toHaveValue('Oslo');
+      },
+    );
+  },
+});
+
 export const ControlledSingle = meta.story({
   render: (args) => {
     const [value, setValue] = useState<string>('');

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -60,6 +60,14 @@ const meta = preview.meta({
             id: 'aria-allowed-role',
             matches: (element) => !(element instanceof HTMLInputElement),
           },
+          /* The option for creating a new value gets its accessible name from
+           * `--dsc-suggestion-create-text`. Axe doesn't take generated content
+           * into account when computing accessible names but the name is
+           * present in the accessibility tree, so this is a false positive. */
+          {
+            id: 'aria-toggle-field-name',
+            matches: (element) => !element.matches('u-option[data-create]'),
+          },
         ],
       },
     },
@@ -85,6 +93,34 @@ async function testSuggestion(el: HTMLElement) {
     await userEvent.click(input);
   }
 }
+
+/**
+ * Types a value that doesn't match any option, leaving the option for creating
+ * a new value as the only one in the list
+ */
+async function typeUnknownValue(el: HTMLElement, value: string) {
+  const input = await waitFor(() => within(el).getByRole('combobox'));
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
+
+  /* Chips for selected values also have `role="option"`, and options that
+   * don't match the input are `aria-hidden`, so the option to create a new
+   * value is the only `u-option` left in the a11y tree */
+  const options = within(el)
+    .getAllByRole('option')
+    .filter((option) => option.matches('u-option'));
+  await expect(options).toHaveLength(1);
+
+  return { input, createOption: options[0] };
+}
+
+const getChipValues = (el: HTMLElement) =>
+  waitFor(() =>
+    within(el)
+      .getAllByLabelText('Press to remove', { exact: false })
+      .filter((chip) => chip instanceof HTMLDataElement)
+      .map((chip) => chip.value),
+  );
 
 const DATA_PLACES = [
   'Sogndal',
@@ -126,7 +162,7 @@ export const Preview = meta.story({
           <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
-            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            <Suggestion.Empty />
             {DATA_PLACES.map((place) => (
               <Suggestion.Option key={place} label={place} value={place}>
                 {place}
@@ -136,6 +172,26 @@ export const Preview = meta.story({
           </Suggestion.List>
         </Suggestion>
       </Field>
+    );
+  },
+});
+
+export const Creatable = Preview.extend({
+  args: { creatable: true },
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Typing an unknown value shows the option to add it',
+      async () => {
+        const { createOption } = await typeUnknownValue(
+          canvasElement,
+          'Finnes ikke',
+        );
+
+        await expect(createOption).toHaveAttribute(
+          'data-create',
+          'Legg til "Finnes ikke"',
+        );
+      },
     );
   },
 });
@@ -157,7 +213,7 @@ export const ControlledSingle = meta.story({
             <Suggestion.Toggle />
             <Suggestion.Clear />
             <Suggestion.List>
-              <Suggestion.Empty>Tomt</Suggestion.Empty>
+              <Suggestion.Empty />
               {DATA_PLACES.map((place) => (
                 <Suggestion.Option key={place} label={place} value={place}>
                   {place}
@@ -208,6 +264,28 @@ export const ControlledSingle = meta.story({
   },
 });
 
+export const ControlledSingleCreatable = ControlledSingle.extend({
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: { creatable: true },
+  play: async ({ canvasElement, step }) => {
+    await step('Created value becomes the controlled selection', async () => {
+      const { input, createOption } = await typeUnknownValue(
+        canvasElement,
+        'Finnes ikke',
+      );
+      await userEvent.click(createOption);
+
+      const resultText = within(canvasElement).getByText('Valgte reisemål:', {
+        exact: false,
+      });
+      await expect(resultText).toHaveTextContent('Finnes ikke');
+      await waitFor(() => expect(input).toHaveValue('Finnes ikke'));
+    });
+  },
+});
+
 export const ControlledMultiple = meta.story({
   render: (args) => {
     const [value, setValue] = useState<string[]>(['Oslo']);
@@ -227,7 +305,7 @@ export const ControlledMultiple = meta.story({
             <Suggestion.Toggle />
             <Suggestion.Clear />
             <Suggestion.List>
-              <Suggestion.Empty>Tomt</Suggestion.Empty>
+              <Suggestion.Empty />
               {DATA_PLACES.map((place) => (
                 <Suggestion.Option key={place} label={place} value={place}>
                   {place}
@@ -254,13 +332,6 @@ export const ControlledMultiple = meta.story({
     );
   },
   play: async ({ canvasElement, step }) => {
-    const getChipValues = async () =>
-      waitFor(() =>
-        within(canvasElement)
-          .getAllByLabelText('Press to remove', { exact: false })
-          .filter((el) => el instanceof HTMLDataElement)
-          .map((x) => x.value),
-      );
     const resultText = within(canvasElement).getByText('Valgte reisemål:', {
       exact: false,
     });
@@ -271,17 +342,46 @@ export const ControlledMultiple = meta.story({
 
     await step('Initial state is rendered correctly', async () => {
       await expect(resultText).toHaveTextContent('Oslo');
-      await expect(await getChipValues()).toContain('Oslo');
+      await expect(await getChipValues(canvasElement)).toContain('Oslo');
     });
 
     await step('Controlled state change renders correctly', async () => {
       await userEvent.click(button);
       await expect(resultText).toHaveTextContent('Sogndal');
       await expect(resultText).toHaveTextContent('Stavanger');
-      const chipValues = await getChipValues();
+      const chipValues = await getChipValues(canvasElement);
       await expect(chipValues).toContain('Sogndal');
       await expect(chipValues).toContain('Stavanger');
     });
+  },
+});
+
+export const ControlledMultipleCreatable = ControlledMultiple.extend({
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: { creatable: true },
+  play: async ({ canvasElement, step }) => {
+    await step(
+      'Created value is added to the controlled selection',
+      async () => {
+        const { createOption } = await typeUnknownValue(
+          canvasElement,
+          'Finnes ikke',
+        );
+        await userEvent.click(createOption);
+
+        const resultText = within(canvasElement).getByText('Valgte reisemål:', {
+          exact: false,
+        });
+        await expect(resultText).toHaveTextContent('Oslo');
+        await expect(resultText).toHaveTextContent('Finnes ikke');
+        await expect(await getChipValues(canvasElement)).toEqual([
+          'Oslo',
+          'Finnes ikke',
+        ]);
+      },
+    );
   },
 });
 
@@ -303,7 +403,7 @@ export const ControlledIndependentLabelValue = meta.story({
             <Suggestion.Toggle />
             <Suggestion.Clear />
             <Suggestion.List>
-              <Suggestion.Empty>Tomt</Suggestion.Empty>
+              <Suggestion.Empty />
               {DATA_PEOPLE.map(({ label, value }) => (
                 <Suggestion.Option key={value} label={label} value={value}>
                   {label}
@@ -355,7 +455,7 @@ export const CustomFilterAlt1 = meta.story({
           <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
-            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            <Suggestion.Empty />
             {DATA_PLACES.map((label) => (
               <Suggestion.Option key={label} value={label.toLowerCase()}>
                 {label}
@@ -391,7 +491,7 @@ export const CustomFilterAlt2 = meta.story({
           <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
-            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            <Suggestion.Empty />
             {DATA_PLACES.filter(
               (_, index) => !value || index === Number(value) - 1,
             ).map((label) => (
@@ -430,7 +530,7 @@ export const AlwaysShowAll = meta.story({
           <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
-            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            <Suggestion.Empty />
             {DATA_PLACES.map((place) => (
               <Suggestion.Option key={place}>{place}</Suggestion.Option>
             ))}
@@ -513,6 +613,24 @@ export const FetchExternal = meta.story({
 
 export const Multiple = Preview.extend({ args: { multiple: true } });
 
+export const MultipleCreatable = Multiple.extend({
+  args: { creatable: true },
+  play: async ({ canvasElement, step }) => {
+    await step('Several values can be created in a row', async () => {
+      const first = await typeUnknownValue(canvasElement, 'Finnes ikke');
+      await userEvent.click(first.createOption);
+
+      const second = await typeUnknownValue(canvasElement, 'Heller ikke');
+      await userEvent.click(second.createOption);
+
+      await expect(await getChipValues(canvasElement)).toEqual([
+        'Finnes ikke',
+        'Heller ikke',
+      ]);
+    });
+  },
+});
+
 export const MultipleCount = meta.story({
   render(args) {
     return (
@@ -528,7 +646,7 @@ export const MultipleCount = meta.story({
           <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
-            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            <Suggestion.Empty />
             {DATA_PLACES.map((place) => (
               <Suggestion.Option key={place} label={place} value={place}>
                 {place}
@@ -555,7 +673,7 @@ export const DefaultValue = meta.story({
           <Suggestion.Toggle />
           <Suggestion.Clear />
           <Suggestion.List>
-            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            <Suggestion.Empty />
             {DATA_PLACES.map((place) => (
               <Suggestion.Option key={place}>{place}</Suggestion.Option>
             ))}
@@ -579,7 +697,7 @@ export const InDetails = meta.story({
               <Suggestion.Toggle />
               <Suggestion.Clear />
               <Suggestion.List>
-                <Suggestion.Empty>Tomt</Suggestion.Empty>
+                <Suggestion.Empty />
                 {DATA_PLACES.map((place) => (
                   <Suggestion.Option key={place}>{place}</Suggestion.Option>
                 ))}

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -189,7 +189,7 @@ export const Creatable = Preview.extend({
 
         await expect(createOption).toHaveAttribute(
           'data-create',
-          'Legg til "Finnes ikke"',
+          'Legg til «Finnes ikke»',
         );
       },
     );

--- a/@udir-design/react/src/components/suggestion/Suggestion.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.tsx
@@ -5,6 +5,7 @@ import {
   EXPERIMENTAL_SuggestionInput as SuggestionInput,
   EXPERIMENTAL_SuggestionList as SuggestionList,
   EXPERIMENTAL_SuggestionOption as SuggestionOption,
+  EXPERIMENTAL_SuggestionToggle as SuggestionToggle,
   type SuggestionClearProps,
   type SuggestionEmptyProps,
   type SuggestionInputProps,
@@ -13,6 +14,7 @@ import {
   type SuggestionMultipleProps as DigdirSuggestionMultipleProps,
   type SuggestionOptionProps,
   type SuggestionSingleProps as DigdirSuggestionSingleProps,
+  type SuggestionToggleProps,
 } from '@digdir/designsystemet-react';
 import {
   type ComponentRef,
@@ -68,12 +70,14 @@ const Suggestion: ForwardRefExoticComponent<
   Input: typeof SuggestionInput;
   List: typeof SuggestionList;
   Option: typeof SuggestionOption;
+  Toggle: typeof SuggestionToggle;
 } = Object.assign(SuggestionBase, {
   Clear: SuggestionClear,
   Empty: SuggestionEmpty,
   Input: SuggestionInput,
   List: SuggestionList,
   Option: SuggestionOption,
+  Toggle: SuggestionToggle,
 });
 
 Suggestion.displayName = 'Suggestion';
@@ -82,6 +86,7 @@ SuggestionEmpty.displayName = 'Suggestion.Empty';
 SuggestionInput.displayName = 'Suggestion.Input';
 SuggestionList.displayName = 'Suggestion.List';
 SuggestionOption.displayName = 'Suggestion.Option';
+SuggestionToggle.displayName = 'Suggestion.Toggle';
 
 export {
   Suggestion,
@@ -99,4 +104,6 @@ export {
   type SuggestionOptionProps,
   type SuggestionProps,
   type SuggestionSingleProps,
+  SuggestionToggle,
+  type SuggestionToggleProps,
 };

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -531,10 +531,10 @@ exports[`Controlled Multiple Creatable 1`] = `
       data-floating="bottom"
     >
       <u-option
-        data-empty="Legg til &quot;{value}&quot;"
+        data-empty="Legg til «{value}»"
         label="Finnes ikke"
         value="Finnes ikke"
-        data-create="Legg til &quot;Finnes ikke&quot;"
+        data-create="Legg til «Finnes ikke»"
         role="option"
         aria-disabled="false"
         aria-selected="true"
@@ -900,10 +900,10 @@ exports[`Controlled Single Creatable 1`] = `
       hidden
     >
       <u-option
-        data-empty="Legg til &quot;{value}&quot;"
+        data-empty="Legg til «{value}»"
         label="Finnes ikke"
         value="Finnes ikke"
-        data-create="Legg til &quot;Finnes ikke&quot;"
+        data-create="Legg til «Finnes ikke»"
         role="option"
         aria-disabled="false"
         aria-selected="true"
@@ -1083,10 +1083,10 @@ exports[`Creatable 1`] = `
       data-floating="bottom"
     >
       <u-option
-        data-empty="Legg til &quot;{value}&quot;"
+        data-empty="Legg til «{value}»"
         label="Finnes ikke"
         value="Finnes ikke"
-        data-create="Legg til &quot;Finnes ikke&quot;"
+        data-create="Legg til «Finnes ikke»"
         role="option"
         aria-disabled="false"
         aria-selected="false"
@@ -2238,10 +2238,10 @@ exports[`Multiple Creatable 1`] = `
       data-floating="bottom"
     >
       <u-option
-        data-empty="Legg til &quot;{value}&quot;"
+        data-empty="Legg til «{value}»"
         label="Heller ikke"
         value="Heller ikke"
-        data-create="Legg til &quot;Heller ikke&quot;"
+        data-create="Legg til «Heller ikke»"
         role="option"
         aria-disabled="false"
         aria-selected="true"

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -19,10 +19,10 @@ exports[`Always Show All 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist10"
-      popovertarget=":u-datalist10"
+      list=":u-datalist11"
+      popovertarget=":u-datalist11"
       aria-autocomplete="list"
-      aria-controls=":u-datalist10"
+      aria-controls=":u-datalist11"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -159,10 +159,10 @@ exports[`Controlled Independent Label Value 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist7"
-      popovertarget=":u-datalist7"
+      list=":u-datalist8"
+      popovertarget=":u-datalist8"
       aria-autocomplete="list"
-      aria-controls=":u-datalist7"
+      aria-controls=":u-datalist8"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -306,8 +306,8 @@ exports[`Controlled Multiple 1`] = `
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
-      list=":u-datalist5"
-      popovertarget=":u-datalist5"
+      list=":u-datalist6"
+      popovertarget=":u-datalist6"
     >
     <button
       aria-expanded="false"
@@ -489,10 +489,10 @@ exports[`Controlled Multiple Creatable 1`] = `
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
-      list=":u-datalist6"
-      popovertarget=":u-datalist6"
+      list=":u-datalist7"
+      popovertarget=":u-datalist7"
       aria-autocomplete="list"
-      aria-controls=":u-datalist6"
+      aria-controls=":u-datalist7"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -683,8 +683,8 @@ exports[`Controlled Single 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist3"
-      popovertarget=":u-datalist3"
+      list=":u-datalist4"
+      popovertarget=":u-datalist4"
     >
     <button
       aria-expanded="false"
@@ -858,10 +858,10 @@ exports[`Controlled Single Creatable 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist4"
-      popovertarget=":u-datalist4"
+      list=":u-datalist5"
+      popovertarget=":u-datalist5"
       aria-autocomplete="list"
-      aria-controls=":u-datalist4"
+      aria-controls=":u-datalist5"
       aria-expanded="false"
       autocomplete="off"
       enterkeyhint="done"
@@ -1204,6 +1204,190 @@ exports[`Creatable 1`] = `
 </ds-field>
 `;
 
+exports[`Creatable Selection Survives Blur 1`] = `
+<ds-field>
+  <label for="<removed>">
+    Velg en destinasjon
+  </label>
+  <ds-suggestion data-creatable>
+    <data
+      value="Oslo"
+      aria-label="Oslo, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Oslo
+    </data>
+    <input
+      placeholder
+      type="text"
+      id="<removed>"
+      list=":u-datalist3"
+      popovertarget=":u-datalist3"
+      aria-autocomplete="list"
+      aria-controls=":u-datalist3"
+      aria-expanded="false"
+      autocomplete="off"
+      enterkeyhint="done"
+      role="combobox"
+    >
+    <button
+      aria-expanded="false"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
+    >
+    </button>
+    <button
+      aria-label="Tøm"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <u-datalist
+      data-nofilter
+      data-sr-plural="%d forslag"
+      data-sr-singular="%d forslag"
+      popover="manual"
+      role="listbox"
+      data-sr-of="of"
+      tabindex="-1"
+      aria-multiselectable="false"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg en destinasjon"
+      style="<removed>"
+      data-floating="bottom"
+      hidden
+    >
+      <u-option
+        data-empty="Legg til «{value}»"
+        label="Oslo"
+        value="Oslo"
+        data-create="Legg til «Oslo»"
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="false"
+        hidden
+        selected
+      >
+      </u-option>
+      <u-option
+        label="Sogndal"
+        value="Sogndal"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Sogndal
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Oslo"
+        value="Oslo"
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="false"
+        selected
+      >
+        Oslo
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Brønnøysund"
+        value="Brønnøysund"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Brønnøysund
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Stavanger"
+        value="Stavanger"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Stavanger
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Trondheim"
+        value="Trondheim"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Trondheim
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Bergen"
+        value="Bergen"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Bergen
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Lillestrøm"
+        value="Lillestrøm"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Lillestrøm
+        <div>
+          Kommune
+        </div>
+      </u-option>
+    </u-datalist>
+  </ds-suggestion>
+</ds-field>
+`;
+
 exports[`Custom Filter Alt 1 1`] = `
 <ds-field>
   <label for="<removed>">
@@ -1214,10 +1398,10 @@ exports[`Custom Filter Alt 1 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist8"
-      popovertarget=":u-datalist8"
+      list=":u-datalist9"
+      popovertarget=":u-datalist9"
       aria-autocomplete="list"
-      aria-controls=":u-datalist8"
+      aria-controls=":u-datalist9"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1351,10 +1535,10 @@ exports[`Custom Filter Alt 2 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist9"
-      popovertarget=":u-datalist9"
+      list=":u-datalist10"
+      popovertarget=":u-datalist10"
       aria-autocomplete="list"
-      aria-controls=":u-datalist9"
+      aria-controls=":u-datalist10"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1490,10 +1674,10 @@ exports[`Default Value 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist15"
-      popovertarget=":u-datalist15"
+      list=":u-datalist16"
+      popovertarget=":u-datalist16"
       aria-autocomplete="list"
-      aria-controls=":u-datalist15"
+      aria-controls=":u-datalist16"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1627,10 +1811,10 @@ exports[`Fetch External 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist11"
-      popovertarget=":u-datalist11"
+      list=":u-datalist12"
+      popovertarget=":u-datalist12"
       aria-autocomplete="list"
-      aria-controls=":u-datalist11"
+      aria-controls=":u-datalist12"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1687,10 +1871,10 @@ exports[`In Details 1`] = `
           placeholder
           type="text"
           id="<removed>"
-          list=":u-datalist16"
-          popovertarget=":u-datalist16"
+          list=":u-datalist17"
+          popovertarget=":u-datalist17"
           aria-autocomplete="list"
-          aria-controls=":u-datalist16"
+          aria-controls=":u-datalist17"
           aria-expanded="true"
           autocomplete="off"
           enterkeyhint="done"
@@ -1820,10 +2004,10 @@ exports[`Multiple 1`] = `
       type="text"
       id="<removed>"
       aria-description="No selected"
-      list=":u-datalist12"
-      popovertarget=":u-datalist12"
+      list=":u-datalist13"
+      popovertarget=":u-datalist13"
       aria-autocomplete="list"
-      aria-controls=":u-datalist12"
+      aria-controls=":u-datalist13"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -2007,10 +2191,10 @@ exports[`Multiple Count 1`] = `
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
-      list=":u-datalist14"
-      popovertarget=":u-datalist14"
+      list=":u-datalist15"
+      popovertarget=":u-datalist15"
       aria-autocomplete="list"
-      aria-controls=":u-datalist14"
+      aria-controls=":u-datalist15"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -2196,10 +2380,10 @@ exports[`Multiple Creatable 1`] = `
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
-      list=":u-datalist13"
-      popovertarget=":u-datalist13"
+      list=":u-datalist14"
+      popovertarget=":u-datalist14"
       aria-autocomplete="list"
-      aria-controls=":u-datalist13"
+      aria-controls=":u-datalist14"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -16,7 +16,7 @@ exports[`Always Show All 1`] = `
       Sogndal
     </data>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist7"
@@ -50,6 +50,19 @@ exports[`Always Show All 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label="Sogndal"
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         selected
         role="option"
@@ -135,7 +148,7 @@ exports[`Controlled Independent Label Value 1`] = `
       Lars
     </data>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist4"
@@ -169,6 +182,19 @@ exports[`Controlled Independent Label Value 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label="Lars"
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         label="Lars"
         value="#004"
@@ -260,7 +286,7 @@ exports[`Controlled Multiple 1`] = `
       Stavanger
     </data>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
@@ -288,6 +314,18 @@ exports[`Controlled Multiple 1`] = `
       id="<removed>"
       data-is-floating="true"
     >
+      <u-option
+        data-empty
+        hidden
+        label
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+      >
+        Tomt
+      </u-option>
       <u-option
         label="Sogndal"
         value="Sogndal"
@@ -412,7 +450,7 @@ exports[`Controlled Single 1`] = `
       Sogndal
     </data>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist2"
@@ -438,6 +476,18 @@ exports[`Controlled Single 1`] = `
       id="<removed>"
       data-is-floating="true"
     >
+      <u-option
+        data-empty
+        hidden
+        label="Sogndal"
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+      >
+        Tomt
+      </u-option>
       <u-option
         label="Sogndal"
         value="Sogndal"
@@ -558,7 +608,7 @@ exports[`Custom Filter Alt 1 1`] = `
   </label>
   <ds-suggestion>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist5"
@@ -593,6 +643,19 @@ exports[`Custom Filter Alt 1 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         value="sogndal"
         role="option"
@@ -675,7 +738,7 @@ exports[`Custom Filter Alt 2 1`] = `
   </label>
   <ds-suggestion>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist6"
@@ -710,6 +773,19 @@ exports[`Custom Filter Alt 2 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         role="option"
         aria-disabled="false"
@@ -794,7 +870,7 @@ exports[`Default Value 1`] = `
       Sogndal
     </data>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist11"
@@ -828,6 +904,19 @@ exports[`Default Value 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label="Sogndal"
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         selected
         role="option"
@@ -910,7 +999,7 @@ exports[`Fetch External 1`] = `
   </label>
   <ds-suggestion>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist8"
@@ -962,7 +1051,7 @@ exports[`In Details 1`] = `
       </label>
       <ds-suggestion autofocus>
         <input
-          placeholder=" "
+          placeholder
           type="text"
           id="<removed>"
           list=":u-datalist12"
@@ -997,6 +1086,19 @@ exports[`In Details 1`] = `
           style="<removed>"
           data-floating="bottom"
         >
+          <u-option
+            data-empty
+            hidden
+            label
+            value
+            role="option"
+            aria-disabled="false"
+            aria-selected="false"
+            id="<removed>"
+            aria-hidden="true"
+          >
+            Tomt
+          </u-option>
           <u-option
             role="option"
             aria-disabled="false"
@@ -1074,7 +1176,7 @@ exports[`Multiple 1`] = `
   </label>
   <ds-suggestion data-multiple>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       aria-description="No selected"
@@ -1110,6 +1212,19 @@ exports[`Multiple 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         label="Sogndal"
         value="Sogndal"
@@ -1241,7 +1356,7 @@ exports[`Multiple Count 1`] = `
       Sogndal
     </data>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
@@ -1277,6 +1392,19 @@ exports[`Multiple Count 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         label="Sogndal"
         value="Sogndal"
@@ -1389,7 +1517,7 @@ exports[`Preview 1`] = `
   </label>
   <ds-suggestion>
     <input
-      placeholder=" "
+      placeholder
       type="text"
       id="<removed>"
       list=":u-datalist1"
@@ -1424,6 +1552,19 @@ exports[`Preview 1`] = `
       style="<removed>"
       data-floating="bottom"
     >
+      <u-option
+        data-empty
+        hidden
+        label
+        value
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+      >
+        Tomt
+      </u-option>
       <u-option
         label="Sogndal"
         value="Sogndal"

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -29,6 +29,15 @@ exports[`Always Show All 1`] = `
       role="combobox"
     >
     <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
+    >
+    </button>
+    <button
       aria-label="Tøm"
       type="reset"
       aria-hidden="false"
@@ -160,6 +169,15 @@ exports[`Controlled Independent Label Value 1`] = `
       enterkeyhint="done"
       role="combobox"
     >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
+    >
+    </button>
     <button
       aria-label="Tøm"
       type="reset"
@@ -293,6 +311,14 @@ exports[`Controlled Multiple 1`] = `
       list=":u-datalist3"
       popovertarget=":u-datalist3"
     >
+    <button
+      aria-expanded="false"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
     <button
       aria-label="Tøm"
       hidden
@@ -456,6 +482,15 @@ exports[`Controlled Single 1`] = `
       list=":u-datalist2"
       popovertarget=":u-datalist2"
     >
+    <button
+      aria-expanded="false"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
+    >
+    </button>
     <button
       aria-label="Tøm"
       type="reset"
@@ -621,6 +656,14 @@ exports[`Custom Filter Alt 1 1`] = `
       role="combobox"
     >
     <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <button
       aria-label="Tøm"
       hidden
       type="reset"
@@ -750,6 +793,14 @@ exports[`Custom Filter Alt 2 1`] = `
       enterkeyhint="done"
       role="combobox"
     >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
     <button
       aria-label="Tøm"
       hidden
@@ -883,6 +934,15 @@ exports[`Default Value 1`] = `
       role="combobox"
     >
     <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      hidden
+      tabindex="-1"
+    >
+    </button>
+    <button
       aria-label="Tøm"
       type="reset"
       aria-hidden="false"
@@ -1012,6 +1072,14 @@ exports[`Fetch External 1`] = `
       role="combobox"
     >
     <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <button
       aria-label="Tøm"
       hidden
       type="reset"
@@ -1063,6 +1131,14 @@ exports[`In Details 1`] = `
           enterkeyhint="done"
           role="combobox"
         >
+        <button
+          aria-expanded="true"
+          aria-label="Valg"
+          type="button"
+          aria-hidden="false"
+          tabindex="-1"
+        >
+        </button>
         <button
           aria-label="Tøm"
           hidden
@@ -1189,6 +1265,14 @@ exports[`Multiple 1`] = `
       enterkeyhint="done"
       role="combobox"
     >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
     <button
       aria-label="Tøm"
       hidden
@@ -1370,6 +1454,14 @@ exports[`Multiple Count 1`] = `
       role="combobox"
     >
     <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <button
       aria-label="Tøm"
       hidden
       type="reset"
@@ -1529,6 +1621,14 @@ exports[`Preview 1`] = `
       enterkeyhint="done"
       role="combobox"
     >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
     <button
       aria-label="Tøm"
       hidden

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -19,10 +19,10 @@ exports[`Always Show All 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist7"
-      popovertarget=":u-datalist7"
+      list=":u-datalist10"
+      popovertarget=":u-datalist10"
       aria-autocomplete="list"
-      aria-controls=":u-datalist7"
+      aria-controls=":u-datalist10"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -70,7 +70,6 @@ exports[`Always Show All 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         selected
@@ -160,10 +159,10 @@ exports[`Controlled Independent Label Value 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist4"
-      popovertarget=":u-datalist4"
+      list=":u-datalist7"
+      popovertarget=":u-datalist7"
       aria-autocomplete="list"
-      aria-controls=":u-datalist4"
+      aria-controls=":u-datalist7"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -211,7 +210,6 @@ exports[`Controlled Independent Label Value 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         label="Lars"
@@ -308,8 +306,8 @@ exports[`Controlled Multiple 1`] = `
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
-      list=":u-datalist3"
-      popovertarget=":u-datalist3"
+      list=":u-datalist5"
+      popovertarget=":u-datalist5"
     >
     <button
       aria-expanded="false"
@@ -350,7 +348,6 @@ exports[`Controlled Multiple 1`] = `
         aria-selected="false"
         id="<removed>"
       >
-        Tomt
       </u-option>
       <u-option
         label="Sogndal"
@@ -460,6 +457,213 @@ exports[`Controlled Multiple 1`] = `
 </button>
 `;
 
+exports[`Controlled Multiple Creatable 1`] = `
+<ds-field>
+  <label for="<removed>">
+    Velg destinasjoner
+  </label>
+  <ds-suggestion
+    data-multiple
+    data-creatable
+  >
+    <data
+      value="Oslo"
+      aria-label="Added Finnes ikke, Oslo, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Oslo
+    </data>
+    <data
+      value="Finnes ikke"
+      aria-label="Added Finnes ikke, Finnes ikke, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Finnes ikke
+    </data>
+    <input
+      placeholder
+      type="text"
+      id="<removed>"
+      aria-description="Navigate left to find 2 selected"
+      list=":u-datalist6"
+      popovertarget=":u-datalist6"
+      aria-autocomplete="list"
+      aria-controls=":u-datalist6"
+      aria-expanded="true"
+      autocomplete="off"
+      enterkeyhint="done"
+      role="combobox"
+      aria-label="Added Finnes ikke, Velg destinasjoner"
+    >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
+    >
+    </button>
+    <button
+      aria-label="Tøm"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <u-datalist
+      data-nofilter
+      data-sr-plural="%d forslag"
+      data-sr-singular="%d forslag"
+      popover="manual"
+      role="listbox"
+      data-sr-of="of"
+      tabindex="-1"
+      aria-multiselectable="true"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg destinasjoner"
+      style="<removed>"
+      data-floating="bottom"
+    >
+      <u-option
+        data-empty="Legg til &quot;{value}&quot;"
+        label="Finnes ikke"
+        value="Finnes ikke"
+        data-create="Legg til &quot;Finnes ikke&quot;"
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="false"
+        selected
+      >
+      </u-option>
+      <u-option
+        label="Sogndal"
+        value="Sogndal"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Sogndal
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Oslo"
+        value="Oslo"
+        selected
+        role="option"
+        aria-disabled="true"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Oslo
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Brønnøysund"
+        value="Brønnøysund"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Brønnøysund
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Stavanger"
+        value="Stavanger"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Stavanger
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Trondheim"
+        value="Trondheim"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Trondheim
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Bergen"
+        value="Bergen"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Bergen
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Lillestrøm"
+        value="Lillestrøm"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Lillestrøm
+        <div>
+          Kommune
+        </div>
+      </u-option>
+    </u-datalist>
+  </ds-suggestion>
+</ds-field>
+<hr
+  aria-hidden="true"
+  style="<removed>"
+>
+<p style="<removed>">
+  Valgte reisemål: Oslo, Finnes ikke
+</p>
+<button type="button">
+  Sett reisemål til Sogndal, Stavanger
+</button>
+`;
+
 exports[`Controlled Single 1`] = `
 <ds-field>
   <label for="<removed>">
@@ -479,8 +683,8 @@ exports[`Controlled Single 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist2"
-      popovertarget=":u-datalist2"
+      list=":u-datalist3"
+      popovertarget=":u-datalist3"
     >
     <button
       aria-expanded="false"
@@ -521,7 +725,6 @@ exports[`Controlled Single 1`] = `
         aria-selected="false"
         id="<removed>"
       >
-        Tomt
       </u-option>
       <u-option
         label="Sogndal"
@@ -636,6 +839,371 @@ exports[`Controlled Single 1`] = `
 </button>
 `;
 
+exports[`Controlled Single Creatable 1`] = `
+<ds-field>
+  <label for="<removed>">
+    Velg destinasjon
+  </label>
+  <ds-suggestion data-creatable>
+    <data
+      value="Finnes ikke"
+      aria-label="Finnes ikke, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Finnes ikke
+    </data>
+    <input
+      placeholder
+      type="text"
+      id="<removed>"
+      list=":u-datalist4"
+      popovertarget=":u-datalist4"
+      aria-autocomplete="list"
+      aria-controls=":u-datalist4"
+      aria-expanded="false"
+      autocomplete="off"
+      enterkeyhint="done"
+      role="combobox"
+    >
+    <button
+      aria-expanded="false"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
+    >
+    </button>
+    <button
+      aria-label="Tøm"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <u-datalist
+      data-nofilter
+      data-sr-plural="%d forslag"
+      data-sr-singular="%d forslag"
+      popover="manual"
+      role="listbox"
+      data-sr-of="of"
+      tabindex="-1"
+      aria-multiselectable="false"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg destinasjon"
+      style="<removed>"
+      data-floating="bottom"
+      hidden
+    >
+      <u-option
+        data-empty="Legg til &quot;{value}&quot;"
+        label="Finnes ikke"
+        value="Finnes ikke"
+        data-create="Legg til &quot;Finnes ikke&quot;"
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="false"
+        selected
+      >
+      </u-option>
+      <u-option
+        label="Sogndal"
+        value="Sogndal"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Sogndal
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Oslo"
+        value="Oslo"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Oslo
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Brønnøysund"
+        value="Brønnøysund"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Brønnøysund
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Stavanger"
+        value="Stavanger"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Stavanger
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Trondheim"
+        value="Trondheim"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Trondheim
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Bergen"
+        value="Bergen"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Bergen
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Lillestrøm"
+        value="Lillestrøm"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Lillestrøm
+        <div>
+          Kommune
+        </div>
+      </u-option>
+    </u-datalist>
+  </ds-suggestion>
+</ds-field>
+<hr
+  aria-hidden="true"
+  style="<removed>"
+>
+<p style="<removed>">
+  Valgte reisemål: Finnes ikke
+</p>
+<button type="button">
+  Sett reisemål til Sogndal
+</button>
+`;
+
+exports[`Creatable 1`] = `
+<ds-field>
+  <label for="<removed>">
+    Velg en destinasjon
+  </label>
+  <ds-suggestion data-creatable>
+    <input
+      placeholder
+      type="text"
+      id="<removed>"
+      list=":u-datalist2"
+      popovertarget=":u-datalist2"
+      aria-autocomplete="list"
+      aria-controls=":u-datalist2"
+      aria-expanded="true"
+      autocomplete="off"
+      enterkeyhint="done"
+      role="combobox"
+    >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
+    >
+    </button>
+    <button
+      aria-label="Tøm"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <u-datalist
+      data-nofilter
+      data-sr-plural="%d forslag"
+      data-sr-singular="%d forslag"
+      popover="manual"
+      role="listbox"
+      data-sr-of="of"
+      tabindex="-1"
+      aria-multiselectable="false"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg en destinasjon"
+      style="<removed>"
+      data-floating="bottom"
+    >
+      <u-option
+        data-empty="Legg til &quot;{value}&quot;"
+        label="Finnes ikke"
+        value="Finnes ikke"
+        data-create="Legg til &quot;Finnes ikke&quot;"
+        role="option"
+        aria-disabled="false"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="false"
+      >
+      </u-option>
+      <u-option
+        label="Sogndal"
+        value="Sogndal"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Sogndal
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Oslo"
+        value="Oslo"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Oslo
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Brønnøysund"
+        value="Brønnøysund"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Brønnøysund
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Stavanger"
+        value="Stavanger"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Stavanger
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Trondheim"
+        value="Trondheim"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Trondheim
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Bergen"
+        value="Bergen"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Bergen
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Lillestrøm"
+        value="Lillestrøm"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Lillestrøm
+        <div>
+          Kommune
+        </div>
+      </u-option>
+    </u-datalist>
+  </ds-suggestion>
+</ds-field>
+`;
+
 exports[`Custom Filter Alt 1 1`] = `
 <ds-field>
   <label for="<removed>">
@@ -646,10 +1214,10 @@ exports[`Custom Filter Alt 1 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist5"
-      popovertarget=":u-datalist5"
+      list=":u-datalist8"
+      popovertarget=":u-datalist8"
       aria-autocomplete="list"
-      aria-controls=":u-datalist5"
+      aria-controls=":u-datalist8"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -697,7 +1265,6 @@ exports[`Custom Filter Alt 1 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         value="sogndal"
@@ -784,10 +1351,10 @@ exports[`Custom Filter Alt 2 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist6"
-      popovertarget=":u-datalist6"
+      list=":u-datalist9"
+      popovertarget=":u-datalist9"
       aria-autocomplete="list"
-      aria-controls=":u-datalist6"
+      aria-controls=":u-datalist9"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -835,7 +1402,6 @@ exports[`Custom Filter Alt 2 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         role="option"
@@ -924,10 +1490,10 @@ exports[`Default Value 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist11"
-      popovertarget=":u-datalist11"
+      list=":u-datalist15"
+      popovertarget=":u-datalist15"
       aria-autocomplete="list"
-      aria-controls=":u-datalist11"
+      aria-controls=":u-datalist15"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -975,7 +1541,6 @@ exports[`Default Value 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         selected
@@ -1062,10 +1627,10 @@ exports[`Fetch External 1`] = `
       placeholder
       type="text"
       id="<removed>"
-      list=":u-datalist8"
-      popovertarget=":u-datalist8"
+      list=":u-datalist11"
+      popovertarget=":u-datalist11"
       aria-autocomplete="list"
-      aria-controls=":u-datalist8"
+      aria-controls=":u-datalist11"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1122,10 +1687,10 @@ exports[`In Details 1`] = `
           placeholder
           type="text"
           id="<removed>"
-          list=":u-datalist12"
-          popovertarget=":u-datalist12"
+          list=":u-datalist16"
+          popovertarget=":u-datalist16"
           aria-autocomplete="list"
-          aria-controls=":u-datalist12"
+          aria-controls=":u-datalist16"
           aria-expanded="true"
           autocomplete="off"
           enterkeyhint="done"
@@ -1173,7 +1738,6 @@ exports[`In Details 1`] = `
             id="<removed>"
             aria-hidden="true"
           >
-            Tomt
           </u-option>
           <u-option
             role="option"
@@ -1256,10 +1820,10 @@ exports[`Multiple 1`] = `
       type="text"
       id="<removed>"
       aria-description="No selected"
-      list=":u-datalist9"
-      popovertarget=":u-datalist9"
+      list=":u-datalist12"
+      popovertarget=":u-datalist12"
       aria-autocomplete="list"
-      aria-controls=":u-datalist9"
+      aria-controls=":u-datalist12"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1307,7 +1871,6 @@ exports[`Multiple 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         label="Sogndal"
@@ -1444,10 +2007,10 @@ exports[`Multiple Count 1`] = `
       type="text"
       id="<removed>"
       aria-description="Navigate left to find 2 selected"
-      list=":u-datalist10"
-      popovertarget=":u-datalist10"
+      list=":u-datalist14"
+      popovertarget=":u-datalist14"
       aria-autocomplete="list"
-      aria-controls=":u-datalist10"
+      aria-controls=":u-datalist14"
       aria-expanded="true"
       autocomplete="off"
       enterkeyhint="done"
@@ -1495,7 +2058,6 @@ exports[`Multiple Count 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         label="Sogndal"
@@ -1602,6 +2164,202 @@ exports[`Multiple Count 1`] = `
 </ds-field>
 `;
 
+exports[`Multiple Creatable 1`] = `
+<ds-field>
+  <label for="<removed>">
+    Velg en destinasjon
+  </label>
+  <ds-suggestion
+    data-multiple
+    data-creatable
+  >
+    <data
+      value="Finnes ikke"
+      aria-label="Added Heller ikke, Finnes ikke, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Finnes ikke
+    </data>
+    <data
+      value="Heller ikke"
+      aria-label="Added Heller ikke, Heller ikke, Press to remove"
+      role="option"
+      slot="items"
+      tabindex="-1"
+    >
+      Heller ikke
+    </data>
+    <input
+      placeholder
+      type="text"
+      id="<removed>"
+      aria-description="Navigate left to find 2 selected"
+      list=":u-datalist13"
+      popovertarget=":u-datalist13"
+      aria-autocomplete="list"
+      aria-controls=":u-datalist13"
+      aria-expanded="true"
+      autocomplete="off"
+      enterkeyhint="done"
+      role="combobox"
+      aria-label="Added Heller ikke, Added Finnes ikke, Velg en destinasjon"
+    >
+    <button
+      aria-expanded="true"
+      aria-label="Valg"
+      type="button"
+      aria-hidden="false"
+      tabindex="-1"
+      hidden
+    >
+    </button>
+    <button
+      aria-label="Tøm"
+      type="reset"
+      aria-hidden="false"
+      tabindex="-1"
+    >
+    </button>
+    <u-datalist
+      data-nofilter
+      data-sr-plural="%d forslag"
+      data-sr-singular="%d forslag"
+      popover="manual"
+      role="listbox"
+      data-sr-of="of"
+      tabindex="-1"
+      aria-multiselectable="true"
+      id="<removed>"
+      data-is-floating="true"
+      aria-label="Velg en destinasjon"
+      style="<removed>"
+      data-floating="bottom"
+    >
+      <u-option
+        data-empty="Legg til &quot;{value}&quot;"
+        label="Heller ikke"
+        value="Heller ikke"
+        data-create="Legg til &quot;Heller ikke&quot;"
+        role="option"
+        aria-disabled="false"
+        aria-selected="true"
+        id="<removed>"
+        aria-hidden="false"
+        selected
+      >
+      </u-option>
+      <u-option
+        label="Sogndal"
+        value="Sogndal"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Sogndal
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Oslo"
+        value="Oslo"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Oslo
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Brønnøysund"
+        value="Brønnøysund"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Brønnøysund
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Stavanger"
+        value="Stavanger"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Stavanger
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Trondheim"
+        value="Trondheim"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Trondheim
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Bergen"
+        value="Bergen"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Bergen
+        <div>
+          Kommune
+        </div>
+      </u-option>
+      <u-option
+        label="Lillestrøm"
+        value="Lillestrøm"
+        role="option"
+        aria-disabled="true"
+        aria-selected="false"
+        id="<removed>"
+        aria-hidden="true"
+        disabled
+      >
+        Lillestrøm
+        <div>
+          Kommune
+        </div>
+      </u-option>
+    </u-datalist>
+  </ds-suggestion>
+</ds-field>
+`;
+
 exports[`Preview 1`] = `
 <ds-field>
   <label for="<removed>">
@@ -1663,7 +2421,6 @@ exports[`Preview 1`] = `
         id="<removed>"
         aria-hidden="true"
       >
-        Tomt
       </u-option>
       <u-option
         label="Sogndal"

--- a/@udir-design/react/src/components/suggestion/docs/FakeSuggestionToggle.tsx
+++ b/@udir-design/react/src/components/suggestion/docs/FakeSuggestionToggle.tsx
@@ -1,0 +1,8 @@
+import type { FunctionComponent } from 'react';
+import type { SuggestionToggleProps } from '../Suggestion';
+
+/**
+ * This component only exists to add relevant html props for SuggestionToggle
+ */
+export const SuggestionToggle: FunctionComponent<SuggestionToggleProps> = () =>
+  null;

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -2,14 +2,20 @@
 :root,
 [lang='nb'] {
   --dsc-suggestion-count-label: 'valgt';
+  --dsc-suggestion-create-text: 'Legg til "{value}"';
+  --dsc-suggestion-empty-text: 'Tomt';
 }
 
 [lang='nn'] {
   --dsc-suggestion-count-label: 'valde';
+  --dsc-suggestion-create-text: 'Legg til "{value}"';
+  --dsc-suggestion-empty-text: 'Tomt';
 }
 
 [lang='en'] {
   --dsc-suggestion-count-label: 'selected';
+  --dsc-suggestion-create-text: 'Add "{value}"';
+  --dsc-suggestion-empty-text: 'Empty';
 }
 
 .ds-suggestion {

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -1,20 +1,32 @@
-/* Translations are defined outside component class so users can easily add translations */
+/* Translations are defined outside component class so users can easily add translations. */
+
+/* Upstream sets the Norwegian texts on the element itself, which beats any inherited
+   value regardless of layer. Reset to `inherit` so the nearest [lang] ancestor decides.
+   `:where()` keeps specificity at 0 so the [lang] blocks below always win. */
+:where(.ds-search, .ds-suggestion) {
+  --dsc-suggestion-create-text: inherit;
+  --dsc-suggestion-empty-text: inherit;
+}
+
+/* No " in these values: digdir reads them via getComputedStyle without unescaping, and
+   lightningcss rewrites '..."..."' to "...\"...\"". «» and “” are correct here anyway. */
 :root,
-[lang='nb'] {
+[lang|='nb' i],
+[lang|='no' i] {
   --dsc-suggestion-count-label: 'valgt';
-  --dsc-suggestion-create-text: 'Legg til "{value}"';
+  --dsc-suggestion-create-text: 'Legg til «{value}»';
   --dsc-suggestion-empty-text: 'Tomt';
 }
 
-[lang='nn'] {
+[lang|='nn' i] {
   --dsc-suggestion-count-label: 'valde';
-  --dsc-suggestion-create-text: 'Legg til "{value}"';
+  --dsc-suggestion-create-text: 'Legg til «{value}»';
   --dsc-suggestion-empty-text: 'Tomt';
 }
 
-[lang='en'] {
+[lang|='en' i] {
   --dsc-suggestion-count-label: 'selected';
-  --dsc-suggestion-create-text: 'Add "{value}"';
+  --dsc-suggestion-create-text: 'Add “{value}”';
   --dsc-suggestion-empty-text: 'Empty';
 }
 

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -13,6 +13,8 @@
 }
 
 .ds-suggestion {
+  --_dsc-suggestion-chevron-size: 1.4em;
+
   /* u-combobox 2.0.5 changed [role="listbox"] from display:contents to inline-flex,
      so chips no longer participate in the host's flex-wrap. Restore wrapping. */
   &::part(items) {
@@ -63,13 +65,13 @@
     }
   }
 
-  &:has(input:placeholder-shown) input {
+  &:has(input:placeholder-shown):not(:has(> button[aria-expanded])) input {
     --_dsc-icon-margin-inline: 0.5em;
     /* SVG background-images can't inherit currentColor, so the chevron uses a
        pre-colored icon (see chevronIcon.css) swapped per color scheme, instead
        of using upstream's gradient trick. */
     background-image: var(--_dsc-chevron-icon-down);
-    background-size: 1.4em;
+    background-size: var(--_dsc-suggestion-chevron-size);
     background-position: calc(
       100% - var(--_dsc-icon-margin-inline) + var(--dsc-input-stroke-width)
     );
@@ -81,8 +83,16 @@
     }
   }
 
+  /* Match the input chevron without changing the centered icon box or button. */
+  & > button[aria-expanded]:empty::before {
+    scale: 1.2;
+  }
+
   /* Swap icon when listbox is open */
-  &:has(input:placeholder-shown):has(:popover-open) input {
+  &:has(input:placeholder-shown):not(:has(> button[aria-expanded])):has(
+      :popover-open
+    )
+    input {
     background-image: var(--_dsc-chevron-icon-up);
   }
 }

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -25,6 +25,8 @@
   &[data-display='count'] {
     counter-reset: selected;
 
+    row-gap: 0;
+
     /* Keep <data> in rendering tree for counter-increment but hide visually. */
     & > data {
       counter-increment: selected;
@@ -40,10 +42,10 @@
     /* NOTE: This styling should be reflected in tag.css */
     &:has(> data)::after {
       content: counter(selected) ' ' var(--dsc-suggestion-count-label);
-      position: absolute;
-      inset-inline-start: var(--ds-size-3);
-      top: 50%;
-      translate: 0 -50%;
+      grid-area: input;
+      align-self: center;
+      justify-self: start;
+      margin-inline-start: var(--ds-size-3);
       pointer-events: none;
       z-index: 1;
       align-items: center;
@@ -59,8 +61,9 @@
       display: inline-flex;
     }
 
-    /* Hide count display when focused to prevent overlap with input text. */
-    &:focus-within::after {
+    /* Hide while editing or selecting; aria-expanded stays stable when an
+       option click briefly moves focus. */
+    &:has(> input:is(:focus, [aria-expanded='true']))::after {
       display: none;
     }
   }

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
@@ -28,7 +28,7 @@ Plasser helst innholdet som styres av `ToggleGroup` rett etter komponenten i DOM
 ```tsx
 import { ToggleGroup } from '@udir-design/react';
 
-<ToggleGroup defaultValue="value1">
+<ToggleGroup aria-label="Visning" defaultValue="value1">
   <ToggleGroup.Item value="value1">Option 1</ToggleGroup.Item>
   <ToggleGroup.Item value="value2">Option 2</ToggleGroup.Item>
   <ToggleGroup.Item value="value3">Option 3</ToggleGroup.Item>
@@ -96,7 +96,7 @@ Ha gjerne med en ledetekst som forklarer hva valgene gjelder. Skriv tydelige tek
 ## Tilgjengelighet
 
 `ToggleGroup` har standard fokusindikator med ramme.
-Komponenten bruker [roving tabindex](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Keyboard-navigable_JavaScript_widgets#managing_focus_inside_groups) for å håndtere fokusbevegelse mellom knappene. I praksis gjør dette at <kbd>Tab</kbd> flytter fokus til den aktive knappen, eller videre ut av `ToggleGroup`, mens piltastene flytter fokus mellom knappene i gruppen.
+Komponenten bruker `focusgroup` for å håndtere fokusbevegelse mellom knappene. Siden `focusgroup` ikke har bred innebygd nettleserstøtte, leveres oppførselen med en polyfill. I praksis gjør dette at <kbd>Tab</kbd> flytter fokus til den aktive knappen, eller videre ut av `ToggleGroup`, mens piltastene flytter fokus mellom knappene i gruppen.
 
 `ToggleGroup` brytes ikke over flere linjer. For mange valg eller lange tekster kan det føre til at deler av komponenten havner utenfor den synlige rammen. Kontroller derfor at alle valg fortsatt er synlige og brukbare ved smal viewport eller høy zoom uten horisontal scrolling.
 

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.mdx
@@ -23,6 +23,8 @@ Med `ToggleGroup` kan brukerne velge mellom alternativer som påvirker innholdet
 <Canvas of={ToggleGroupStories.Preview} withToolbar />
 <Controls of={ToggleGroupStories.Preview} />
 
+`ToggleGroup` må ha en ledetekst som forteller hva valgene gjelder. Du oppgir den med `aria-label`, eller med `aria-labelledby` dersom teksten allerede finnes synlig på siden.
+
 Plasser helst innholdet som styres av `ToggleGroup` rett etter komponenten i DOM-en. Hvis dette ikke er mulig, bør du bruke `aria-controls` på `ToggleGroup` for å knytte den til containeren med innholdet som endrer seg.
 
 ```tsx
@@ -34,6 +36,8 @@ import { ToggleGroup } from '@udir-design/react';
   <ToggleGroup.Item value="value3">Option 3</ToggleGroup.Item>
 </ToggleGroup>;
 ```
+
+Eksempelet under [Bare tekst](#bare-tekst) viser hvordan du bruker `aria-labelledby` mot en `Fieldset.Legend`.
 
 ## Varianter av ToggleGroup
 

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -26,6 +26,9 @@ import { ToggleGroup } from './';
 
 const meta = preview.meta({
   component: FakeToggleGroup,
+  args: {
+    'aria-label': 'Velg epostboks',
+  },
   subcomponents: {
     'ToggleGroup.Item': ToggleGroupItem,
   },
@@ -45,7 +48,7 @@ export const Preview = meta.story({
     onChange: fn(),
   },
   render: (args) => (
-    <ToggleGroup {...args} aria-label="Velg epostboks">
+    <ToggleGroup {...args}>
       <ToggleGroup.Item value="innboks">Innboks</ToggleGroup.Item>
       <ToggleGroup.Item value="utkast">Utkast</ToggleGroup.Item>
       <ToggleGroup.Item value="arkiv">Arkiv</ToggleGroup.Item>
@@ -74,13 +77,13 @@ export const Preview = meta.story({
       await userEvent.tab();
       expect(innboksInput).toHaveFocus();
 
-      await userEvent.keyboard('{arrowright}');
+      await userEvent.keyboard('{ArrowRight}');
       expect(utkastInput).toHaveFocus();
 
-      await userEvent.keyboard('{arrowright}');
+      await userEvent.keyboard('{ArrowRight}');
       expect(arkivInput).toHaveFocus();
 
-      await userEvent.keyboard('{arrowleft}');
+      await userEvent.keyboard('{ArrowLeft}');
       expect(utkastInput).toHaveFocus();
     });
 
@@ -115,7 +118,6 @@ export const Secondary = meta.story({
   render: Preview.input.render,
 });
 
-// TODO: this example should use `aria-labelledby` when supported by Digdir
 export const OnlyText = meta.story({
   args: {},
   parameters: {
@@ -127,8 +129,10 @@ export const OnlyText = meta.story({
   },
   render: () => (
     <Fieldset>
-      <Fieldset.Legend>Filtrering av skjema</Fieldset.Legend>
-      <ToggleGroup defaultValue="personlig" aria-label="Filtrering av skjema">
+      <Fieldset.Legend id="form-filter-label">
+        Filtrering av skjema
+      </Fieldset.Legend>
+      <ToggleGroup defaultValue="personlig" aria-labelledby="form-filter-label">
         <ToggleGroup.Item value="personlig">Personlig</ToggleGroup.Item>
         <ToggleGroup.Item value="generelt">Generelt</ToggleGroup.Item>
         <ToggleGroup.Item value="tilleggsinformasjon">
@@ -163,10 +167,11 @@ export const TextAndIcons = meta.story({
 
 export const OnlyIcons = meta.story({
   args: {
+    'aria-label': 'Tekstjustering',
     defaultValue: 'venstrestilt',
   },
   render: (args) => (
-    <ToggleGroup {...args} aria-label="Tekstjustering">
+    <ToggleGroup {...args}>
       <Tooltip content="Venstrestilt">
         <ToggleGroup.Item value="venstrestilt">
           <AlignLeftIcon aria-hidden />
@@ -263,6 +268,11 @@ export const Controlled = meta.story({
     docs: advancedCodeDocs,
   },
   render: function Render(args) {
+    const {
+      'aria-label': _ariaLabel,
+      'aria-labelledby': _ariaLabelledby,
+      ...toggleGroupProps
+    } = args;
     const [value, setValue] = useState<string>('correctedAnswers');
     const isAnswers = value === 'answers';
     const actionData = {
@@ -287,7 +297,7 @@ export const Controlled = meta.story({
           aria-label="Filtrer på status"
           value={value}
           onChange={setValue}
-          {...args}
+          {...toggleGroupProps}
         >
           <ToggleGroup.Item value="answers">
             <TasklistIcon aria-hidden />

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.stories.tsx
@@ -59,7 +59,6 @@ export const Preview = meta.story({
     const canvas = within(canvasElement);
     const innboksInput = canvas.getByRole('radio', { name: /innboks/i });
     const utkastInput = canvas.getByRole('radio', { name: /utkast/i });
-    const arkivInput = canvas.getByRole('radio', { name: /arkiv/i });
 
     await step('Default selection is "Innboks"', async () => {
       expect(innboksInput).toBeChecked();
@@ -73,23 +72,26 @@ export const Preview = meta.story({
       expect(activeButtons).toHaveLength(1);
     });
 
-    await step('User can navigate with arrow keys', async () => {
-      await userEvent.tab();
-      expect(innboksInput).toHaveFocus();
-
-      await userEvent.keyboard('{ArrowRight}');
-      expect(utkastInput).toHaveFocus();
-
-      await userEvent.keyboard('{ArrowRight}');
-      expect(arkivInput).toHaveFocus();
-
-      await userEvent.keyboard('{ArrowLeft}');
-      expect(utkastInput).toHaveFocus();
+    await step('Keyboard navigation is set up with focusgroup', async () => {
+      // We assert the focusgroup contract rather than the keyboard navigation
+      // itself. Both the arrow keys and the single tab stop come from the
+      // `focusgroup` attribute, implemented natively from Chrome 150 and by a
+      // polyfill in older browsers. Neither reacts to the untrusted events
+      // `userEvent` dispatches, so asserting the movement only passes where the
+      // polyfill happens to be inactive. Digdir tests the behaviour itself,
+      // across several browser engines, in
+      // packages/web/src/focusgroup/focusgroup.browser.test.ts.
+      expect(canvasElement.querySelector('fieldset')).toHaveAttribute(
+        'focusgroup',
+        'radiogroup',
+      );
+      expect(canvas.getAllByRole('radio')).toHaveLength(4);
     });
 
     await step(
       'Selecting a different option updates the active state and calls onChange',
       async () => {
+        utkastInput.focus();
         expect(utkastInput).not.toBeChecked();
         await userEvent.keyboard('{Enter}');
         expect(utkastInput).toBeChecked();

--- a/@udir-design/react/src/components/toggleGroup/ToggleGroup.tsx
+++ b/@udir-design/react/src/components/toggleGroup/ToggleGroup.tsx
@@ -5,31 +5,37 @@ import {
 import { forwardRef } from 'react';
 import './togglegroup.css';
 
+// Digdir's deprecated optional data-toggle-group branch permits unnamed groups.
+// Require exactly one supported accessible name instead.
+type ToggleGroupAccessibleName =
+  | {
+      'aria-label': string;
+      'aria-labelledby'?: never;
+    }
+  | {
+      'aria-label'?: never;
+      'aria-labelledby': string;
+    };
+
 export type ToggleGroupProps = Omit<
   DigdirToggleGroupProps,
-  'data-color' | 'data-toggle-group' | 'variant'
-> & {
-  /**
-   * Specify which variant to use
-   * @default secondary
-   */
-  variant?: 'primary' | 'secondary';
-  'aria-label'?: string;
-};
+  | 'aria-label'
+  | 'aria-labelledby'
+  | 'data-color'
+  | 'data-toggle-group'
+  | 'variant'
+> &
+  ToggleGroupAccessibleName & {
+    /**
+     * Specify which variant to use.
+     * @default secondary
+     */
+    variant?: 'primary' | 'secondary';
+  };
 
 export const ToggleGroup = forwardRef<HTMLFieldSetElement, ToggleGroupProps>(
-  function ToggleGroup(
-    { variant = 'secondary', 'aria-label': ariaLabel, ...props },
-    ref,
-  ) {
-    return (
-      <DigdirToggleGroup
-        {...props}
-        variant={variant}
-        data-toggle-group={ariaLabel} // temporary until Digdir supports aria-label directly
-        ref={ref}
-      />
-    );
+  function ToggleGroup({ variant = 'secondary', ...props }, ref) {
+    return <DigdirToggleGroup {...props} variant={variant} ref={ref} />;
   },
 );
 

--- a/@udir-design/react/src/components/toggleGroup/__snapshots__/ToggleGroup.stories.tsx.snap
+++ b/@udir-design/react/src/components/toggleGroup/__snapshots__/ToggleGroup.stories.tsx.snap
@@ -5,9 +5,9 @@ exports[`Controlled 1`] = `
   Retting av prøver
 </h1>
 <fieldset
-  data-toggle-group="Filtrer på status"
-  data-variant="secondary"
   aria-label="Filtrer på status"
+  data-variant="secondary"
+  focusgroup="radiogroup"
 >
   <label data-variant="tertiary">
     <input
@@ -237,9 +237,9 @@ exports[`Controlled 1`] = `
 
 exports[`Only Icons 1`] = `
 <fieldset
-  data-toggle-group="Tekstjustering"
-  data-variant="secondary"
   aria-label="Tekstjustering"
+  data-variant="secondary"
+  focusgroup="radiogroup"
 >
   <label
     data-tooltip="Venstrestilt"
@@ -344,9 +344,9 @@ exports[`Only Text 1`] = `
     Filtrering av skjema
   </legend>
   <fieldset
-    data-toggle-group="Filtrering av skjema"
     data-variant="secondary"
-    aria-label="Filtrering av skjema"
+    focusgroup="radiogroup"
+    aria-labelledby="<removed>"
   >
     <label data-variant="tertiary">
       <input
@@ -379,9 +379,9 @@ exports[`Only Text 1`] = `
 
 exports[`Preview 1`] = `
 <fieldset
-  data-toggle-group="Velg epostboks"
-  data-variant="secondary"
   aria-label="Velg epostboks"
+  data-variant="secondary"
+  focusgroup="radiogroup"
 >
   <label data-variant="tertiary">
     <input
@@ -421,9 +421,9 @@ exports[`Preview 1`] = `
 
 exports[`Primary 1`] = `
 <fieldset
-  data-toggle-group="Velg epostboks"
-  data-variant="primary"
   aria-label="Velg epostboks"
+  data-variant="primary"
+  focusgroup="radiogroup"
 >
   <label data-variant="tertiary">
     <input
@@ -463,9 +463,9 @@ exports[`Primary 1`] = `
 
 exports[`Secondary 1`] = `
 <fieldset
-  data-toggle-group="Velg epostboks"
-  data-variant="secondary"
   aria-label="Velg epostboks"
+  data-variant="secondary"
+  focusgroup="radiogroup"
 >
   <label data-variant="tertiary">
     <input
@@ -505,9 +505,9 @@ exports[`Secondary 1`] = `
 
 exports[`Secondary Only Icons 1`] = `
 <fieldset
-  data-toggle-group="Tekstjustering"
-  data-variant="secondary"
   aria-label="Tekstjustering"
+  data-variant="secondary"
+  focusgroup="radiogroup"
 >
   <label
     data-tooltip="Venstrestilt"
@@ -608,9 +608,9 @@ exports[`Secondary Only Icons 1`] = `
 
 exports[`Text And Icons 1`] = `
 <fieldset
-  data-toggle-group="Filtrer på status"
-  data-variant="secondary"
   aria-label="Filtrer på status"
+  data-variant="secondary"
+  focusgroup="radiogroup"
 >
   <label data-variant="tertiary">
     <input
@@ -700,9 +700,9 @@ exports[`Toggle Group In Color Context 1`] = `
   data-color="accent"
 >
   <fieldset
-    data-toggle-group="Velg epostboks"
-    data-variant="primary"
     aria-label="Velg epostboks"
+    data-variant="primary"
+    focusgroup="radiogroup"
   >
     <label data-variant="tertiary">
       <input

--- a/@udir-design/react/src/components/toggleGroup/index.ts
+++ b/@udir-design/react/src/components/toggleGroup/index.ts
@@ -32,7 +32,7 @@ type ToggleGroup = typeof ToggleGroupParent & {
  * Display a group of buttons that can be toggled between.
  *
  * @example
- * <ToggleGroup data-toggle-group="Label" onChange={(value) => console.log(value)}>
+ * <ToggleGroup aria-label="Label" onChange={(value) => console.log(value)}>
  *   <ToggleGroup.Item value='1'>Toggle 1</ToggleGroup.Item>
  *   <ToggleGroup.Item value='2'>Toggle 2</ToggleGroup.Item>
  *   <ToggleGroup.Item value='3'>Toggle 3</ToggleGroup.Item>

--- a/@udir-design/react/src/components/typography/Typography.mdx
+++ b/@udir-design/react/src/components/typography/Typography.mdx
@@ -65,6 +65,8 @@ En `<label>` skal alltid være knyttet til et skjemaelement for å sikre god til
 
 Meldinger skal plasseres nær feltet de gjelder, slik at både visuelle brukere og brukere av hjelpemidler enkelt forstår sammenhengen. [Se mønsteret for feilmeldinger](/docs/patterns-feilmeldinger--docs) for mer informasjon om god praksis ved bruk av valideringsmeldinger.
 
+Når `ValidationMessage` brukes i en [`Field`](/docs/components-field--docs), kobles meldingen automatisk til feltet med `aria-describedby`. Feltet får `aria-invalid="true"` når meldingen har `data-color="danger"` eller ikke har en angitt farge. Andre farger kobler fortsatt meldingen til feltet, men markerer ikke feltet som ugyldig.
+
 <Canvas of={ValidationMessageStories.Preview} />
 <Controls of={ValidationMessageStories.Preview} />
 

--- a/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
@@ -504,7 +504,7 @@ exports[`Page Story 1`] = `
           <input
             aria-label="Søk"
             autocomplete="off"
-            type="search"
+            type="text"
           >
           <button
             data-variant="tertiary"

--- a/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DemoPage.stories.tsx.snap
@@ -500,24 +500,25 @@ exports[`Page Story 1`] = `
             </div>
           </div>
         </div>
-        <div>
+        <ds-suggestion>
           <input
-            placeholder
             aria-label="Søk"
             autocomplete="off"
             type="search"
           >
           <button
-            data-icon="true"
             data-variant="tertiary"
             type="reset"
             aria-label="Tøm"
+            aria-hidden="false"
+            hidden
+            tabindex="-1"
           >
           </button>
           <button type="submit">
             Søk
           </button>
-        </div>
+        </ds-suggestion>
       </div>
       <div>
         <table>

--- a/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/FormDemo.stories.tsx.snap
@@ -302,7 +302,7 @@ exports[`Form Page 2 1`] = `
         </div>
         <ds-suggestion>
           <input
-            placeholder=" "
+            placeholder
             autocomplete="off"
             id="<removed>"
             required
@@ -332,6 +332,18 @@ exports[`Form Page 2 1`] = `
             id="<removed>"
             data-is-floating="true"
           >
+            <u-option
+              data-empty
+              hidden
+              label
+              value
+              role="option"
+              aria-disabled="false"
+              aria-selected="false"
+              id="<removed>"
+            >
+              Ingen resultater
+            </u-option>
             <u-option
               label="Agder"
               value="Agder"

--- a/@udir-design/react/src/demo/__snapshots__/TableDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/TableDemo.stories.tsx.snap
@@ -46,23 +46,25 @@ exports[`Table Story 1`] = `
           </label>
         </div>
       </fieldset>
-      <div>
+      <ds-suggestion>
         <input
-          placeholder="Søk"
           aria-label="Søk"
+          placeholder="Søk"
           autocomplete="off"
           type="search"
           value
           name="search"
         >
         <button
-          data-icon="true"
           data-variant="tertiary"
           type="reset"
           aria-label="Tøm"
+          aria-hidden="false"
+          hidden
+          tabindex="-1"
         >
         </button>
-      </div>
+      </ds-suggestion>
     </div>
     <div>
       <table data-border="true">
@@ -712,8 +714,8 @@ exports[`Table Story 1`] = `
         <ul>
           <li>
             <button
-              aria-disabled="true"
               type="button"
+              aria-disabled="true"
             >
               <span>
                 Forrige

--- a/@udir-design/react/src/html.ts
+++ b/@udir-design/react/src/html.ts
@@ -1,5 +1,14 @@
 import type { Color, Size } from '@digdir/designsystemet-types';
 
+/**
+ * Augments React's global HTML attributes. Published as `@udir-design/react/html` and
+ * opted into through the `types` array in `tsconfig.json`, see 2864ef9c.
+ *
+ * `@digdir/designsystemet-react` declares much the same set in its own
+ * `react-types.d.ts`, behind an opt-in `./react-types` export. We keep our own copy
+ * rather than referencing theirs, because theirs points `data-color` at
+ * https://theme.designsystemet.no, which our consumers should not use.
+ */
 declare global {
   // oxlint-disable-next-line @typescript-eslint/no-namespace
   namespace React {
@@ -8,6 +17,34 @@ declare global {
       'data-size'?: Size | (string & {});
       'data-color'?: Color | (string & {});
       'data-color-scheme'?: 'light' | 'dark' | 'auto';
+      // Make React 18 support popover attributes https://github.com/facebook/react/issues/27479
+      popovertarget?: string;
+      popover?: '' | 'auto' | 'manual' | 'hint';
+      /**
+       * Give the focusable children of this element arrow key navigation, a single
+       * tab stop, and memory of the last focused element.
+       *
+       * The value is a space-separated list of tokens. It must contain one behavior
+       * token (`toolbar`, `tablist`, `radiogroup`, `listbox`, `menu` or `menubar`),
+       * which also decides the ARIA roles that get applied. It may additionally contain
+       * `inline`, `block`, `wrap`, `nowrap` and `nomemory` to override the defaults that
+       * follow from the behavior, in the conventional order
+       * [documented by open-ui.org](https://open-ui.org/components/scoped-focusgroup.explainer/):
+       * `focusgroup="<behavior> [inline|block] [wrap|nowrap] [nomemory]"`.
+       *
+       * Set `focusgroup="none"` on a child to split the surrounding focusgroup into
+       * separate segments at that point.
+       *
+       * @example 'toolbar'
+       * @example 'menu inline nowrap'
+       * @example 'none'
+       */
+      focusgroup?: FocusgroupValue;
+      /**
+       * Mark this element as the one that receives focus the first time the
+       * surrounding focusgroup is focused.
+       */
+      focusgroupstart?: boolean;
     }
     // Make React support command attributes https://github.com/facebook/react/issues/27479
     interface ButtonHTMLAttributes<T> extends React.HTMLAttributes<T> {
@@ -16,3 +53,21 @@ declare global {
     }
   }
 }
+
+export type FocusgroupBehavior =
+  | 'toolbar'
+  | 'tablist'
+  | 'radiogroup'
+  | 'listbox'
+  | 'menu'
+  | 'menubar';
+
+export type FocusgroupAxis = 'inline' | 'block';
+export type FocusgroupWrap = 'wrap' | 'nowrap';
+export type FocusgroupMemory = 'nomemory';
+/**
+ * Type based on the conventional order from https://open-ui.org/components/scoped-focusgroup.explainer/
+ */
+export type FocusgroupValue =
+  | 'none'
+  | `${FocusgroupBehavior}${` ${FocusgroupAxis}` | ''}${` ${FocusgroupWrap}` | ''}${` ${FocusgroupMemory}` | ''}`;

--- a/@udir-design/react/src/icons/docs/IconDisplay.tsx
+++ b/@udir-design/react/src/icons/docs/IconDisplay.tsx
@@ -42,6 +42,7 @@ export const IconDisplay = () => {
           </Search>
         </div>
         <ToggleGroup
+          aria-label="Velg ikonstil"
           defaultValue="stroke"
           onChange={(value) => {
             setIconToggle(value as 'fill' | 'stroke');

--- a/@udir-design/react/src/icons/docs/IconInformation.tsx
+++ b/@udir-design/react/src/icons/docs/IconInformation.tsx
@@ -69,6 +69,7 @@ import ${icon.name}Svg from
           Bruk i kode
         </Heading>
         <ToggleGroup
+          aria-label="Velg kodeformat"
           data-size="sm"
           variant="secondary"
           value={codeType}

--- a/@udir-design/react/src/icons/docs/PackageInformation.tsx
+++ b/@udir-design/react/src/icons/docs/PackageInformation.tsx
@@ -45,6 +45,7 @@ function MyComponent () {
         </div>
       </div>
       <ToggleGroup
+        aria-label="Velg kodeformat"
         data-size="sm"
         variant="secondary"
         value={codeType}

--- a/@udir-design/react/src/patterns/DisabledOgReadonly.mdx
+++ b/@udir-design/react/src/patterns/DisabledOgReadonly.mdx
@@ -30,7 +30,7 @@ I de fleste tilfeller finnes det en bedre løsning enn å deaktivere eller skriv
 
 <Canvas of={DisabledOgReadonlyStories.VisFeilmeldinger} />
 
-**For knapper:** bruk `loading` med `aria-disabled` i stedet for `disabled` mens noe lastes eller lagres. Da beholder knappen fokus og er synlig for hjelpemidler. Se [retningslinjene for `Button`](/docs/components-button--docs#lasting).
+**For knapper:** bruk `loading` i stedet for `disabled` mens noe lastes eller lagres. Da beholder knappen fokus og er synlig for hjelpemidler. Se [retningslinjene for `Button`](/docs/components-button--docs#last-inn).
 
 <Canvas of={DisabledOgReadonlyStories.BrukLoadingForKnapper} />
 

--- a/@udir-design/react/src/patterns/DisabledOgReadonly.stories.tsx
+++ b/@udir-design/react/src/patterns/DisabledOgReadonly.stories.tsx
@@ -150,8 +150,9 @@ export const VisFeilmeldinger = meta.story({
 });
 
 /**
- * For knapper: bruk `loading` med `aria-disabled` i stedet for `disabled`
- * mens noe lastes eller lagres. Da beholder knappen fokus og er synlig for hjelpemidler.
+ * For knapper: bruk `loading` i stedet for `disabled` mens noe lastes eller lagres.
+ * Da beholder knappen fokus og er synlig for hjelpemidler. `loading` setter
+ * `aria-busy`, men stopper ikke `onClick`, så handlingen må hindres i koden.
  */
 export const BrukLoadingForKnapper = meta.story({
   name: 'Bruk loading for knapper',
@@ -162,6 +163,7 @@ export const BrukLoadingForKnapper = meta.story({
     const [isLoading, setIsLoading] = useState(false);
 
     const handleClick = () => {
+      if (isLoading) return;
       args.onClick?.();
       setIsLoading(true);
       setTimeout(() => setIsLoading(false), 2000);

--- a/@udir-design/react/src/patterns/Tabeller/Filtrering/__snapshots__/Filtrering.stories.tsx.snap
+++ b/@udir-design/react/src/patterns/Tabeller/Filtrering/__snapshots__/Filtrering.stories.tsx.snap
@@ -32,7 +32,7 @@ exports[`Preview 1`] = `
               Rogaland
             </data>
             <input
-              placeholder=" "
+              placeholder
               type="text"
               id="<removed>"
               aria-description="Navigate left to find 2 selected"
@@ -60,6 +60,18 @@ exports[`Preview 1`] = `
               id="<removed>"
               data-is-floating="true"
             >
+              <u-option
+                data-empty
+                hidden
+                label
+                value
+                role="option"
+                aria-disabled="false"
+                aria-selected="false"
+                id="<removed>"
+              >
+                Tomt
+              </u-option>
               <u-option
                 label="Agder"
                 value="Agder"
@@ -221,7 +233,7 @@ exports[`Preview 1`] = `
               Sandnes
             </data>
             <input
-              placeholder=" "
+              placeholder
               type="text"
               id="<removed>"
               aria-description="Navigate left to find 3 selected"
@@ -249,6 +261,18 @@ exports[`Preview 1`] = `
               id="<removed>"
               data-is-floating="true"
             >
+              <u-option
+                data-empty
+                hidden
+                label
+                value
+                role="option"
+                aria-disabled="false"
+                aria-selected="false"
+                id="<removed>"
+              >
+                Tomt
+              </u-option>
               <u-option
                 label="Arendal"
                 value="Arendal"
@@ -309,22 +333,23 @@ exports[`Preview 1`] = `
         <label for="<removed>">
           Søk
         </label>
-        <div>
+        <ds-suggestion>
           <input
-            placeholder
             aria-label="Søk"
             type="search"
             value
             id="<removed>"
           >
           <button
-            data-icon="true"
             data-variant="tertiary"
             type="reset"
             aria-label="Tøm"
+            aria-hidden="false"
+            hidden
+            tabindex="-1"
           >
           </button>
-        </div>
+        </ds-suggestion>
       </ds-field>
     </div>
     <table
@@ -546,9 +571,9 @@ exports[`Preview 1`] = `
         <ul>
           <li>
             <button
-              aria-disabled="true"
               type="button"
               aria-label="Forrige side"
+              aria-disabled="true"
             >
             </button>
           </li>
@@ -642,7 +667,7 @@ exports[`With Chips 1`] = `
               Rogaland
             </data>
             <input
-              placeholder=" "
+              placeholder
               type="text"
               id="<removed>"
               aria-description="Navigate left to find 2 selected"
@@ -670,6 +695,18 @@ exports[`With Chips 1`] = `
               id="<removed>"
               data-is-floating="true"
             >
+              <u-option
+                data-empty
+                hidden
+                label
+                value
+                role="option"
+                aria-disabled="false"
+                aria-selected="false"
+                id="<removed>"
+              >
+                Tomt
+              </u-option>
               <u-option
                 label="Agder"
                 value="Agder"
@@ -831,7 +868,7 @@ exports[`With Chips 1`] = `
               Sandnes
             </data>
             <input
-              placeholder=" "
+              placeholder
               type="text"
               id="<removed>"
               aria-description="Navigate left to find 3 selected"
@@ -859,6 +896,18 @@ exports[`With Chips 1`] = `
               id="<removed>"
               data-is-floating="true"
             >
+              <u-option
+                data-empty
+                hidden
+                label
+                value
+                role="option"
+                aria-disabled="false"
+                aria-selected="false"
+                id="<removed>"
+              >
+                Tomt
+              </u-option>
               <u-option
                 label="Arendal"
                 value="Arendal"
@@ -919,22 +968,23 @@ exports[`With Chips 1`] = `
         <label for="<removed>">
           Søk
         </label>
-        <div>
+        <ds-suggestion>
           <input
-            placeholder
             aria-label="Søk"
             type="search"
             value
             id="<removed>"
           >
           <button
-            data-icon="true"
             data-variant="tertiary"
             type="reset"
             aria-label="Tøm"
+            aria-hidden="false"
+            hidden
+            tabindex="-1"
           >
           </button>
-        </div>
+        </ds-suggestion>
       </ds-field>
     </div>
     <div>
@@ -1217,9 +1267,9 @@ exports[`With Chips 1`] = `
         <ul>
           <li>
             <button
-              aria-disabled="true"
               type="button"
               aria-label="Forrige side"
+              aria-disabled="true"
             >
             </button>
           </li>
@@ -1289,22 +1339,23 @@ exports[`With Dialog 1`] = `
         <label for="<removed>">
           Søk
         </label>
-        <div>
+        <ds-suggestion>
           <input
-            placeholder
             aria-label="Søk"
             type="search"
             value
             id="<removed>"
           >
           <button
-            data-icon="true"
             data-variant="tertiary"
             type="reset"
             aria-label="Tøm"
+            aria-hidden="false"
+            hidden
+            tabindex="-1"
           >
           </button>
-        </div>
+        </ds-suggestion>
       </ds-field>
       <div>
         <button
@@ -1363,7 +1414,7 @@ exports[`With Dialog 1`] = `
                     data-display="count"
                   >
                     <input
-                      placeholder=" "
+                      placeholder
                       type="text"
                       id="<removed>"
                       aria-description="No selected"
@@ -1391,6 +1442,18 @@ exports[`With Dialog 1`] = `
                       id="<removed>"
                       data-is-floating="true"
                     >
+                      <u-option
+                        data-empty
+                        hidden
+                        label
+                        value
+                        role="option"
+                        aria-disabled="false"
+                        aria-selected="false"
+                        id="<removed>"
+                      >
+                        Tomt
+                      </u-option>
                       <u-option
                         label="2026"
                         value="2026"
@@ -1451,7 +1514,7 @@ exports[`With Dialog 1`] = `
                       Rogaland
                     </data>
                     <input
-                      placeholder=" "
+                      placeholder
                       type="text"
                       id="<removed>"
                       aria-description="Navigate left to find 2 selected"
@@ -1479,6 +1542,18 @@ exports[`With Dialog 1`] = `
                       id="<removed>"
                       data-is-floating="true"
                     >
+                      <u-option
+                        data-empty
+                        hidden
+                        label
+                        value
+                        role="option"
+                        aria-disabled="false"
+                        aria-selected="false"
+                        id="<removed>"
+                      >
+                        Tomt
+                      </u-option>
                       <u-option
                         label="Agder"
                         value="Agder"
@@ -1640,7 +1715,7 @@ exports[`With Dialog 1`] = `
                       Sandnes
                     </data>
                     <input
-                      placeholder=" "
+                      placeholder
                       type="text"
                       id="<removed>"
                       aria-description="Navigate left to find 3 selected"
@@ -1668,6 +1743,18 @@ exports[`With Dialog 1`] = `
                       id="<removed>"
                       data-is-floating="true"
                     >
+                      <u-option
+                        data-empty
+                        hidden
+                        label
+                        value
+                        role="option"
+                        aria-disabled="false"
+                        aria-selected="false"
+                        id="<removed>"
+                      >
+                        Tomt
+                      </u-option>
                       <u-option
                         label="Arendal"
                         value="Arendal"
@@ -1772,7 +1859,7 @@ exports[`With Dialog 1`] = `
                     data-display="count"
                   >
                     <input
-                      placeholder=" "
+                      placeholder
                       type="text"
                       id="<removed>"
                       aria-description="No selected"
@@ -1800,6 +1887,18 @@ exports[`With Dialog 1`] = `
                       id="<removed>"
                       data-is-floating="true"
                     >
+                      <u-option
+                        data-empty
+                        hidden
+                        label
+                        value
+                        role="option"
+                        aria-disabled="false"
+                        aria-selected="false"
+                        id="<removed>"
+                      >
+                        Tomt
+                      </u-option>
                       <u-option
                         label="Brukerstøtte"
                         value="Brukerstøtte"
@@ -2137,9 +2236,9 @@ exports[`With Dialog 1`] = `
         <ul>
           <li>
             <button
-              aria-disabled="true"
               type="button"
               aria-label="Forrige side"
+              aria-disabled="true"
             >
             </button>
           </li>

--- a/@udir-design/react/src/patterns/Tabeller/Sidevisning/__snapshots__/Sidevisning.stories.tsx.snap
+++ b/@udir-design/react/src/patterns/Tabeller/Sidevisning/__snapshots__/Sidevisning.stories.tsx.snap
@@ -294,9 +294,9 @@ exports[`Preview 1`] = `
         <ul>
           <li>
             <button
-              aria-disabled="true"
               type="button"
               aria-label="Forrige side"
+              aria-disabled="true"
             >
             </button>
           </li>

--- a/@udir-design/react/src/symbols/docs/PackageInformation.tsx
+++ b/@udir-design/react/src/symbols/docs/PackageInformation.tsx
@@ -39,6 +39,7 @@ function MyComponent () {
         </div>
       </div>
       <ToggleGroup
+        aria-label="Velg kodeformat"
         data-size="sm"
         variant="secondary"
         value={codeType}

--- a/@udir-design/react/src/symbols/docs/SymbolInformation.tsx
+++ b/@udir-design/react/src/symbols/docs/SymbolInformation.tsx
@@ -74,6 +74,7 @@ import ${currentVariant.name}Svg from
           Bruk i kode
         </Heading>
         <ToggleGroup
+          aria-label="Velg kodeformat"
           data-size="sm"
           variant="secondary"
           value={codeType}

--- a/@udir-design/react/src/utilities/focusgroup.mdx
+++ b/@udir-design/react/src/utilities/focusgroup.mdx
@@ -1,0 +1,19 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="utilities/focusgroup" />
+
+# focusgroup
+
+Dette er et attributt du kan sette på et element for å gi de fokuserbare barna piltastnavigasjon, ett tab-stopp og hukommelse for hvilket element som sist hadde fokus. Dette er nyttig når du for eksempel lager en verktøylinje eller en meny, der brukerne forventer å kunne flytte seg mellom valgene med piltastene.
+
+Verdien er en liste med tokens atskilt av mellomrom. Den må inneholde ett token som beskriver oppførselen: `toolbar`, `tablist`, `radiogroup`, `listbox`, `menu` eller `menubar`. Merk at dette tokenet også bestemmer hvilke ARIA-roller som blir satt på gruppen og elementene i den.
+
+I tillegg kan du bruke `inline`, `block`, `wrap`, `nowrap` og `nomemory` for å overstyre oppførselen som følger av rollen, for eksempel `focusgroup="menu inline nowrap"`.
+
+Setter du `focusgroup="none"` på et element inne i gruppen, deles gruppen i to atskilte deler der.
+
+Attributtet er en del av biblioteket `@digdir/designsystemet-web`, som automatisk er tilgjengelig når du bruker `@udir-design/react`. `focusgroup` er foreløpig bare støttet i nyere Chrome, men biblioteket legger automatisk til en polyfill slik at oppførselen fungerer i alle nettlesere.
+
+Bruker du TypeScript, får du typer for `focusgroup` og `focusgroupstart` ved å legge til `@udir-design/react/html` i `types` i `tsconfig.json`. Se [Kom i gang som utvikler](/docs/introduksjon-kom-i-gang-som-utvikler--docs).
+
+[Se dokumentasjon på designsystemet.no](https://designsystemet.no/no/components/utilities/focusgroup).

--- a/@udir-design/theme/dist/index.css
+++ b/@udir-design/theme/dist/index.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 /*
-build: v1.18.0
+build: v1.20.1
 design-tokens: v1.17.0
 */
 

--- a/@udir-design/theme/dist/types.d.ts
+++ b/@udir-design/theme/dist/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.18.0 */
+/* build: v1.20.1 */
 import type {} from '@digdir/designsystemet-types';
 
 // Augment types based on theme

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "24.15.0",
+      "version": "24.19.0",
       "onFail": "download"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,20 +19,20 @@ catalogs:
       specifier: ^21.2.0
       version: 21.2.0
     '@digdir/designsystemet':
-      specifier: 1.18.0
-      version: 1.18.0
+      specifier: 1.20.1
+      version: 1.20.1
     '@digdir/designsystemet-css':
-      specifier: 1.18.0
-      version: 1.18.0
+      specifier: 1.20.1
+      version: 1.20.1
     '@digdir/designsystemet-react':
-      specifier: 1.18.0
-      version: 1.18.0
+      specifier: 1.20.1
+      version: 1.20.1
     '@digdir/designsystemet-types':
-      specifier: 1.18.0
-      version: 1.18.0
+      specifier: 1.20.1
+      version: 1.20.1
     '@digdir/designsystemet-web':
-      specifier: 1.18.0
-      version: 1.18.0
+      specifier: 1.20.1
+      version: 1.20.1
     '@figma/rest-api-spec':
       specifier: ^0.41.0
       version: 0.41.0
@@ -388,8 +388,8 @@ importers:
         specifier: 'catalog:'
         version: 29.1.1
       node:
-        specifier: runtime:24.15.0
-        version: runtime:24.15.0
+        specifier: runtime:24.19.0
+        version: runtime:24.19.0
       oxfmt:
         specifier: 'catalog:'
         version: 0.65.0
@@ -458,7 +458,7 @@ importers:
     dependencies:
       '@digdir/designsystemet-css':
         specifier: 'catalog:'
-        version: 1.18.0
+        version: 1.20.1
       '@udir-design/theme':
         specifier: workspace:*
         version: link:../theme
@@ -514,13 +514,13 @@ importers:
     dependencies:
       '@digdir/designsystemet-react':
         specifier: 'catalog:'
-        version: 1.18.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.20.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@digdir/designsystemet-types':
         specifier: 'catalog:'
-        version: 1.18.0
+        version: 1.20.1
       '@digdir/designsystemet-web':
         specifier: 'catalog:'
-        version: 1.18.0
+        version: 1.20.1
       '@radix-ui/react-slot':
         specifier: 'catalog:'
         version: 1.3.3(@types/react@19.2.18)(react@19.2.8)
@@ -767,7 +767,7 @@ importers:
     dependencies:
       '@digdir/designsystemet-types':
         specifier: 'catalog:'
-        version: 1.18.0
+        version: 1.20.1
     devDependencies:
       '@udir-design/tokens':
         specifier: workspace:*
@@ -784,7 +784,7 @@ importers:
     devDependencies:
       '@digdir/designsystemet':
         specifier: 'catalog:'
-        version: 1.18.0(@types/node@24.13.3)
+        version: 1.20.1(@types/node@24.13.3)
       '@tokens-studio/sd-transforms':
         specifier: 'catalog:'
         version: 2.0.3(style-dictionary@5.5.2)
@@ -893,7 +893,7 @@ importers:
     dependencies:
       '@digdir/designsystemet-css':
         specifier: 'catalog:'
-        version: 1.18.0
+        version: 1.20.1
       '@udir-design/css':
         specifier: workspace:*
         version: link:../../@udir-design/css
@@ -1044,10 +1044,10 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@commander-js/extra-typings@14.0.0':
-    resolution: {integrity: sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==}
+  '@commander-js/extra-typings@15.0.0':
+    resolution: {integrity: sha512-yeJlba62xqmkgELUsn7356MEnzLLu/fw2x4lofFqGnXh6YysRdEs2BaLeLtg1+KU0AXvMeqQvTTp+3hBEBK+EA==}
     peerDependencies:
-      commander: ~14.0.0
+      commander: ~15.0.0
 
   '@commitlint/cli@21.2.2':
     resolution: {integrity: sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==}
@@ -1182,24 +1182,24 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.1.1
 
-  '@digdir/designsystemet-css@1.18.0':
-    resolution: {integrity: sha512-AiJAOGOJa8XKnaGhlho+/I16jYYB8gJuXgdoCreotFGhZWf9FPjRp/3IXh4CoLmSwooNXJL/5/qmiFRBhbrJ2Q==}
+  '@digdir/designsystemet-css@1.20.1':
+    resolution: {integrity: sha512-6YAlQuNZ23kd3PMCOUjYmAXUaRzGa0wRT5DdL+IjWLYSFSW2h8KCSh/ovr70iMeeUKjXOZ92GwG48X+SHxtEMQ==}
 
-  '@digdir/designsystemet-react@1.18.0':
-    resolution: {integrity: sha512-rBOG0wWrHYeQFsmfjcECiEyXdt5RQ06Ec5oTT3SyvaU/+5cEpaCSCcF97S4EfA/2vsRVjIjYa6V854ibEM2FbA==}
+  '@digdir/designsystemet-react@1.20.1':
+    resolution: {integrity: sha512-yPU+OtTqXk/JsiFoY5XlJQz5EDUBYtw52pz7PsBhUXwiZp+cqN5waZY2df9Rn9eUXNnlWpXK0lcWG5VZst/97A==}
     peerDependencies:
       react: '>=18.3.1 || ^19.0.0'
       react-dom: '>=18.3.1 || ^19.0.0'
 
-  '@digdir/designsystemet-types@1.18.0':
-    resolution: {integrity: sha512-2Qfn9Pf59AZyjc95NcWpsNyma3vcsWbiNMLmoMjHG8o0oBNYQdaln4V7wJig5avjbz7Z1BcBhs60d/DOcP+j5w==}
+  '@digdir/designsystemet-types@1.20.1':
+    resolution: {integrity: sha512-Y8sKF7Xt/SAbZ+hR2CCwqPEHbCvkYazZlQkYRZwLOGGCyc8vjjVz86sA9jMSNIHxjAdLUsYJosYIYauCy0/Myw==}
 
-  '@digdir/designsystemet-web@1.18.0':
-    resolution: {integrity: sha512-CLQZWSywbk2StmD6kzTi9ZsHiZrNKbWVOTRG0/JGP0xX+QZwadDqz1Dsh11HeRDRCoz6PjMz6Yi1HV/icmwcjQ==}
+  '@digdir/designsystemet-web@1.20.1':
+    resolution: {integrity: sha512-kFE3gpNNU0jzjcigG6a7l/iyqLCipOCPGPnvQw7sX3dJGHXFtW2ZwTYeiidfUo4uUczYNKMaD8n+z1ONgXRMZg==}
 
-  '@digdir/designsystemet@1.18.0':
-    resolution: {integrity: sha512-DjQICv8NmSvbm1UPBwGRyPxG+niU1mn7PpPr2F2eRMyVRoGLbPak2BCjph7rvHjt3dDE6b2REz5yfSVG7fvnbA==}
-    engines: {node: '>=24.16.0'}
+  '@digdir/designsystemet@1.20.1':
+    resolution: {integrity: sha512-C5rJjP82oLWPCoh9VhyXDfZSkqMeQ5M0f4FPjX6Vzt+h+LQlpG88+8Brf3l4xbXpLu4LHQo0MCIMdxhH8L7rRw==}
+    engines: {node: '>=22.12.0'}
     hasBin: true
 
   '@emnapi/core@1.10.0':
@@ -4226,8 +4226,8 @@ packages:
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
 
-  colorjs.io@0.6.1:
-    resolution: {integrity: sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==}
+  colorjs.io@0.7.1:
+    resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -4240,9 +4240,9 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -4769,7 +4769,6 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6022,7 +6021,7 @@ packages:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
     engines: {node: '>=18'}
 
-  node@runtime:24.15.0:
+  node@runtime:24.19.0:
     resolution:
       type: variations
       variants:
@@ -6030,9 +6029,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-3UvHfctfTJoslkNzm7WTUAzLCUE+xCyqD47w5e8RYJU=
+            integrity: sha256-9ONcExZd5ogMqiVYwKpIyoitpH/iI0vtB9Ztu4CkfI0=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -6040,9 +6039,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-NyMxuWl3mrXRW5SYhPxur4jVr+h73ouogdZAC5EA/8Q=
+            integrity: sha256-gpS3qpsDmXSBwGur8eiycMhZNY8n2lehFQmv5TesOB0=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -6050,9 +6049,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-/9XuKTRnkn8+5zGlU+uI/R9Iz3TuvC10prq+SvIoZzs=
+            integrity: sha256-0bXpmdsVjGL+j3JnpEdrA12L2TsaYFusJKPw3RZuMxY=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -6060,9 +6059,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-c6/CNNVYwkkZh19RwtHqACoq2k6m+DYBo4OGn++mTu0=
+            integrity: sha256-0oyKW/CoCPDtQ0odzoxUrpjwNxwL2GrFirxhP3PmZD8=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -6070,9 +6069,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-sfiJAKSxY2XqulYmkwT8Edp1gdvwNVLUSV+azh/AX20=
+            integrity: sha256-sxqMTLxYn5FS8y/bQxhGl1nhZViltdk7f/L7KHsBPbI=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -6080,9 +6079,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-+YVFVDnVL+m43mqPbQe/7MxzbepSfofqyv5ajXUWo4A=
+            integrity: sha256-s6tqQ5KCjbn9TtloOY1VGIKSvMFYGVQtU74LEQDjMvw=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -6090,9 +6089,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-RINoctmuxJ8ea1KpqSKHLbmisC0jWmFqVoG2qF/sjYk=
+            integrity: sha256-9iXZfNcH30/5YlSRb7xf8BTwnAnv/loeDKj21BqHidQ=
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -6100,10 +6099,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-yet0Au2ibiun5EtnJ/yFqN5WxQlbH3Hr0wYokiEaoRY=
-            prefix: node-v24.15.0-win-arm64
+            integrity: sha256-hQL0pQtFjUzDjtjyABVWws0jnUZJIPdAF5Jsyx4cFX8=
+            prefix: node-v24.19.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -6111,10 +6110,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-zFFJ6r1Td5zh573FQBZDYi0MfmgAreGJKKdn6UC7DmI=
-            prefix: node-v24.15.0-win-x64
+            integrity: sha256-V/cas2UueX2ErN3HnIHMn/HG3bKhl0zbg/AP7pv/THM=
+            prefix: node-v24.19.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v24.15.0/node-v24.15.0-win-x64.zip
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-x64.zip
           targets:
             - cpu: x64
               os: win32
@@ -6122,9 +6121,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-MemKqWCgZ9qR7f/V2TvEZle10qgClhLDWfXyrABgFSo=
+            integrity: sha256-IIJOTTWUj65bM33M70eBOwTYmVMS9Z33OG8iVtn5q34=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-arm64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64-musl.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -6133,14 +6132,14 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-9Vr1vUicU0exE8pllMrgClSzC6V6xYdTJDEb/G9HYuM=
+            integrity: sha256-xgIjeG3xSl0j4iDruOYDGPUyJkCmL5Dm2eVNOhjaUy4=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.15.0/node-v24.15.0-linux-x64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
               libc: musl
-    version: 24.15.0
+    version: 24.19.0
     hasBin: true
 
   normalize-package-data@6.0.2:
@@ -8277,9 +8276,9 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commander-js/extra-typings@14.0.0(commander@14.0.3)':
+  '@commander-js/extra-typings@15.0.0(commander@15.0.0)':
     dependencies:
-      commander: 14.0.3
+      commander: 15.0.0
 
   '@commitlint/cli@21.2.2(@types/node@24.13.3)(@typescript/typescript6@6.0.2)(conventional-commits-parser@7.1.2)':
     dependencies:
@@ -8432,14 +8431,14 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.5
 
-  '@digdir/designsystemet-css@1.18.0':
+  '@digdir/designsystemet-css@1.20.1':
     dependencies:
-      '@digdir/designsystemet-types': 1.18.0
+      '@digdir/designsystemet-types': 1.20.1
 
-  '@digdir/designsystemet-react@1.18.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@digdir/designsystemet-react@1.20.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@digdir/designsystemet-types': 1.18.0
-      '@digdir/designsystemet-web': 1.18.0
+      '@digdir/designsystemet-types': 1.20.1
+      '@digdir/designsystemet-web': 1.20.1
       '@floating-ui/dom': 1.8.0
       '@floating-ui/react': 0.26.23(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@navikt/aksel-icons': 8.16.1(@types/react@19.2.18)(react@19.2.8)
@@ -8451,9 +8450,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@digdir/designsystemet-types@1.18.0': {}
+  '@digdir/designsystemet-types@1.20.1': {}
 
-  '@digdir/designsystemet-web@1.18.0':
+  '@digdir/designsystemet-web@1.20.1':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@u-elements/u-combobox': 2.1.3
@@ -8461,17 +8460,19 @@ snapshots:
       '@u-elements/u-details': 1.0.0
       '@u-elements/u-tabs': 1.0.4
 
-  '@digdir/designsystemet@1.18.0(@types/node@24.13.3)':
+  '@digdir/designsystemet@1.20.1(@types/node@24.13.3)':
     dependencies:
-      '@commander-js/extra-typings': 14.0.0(commander@14.0.3)
-      '@digdir/designsystemet-types': 1.18.0
+      '@commander-js/extra-typings': 15.0.0(commander@15.0.0)
+      '@digdir/designsystemet-types': 1.20.1
       '@inquirer/confirm': 6.2.0(@types/node@24.13.3)
       '@tokens-studio/sd-transforms': 2.0.3(style-dictionary@5.5.2)
+      '@tokens-studio/types': 0.5.2
       chroma-js: 3.2.0
-      colorjs.io: 0.6.1
-      commander: 14.0.3
+      colorjs.io: 0.7.1
+      commander: 15.0.0
       fast-glob: 3.3.3
       hsluv: 1.0.2
+      jsonc-parser: 3.3.1
       object-hash: 3.0.0
       picocolors: 1.1.1
       postcss: 8.5.26
@@ -10269,9 +10270,9 @@ snapshots:
 
   '@udir-design/react@file:@udir-design/react(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@digdir/designsystemet-react': 1.18.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@digdir/designsystemet-types': 1.18.0
-      '@digdir/designsystemet-web': 1.18.0
+      '@digdir/designsystemet-react': 1.20.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@digdir/designsystemet-types': 1.20.1
+      '@digdir/designsystemet-web': 1.20.1
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
       '@u-elements/u-details': 1.0.0
       '@u-elements/u-progress': 1.0.1
@@ -10957,7 +10958,7 @@ snapshots:
 
   colorjs.io@0.5.2: {}
 
-  colorjs.io@0.6.1: {}
+  colorjs.io@0.7.1: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -10965,7 +10966,7 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@14.0.3: {}
+  commander@15.0.0: {}
 
   commander@7.2.0: {}
 
@@ -13053,7 +13054,7 @@ snapshots:
 
   node-releases@2.0.53: {}
 
-  node@runtime:24.15.0: {}
+  node@runtime:24.19.0: {}
 
   normalize-package-data@6.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,11 +22,11 @@ catalog:
   "@commitlint/cli": ^21.2.2
   "@commitlint/config-conventional": ^21.2.2
   "@commitlint/types": ^21.2.0
-  "@digdir/designsystemet": 1.18.0
-  "@digdir/designsystemet-css": 1.18.0
-  "@digdir/designsystemet-react": 1.18.0
-  "@digdir/designsystemet-types": 1.18.0
-  "@digdir/designsystemet-web": 1.18.0
+  "@digdir/designsystemet": 1.20.1
+  "@digdir/designsystemet-css": 1.20.1
+  "@digdir/designsystemet-react": 1.20.1
+  "@digdir/designsystemet-types": 1.20.1
+  "@digdir/designsystemet-web": 1.20.1
   "@figma/rest-api-spec": ^0.41.0
   "@hookform/resolvers": ^5.9.1
   "@navikt/aksel-icons": 8.15.0


### PR DESCRIPTION
## Summary

Upgrades all `@digdir/designsystemet` packages from `1.18.0` to `1.20.1` and adapts our
components to the changes.

`fix: update @digdir/* to 1.20.1` has the full list of upstream behaviour changes in its commit body.
The headlines for consumers:

- ⚠️ `ToggleGroup` now requires `aria-label` or `aria-labelledby`.
- ⚠️ `Search` and `HeaderSearch` render a `<ds-suggestion>` root. `Search.Input` defaults
  to `type="search"`; combine with `Search.Button` using `type="text"` to avoid two icons.
- ⚠️ `Button` with `loading` no longer sets `aria-disabled`, only `aria-busy`.
- Visual: `Badge` with a count is taller, `Chip` is 1px shorter with top-aligned controls,
  `ErrorSummary` has uniform padding.

### New

- `Suggestion.Toggle` subcomponent, with exports, docs, stories and tests.
- `popover` and `focusgroup` attribute types, plus a utilities page documenting focusgroup.
- `Suggestion`'s create and empty text are translated to bokmål, nynorsk and English, and
  follow the nearest `[lang]` ancestor so they can be overridden per language. Upstream
  only provides Norwegian, declared where a `[lang]` ancestor cannot override it.
- `creatable` is documented for the first time. It was effectively unusable before:
  searching for a substring of an option's label and then selecting that option reset the
  input back to the query on blur, and fired `onSelectedChange` with the query as both
  label and value. Upstream rewrote Suggestion's internals in 1.19 and fixed it without
  noting it in their changelog, so this PR adds a regression test that fails on 1.18 and
  passes from 1.20.1.

### Adapted to upstream

- `Suggestion`'s selected-count tag moves to `grid-area` for the new grid input, keys its
  visibility off `aria-expanded` so it no longer flashes while an option is clicked, and
  zeroes the row gap that made count mode taller than a plain input.
- `Search` and `Search.Clear` are temporarily our own wrappers. Now that Search is built on
  `<ds-suggestion>`, u-combobox only recomputes the clear button on real `input` events, so
  a value from React state left it stale in both directions. Reported upstream as [digdir/designsystemet#5295](https://github.com/digdir/designsystemet/issues/5295).
  Remove the wrappers and `useSyncedClearButton` once that is fixed.

### Docs

- Align Dropdown, Breadcrumbs and ToggleGroup with 1.19–1.20.
- `legend` as a direct child of `Fieldset` in the ProgressBar example.
- `type="text"` in the demo page search.

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten er eksportert fra riktig fil
- [x] Komponenten har tester i Storybook