### PR TITLE
fix(Tabs): scope card styles to the owning tab list

### DIFF
--- a/@udir-design/react/src/components/tabs/Tabs.stories.tsx
+++ b/@udir-design/react/src/components/tabs/Tabs.stories.tsx
@@ -409,3 +409,59 @@ export const CardPanel = meta.story({
     </>
   ),
 });
+
+export const NestedVariants = meta.story({
+  parameters: {
+    customStyles: {
+      width: '500px',
+    },
+  },
+  render: () => (
+    <Tabs defaultValue="assessments" variant="card">
+      <Tabs.List>
+        <Tabs.Tab value="assessments">Vurderinger</Tabs.Tab>
+        <Tabs.Tab value="absence">Fravær</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel value="assessments" variant="card">
+        <Tabs defaultValue="final-grades">
+          <Tabs.List>
+            <Tabs.Tab value="final-grades">Standpunkt</Tabs.Tab>
+            <Tabs.Tab value="exams">Eksamen</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="final-grades">Norsk: 5 · Matematikk: 4</Tabs.Panel>
+          <Tabs.Panel value="exams">Skriftlig eksamen: 22. mai</Tabs.Panel>
+        </Tabs>
+      </Tabs.Panel>
+      <Tabs.Panel value="absence" variant="card">
+        Registrert fravær: 2 dager og 3 timer
+      </Tabs.Panel>
+    </Tabs>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const [outerTabList, innerTabList] = canvas.getAllByRole('tablist');
+    const outerTab = within(outerTabList).getByRole('tab', {
+      name: 'Vurderinger',
+    });
+    const innerGeneralTab = within(innerTabList).getByRole('tab', {
+      name: 'Standpunkt',
+    });
+    const innerAdvancedTab = within(innerTabList).getByRole('tab', {
+      name: 'Eksamen',
+    });
+
+    await step('Variants are scoped to their own Tabs', async () => {
+      expect(getComputedStyle(outerTab, '::after').display).toBe('none');
+      expect(getComputedStyle(innerGeneralTab, '::after').display).not.toBe(
+        'none',
+      );
+    });
+
+    await step('Inner tabs change independently', async () => {
+      await userEvent.click(innerAdvancedTab);
+      expect(innerAdvancedTab).toHaveAttribute('aria-selected', 'true');
+      expect(canvas.getByText('Skriftlig eksamen: 22. mai')).toBeVisible();
+      expect(outerTab).toHaveAttribute('aria-selected', 'true');
+    });
+  },
+});

--- a/@udir-design/react/src/components/tabs/__snapshots__/Tabs.stories.tsx.snap
+++ b/@udir-design/react/src/components/tabs/__snapshots__/Tabs.stories.tsx.snap
@@ -452,6 +452,92 @@ exports[`Icons With Text 1`] = `
 </ds-tabs>
 `;
 
+exports[`Nested Variants 1`] = `
+<ds-tabs data-variant="card">
+  <ds-tablist role="tablist">
+    <ds-tab
+      aria-controls="_r_g_-assessments"
+      aria-selected="true"
+      data-value="assessments"
+      role="tab"
+      tabindex="0"
+      id="<removed>"
+    >
+      Vurderinger
+    </ds-tab>
+    <ds-tab
+      aria-controls="_r_g_-absence"
+      aria-selected="false"
+      data-value="absence"
+      role="tab"
+      tabindex="-1"
+    >
+      Fravær
+    </ds-tab>
+  </ds-tablist>
+  <ds-tabpanel
+    id="<removed>"
+    data-variant="card"
+    role="tabpanel"
+    aria-hidden="false"
+    tabindex="0"
+    aria-labelledby="<removed>"
+  >
+    <ds-tabs>
+      <ds-tablist role="tablist">
+        <ds-tab
+          aria-controls="_r_h_-final-grades"
+          aria-selected="false"
+          data-value="final-grades"
+          role="tab"
+          tabindex="-1"
+          id="<removed>"
+        >
+          Standpunkt
+        </ds-tab>
+        <ds-tab
+          aria-controls="_r_h_-exams"
+          aria-selected="true"
+          data-value="exams"
+          role="tab"
+          tabindex="0"
+          id="<removed>"
+        >
+          Eksamen
+        </ds-tab>
+      </ds-tablist>
+      <ds-tabpanel
+        id="<removed>"
+        role="tabpanel"
+        aria-hidden="true"
+        aria-labelledby="<removed>"
+        hidden
+      >
+        Norsk: 5 · Matematikk: 4
+      </ds-tabpanel>
+      <ds-tabpanel
+        id="<removed>"
+        role="tabpanel"
+        aria-hidden="false"
+        tabindex="0"
+        aria-labelledby="<removed>"
+      >
+        Skriftlig eksamen: 22. mai
+      </ds-tabpanel>
+    </ds-tabs>
+  </ds-tabpanel>
+  <ds-tabpanel
+    id="<removed>"
+    data-variant="card"
+    role="tabpanel"
+    aria-hidden="true"
+    hidden
+  >
+    Registrert fravær: 2 dager og 3 timer
+  </ds-tabpanel>
+</ds-tabs>
+`;
+
 exports[`Only Icons 1`] = `
 <ds-tabs>
   <ds-tablist role="tablist">

--- a/@udir-design/react/src/components/tabs/tabs.css
+++ b/@udir-design/react/src/components/tabs/tabs.css
@@ -18,7 +18,7 @@
   }
 
   &[data-variant='card'] {
-    :is([role='tablist'], u-tablist) {
+    > :is([role='tablist'], u-tablist) {
       overflow: visible;
 
       & > :is([role='tab'], u-tab) {


### PR DESCRIPTION
Prevent a parent card variant from leaking into nested tabs with a different variant.
