### PR TITLE
feat: add compact density mode to components

### DIFF
--- a/@udir-design/css/src/density.css
+++ b/@udir-design/css/src/density.css
@@ -1,0 +1,35 @@
+@layer udir.density {
+  [data-density='compact'] {
+    --udsc-density-table-padding: var(--ds-size-1) var(--ds-size-2);
+    --udsc-density-button-size: var(--ds-size-10);
+    --udsc-density-button-padding: var(--ds-size-1) var(--ds-size-2);
+    --udsc-density-chip-height: var(--ds-size-6);
+    --udsc-density-chip-icon-size: var(--ds-size-4);
+    --udsc-density-chip-input-size: var(--ds-size-4);
+    --udsc-density-chip-padding-inline: var(--ds-size-2);
+    --udsc-density-input-size: var(--ds-size-10);
+    --udsc-density-suggestion-option-padding: var(--ds-size-2);
+    --udsc-density-toggle-group-button-size: var(--ds-size-10);
+    --udsc-density-tabs-tab-padding: var(--ds-size-2) var(--ds-size-3);
+    --udsc-density-tag-min-height: var(--ds-size-6);
+    --udsc-density-tag-padding: 0 var(--ds-size-1);
+    --udsc-density-pagination-gap: var(--ds-size-1);
+  }
+
+  [data-density='default'] {
+    --udsc-density-table-padding: initial;
+    --udsc-density-button-size: initial;
+    --udsc-density-button-padding: initial;
+    --udsc-density-chip-height: initial;
+    --udsc-density-chip-icon-size: initial;
+    --udsc-density-chip-input-size: initial;
+    --udsc-density-chip-padding-inline: initial;
+    --udsc-density-input-size: initial;
+    --udsc-density-suggestion-option-padding: initial;
+    --udsc-density-toggle-group-button-size: initial;
+    --udsc-density-tabs-tab-padding: initial;
+    --udsc-density-tag-min-height: initial;
+    --udsc-density-tag-padding: initial;
+    --udsc-density-pagination-gap: initial;
+  }
+}

--- a/@udir-design/css/src/index.css
+++ b/@udir-design/css/src/index.css
@@ -1,4 +1,5 @@
 @layer ds, udir;
 @import './external.css';
+@import './density.css';
 @import './components.css';
 @import './icons.css';

--- a/@udir-design/react/.storybook/style.css
+++ b/@udir-design/react/.storybook/style.css
@@ -7,6 +7,7 @@
     - If table.css changes, Table stories must be re-snapshotted
 */
 @import '../../css/src/external.css';
+@import '../../css/src/density.css';
 @import '../../css/src/icons.css';
 @import '../../theme/dist/datavis.css';
 

--- a/@udir-design/react/demo-pages/TestHeader.tsx
+++ b/@udir-design/react/demo-pages/TestHeader.tsx
@@ -111,6 +111,17 @@ export function TestHeader() {
               </List.Item>
               <List.Item>
                 <Link
+                  href="/density"
+                  style={{
+                    textDecoration: 'none',
+                  }}
+                >
+                  <ArrowRightIcon aria-hidden />
+                  <span>Kompakt visning</span>
+                </Link>
+              </List.Item>
+              <List.Item>
+                <Link
                   href="/page"
                   style={{
                     textDecoration: 'none',

--- a/@udir-design/react/demo-pages/density-demo/DensityDemo.module.css
+++ b/@udir-design/react/demo-pages/density-demo/DensityDemo.module.css
@@ -1,0 +1,164 @@
+.page {
+  box-sizing: border-box;
+  display: grid;
+  gap: var(--ds-size-5);
+  width: min(100%, 75rem);
+  margin: 0 auto;
+  padding: var(--ds-size-6);
+}
+
+.header,
+.toolbar,
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-size-4);
+  flex-wrap: wrap;
+}
+
+.heading {
+  display: grid;
+  gap: var(--ds-size-1);
+}
+
+.toolbar {
+  align-items: flex-end;
+  gap: var(--ds-size-2);
+}
+
+.toolbar .subtleText {
+  align-self: center;
+}
+
+.heading p,
+.subtleText {
+  margin: 0;
+  color: var(--ds-color-text-subtle);
+}
+
+.region {
+  padding-block: var(--ds-size-4);
+  border-block: 1px solid var(--ds-color-border-subtle);
+}
+
+.panel:not([hidden]) {
+  display: grid;
+  gap: var(--ds-size-5);
+  container-type: inline-size;
+}
+
+.search {
+  flex: 1 1 18rem;
+  max-width: 22rem;
+}
+
+.filterControl {
+  flex: 1 1 12rem;
+  max-width: 18rem;
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  flex-wrap: wrap;
+}
+
+.toggleGroup {
+  align-self: flex-end;
+  margin-inline-start: auto;
+}
+
+.activeFilters {
+  display: grid;
+  gap: var(--ds-size-2);
+}
+
+.activeFilters ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-size-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.emptyState {
+  padding-block: var(--ds-size-6);
+  color: var(--ds-color-text-subtle);
+}
+
+.tableFrame {
+  overflow-x: auto;
+  margin-block-start: var(--ds-size-4);
+}
+
+.table {
+  min-width: 56rem;
+}
+
+.footer {
+  flex-direction: column;
+  justify-content: center;
+}
+
+.paginationControls {
+  flex-direction: column;
+  justify-content: flex-start;
+  width: auto;
+}
+
+.paginationControls,
+.itemsPerPage {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+}
+
+.itemsPerPage {
+  white-space: nowrap;
+}
+
+.itemsPerPage select {
+  margin-top: 0;
+}
+
+@container (min-width: 30rem) {
+  .paginationControls {
+    flex-direction: row;
+    justify-content: space-between;
+    width: fit-content;
+    gap: var(--ds-size-8);
+  }
+}
+
+@container (min-width: 50rem) {
+  .footer {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+
+  .paginationControls {
+    gap: var(--ds-size-6);
+  }
+}
+
+@media (max-width: 42rem) {
+  .page {
+    padding: var(--ds-size-4);
+  }
+
+  .toolbar,
+  .filters {
+    align-items: stretch;
+  }
+
+  .search {
+    max-width: none;
+  }
+
+  .filterControl {
+    max-width: none;
+  }
+}

--- a/@udir-design/react/demo-pages/density-demo/DensityDemo.tsx
+++ b/@udir-design/react/demo-pages/density-demo/DensityDemo.tsx
@@ -2,7 +2,6 @@ import {
   type ChangeEvent,
   type HTMLAttributes,
   type SubmitEvent,
-  useEffect,
   useState,
 } from 'react';
 import { Button } from 'src/components/button';
@@ -109,17 +108,6 @@ export const DensityDemo = ({ className, ...props }: DensityDemoProps) => {
   ]);
   const [itemsPerPage, setItemsPerPage] = useState(5);
   const [page, setCurrentPage] = useState(1);
-  const [isMobile, setIsMobile] = useState(
-    () => !window.matchMedia('(min-width: 48rem)').matches,
-  );
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(min-width: 48rem)');
-    const handleChange = (event: MediaQueryListEvent) =>
-      setIsMobile(!event.matches);
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
 
   const normalizedSearchQuery = searchQuery.toLocaleLowerCase('nb');
   const filteredEmployees = employees.filter((employee) => {
@@ -140,7 +128,7 @@ export const DensityDemo = ({ className, ...props }: DensityDemoProps) => {
   const { pages, nextButtonProps, prevButtonProps } = usePagination({
     currentPage: page,
     totalPages,
-    showPages: isMobile ? 3 : 6,
+    showPages: 3,
     setCurrentPage,
   });
   const rangeStart = totalRows === 0 ? 0 : (page - 1) * itemsPerPage + 1;

--- a/@udir-design/react/demo-pages/density-demo/DensityDemo.tsx
+++ b/@udir-design/react/demo-pages/density-demo/DensityDemo.tsx
@@ -1,0 +1,405 @@
+import {
+  type ChangeEvent,
+  type HTMLAttributes,
+  type SubmitEvent,
+  useEffect,
+  useState,
+} from 'react';
+import { Button } from 'src/components/button';
+import { Chip } from 'src/components/chip';
+import { Field } from 'src/components/field';
+import { Pagination } from 'src/components/pagination';
+import { Search } from 'src/components/search';
+import { Select } from 'src/components/select';
+import { Suggestion } from 'src/components/suggestion';
+import { Switch } from 'src/components/switch';
+import { Table } from 'src/components/table';
+import { Tabs } from 'src/components/tabs';
+import { Tag } from 'src/components/tag';
+import { ToggleGroup } from 'src/components/toggleGroup';
+import { Heading } from 'src/components/typography/heading';
+import { Label } from 'src/components/typography/label';
+import { usePagination } from 'src/hooks/usePagination';
+import classes from './DensityDemo.module.css';
+
+const employees = [
+  {
+    id: 1,
+    name: 'Rita Nordmann',
+    email: 'rita@nordmann.no',
+    role: 'Rektor',
+    department: 'Ledelse',
+    status: 'Aktiv',
+  },
+  {
+    id: 2,
+    name: 'Kari Nordmann',
+    email: 'kari@nordmann.no',
+    role: 'Lektor',
+    department: 'Språkfag',
+    status: 'Deaktivert',
+  },
+  {
+    id: 3,
+    name: 'Ola Nordmann',
+    email: 'ola@nordmann.no',
+    role: 'Lektor',
+    department: 'Realfag',
+    status: 'Aktiv',
+  },
+  {
+    id: 4,
+    name: 'Kai Nordmann',
+    email: 'kai@nordmann.no',
+    role: 'Lektor',
+    department: 'Realfag',
+    status: 'Aktiv',
+  },
+  {
+    id: 5,
+    name: 'Mateo Nordmann',
+    email: 'mateo@nordmann.no',
+    role: 'Ass. rektor',
+    department: 'Ledelse',
+    status: 'Deaktivert',
+  },
+  {
+    id: 6,
+    name: 'Sara Nordmann',
+    email: 'sara@nordmann.no',
+    role: 'Lektor',
+    department: 'Språkfag',
+    status: 'Aktiv',
+  },
+  {
+    id: 7,
+    name: 'Ali Nordmann',
+    email: 'ali@nordmann.no',
+    role: 'Rådgiver',
+    department: 'Samfunnsfag',
+    status: 'Aktiv',
+  },
+  {
+    id: 8,
+    name: 'Liv Nordmann',
+    email: 'liv@nordmann.no',
+    role: 'Lektor',
+    department: 'Realfag',
+    status: 'Aktiv',
+  },
+];
+
+const departments = ['Ledelse', 'Realfag', 'Språkfag', 'Samfunnsfag'];
+
+const statusColor = (status: string) => {
+  return status === 'Aktiv' ? 'success' : 'warning';
+};
+
+type DensityDemoProps = HTMLAttributes<HTMLDivElement>;
+
+export const DensityDemo = ({ className, ...props }: DensityDemoProps) => {
+  const [isCompact, setIsCompact] = useState(false);
+  const [searchInput, setSearchInput] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [roleFilter, setRoleFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [selectedDepartments, setSelectedDepartments] = useState<string[]>([
+    'Ledelse',
+    'Realfag',
+  ]);
+  const [itemsPerPage, setItemsPerPage] = useState(5);
+  const [page, setCurrentPage] = useState(1);
+  const [isMobile, setIsMobile] = useState(
+    () => !window.matchMedia('(min-width: 48rem)').matches,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(min-width: 48rem)');
+    const handleChange = (event: MediaQueryListEvent) =>
+      setIsMobile(!event.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const normalizedSearchQuery = searchQuery.toLocaleLowerCase('nb');
+  const filteredEmployees = employees.filter((employee) => {
+    const matchesSearch = [employee.name, employee.email].some((value) =>
+      value.toLocaleLowerCase('nb').includes(normalizedSearchQuery),
+    );
+
+    return (
+      matchesSearch &&
+      (roleFilter === 'all' || employee.role === roleFilter) &&
+      (statusFilter === 'all' || employee.status === statusFilter) &&
+      (selectedDepartments.length === 0 ||
+        selectedDepartments.includes(employee.department))
+    );
+  });
+  const totalRows = filteredEmployees.length;
+  const totalPages = Math.ceil(totalRows / itemsPerPage);
+  const { pages, nextButtonProps, prevButtonProps } = usePagination({
+    currentPage: page,
+    totalPages,
+    showPages: isMobile ? 3 : 6,
+    setCurrentPage,
+  });
+  const rangeStart = totalRows === 0 ? 0 : (page - 1) * itemsPerPage + 1;
+  const rangeEnd =
+    totalRows === 0 ? 0 : Math.min(page * itemsPerPage, totalRows);
+  const paginatedEmployees = filteredEmployees.slice(
+    (page - 1) * itemsPerPage,
+    page * itemsPerPage,
+  );
+
+  const handleItemsPerPageChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setItemsPerPage(Number(event.target.value));
+    setCurrentPage(1);
+  };
+
+  const handleSearchSubmit = (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSearchQuery(searchInput.trim());
+    setCurrentPage(1);
+  };
+
+  const handleSearchReset = () => {
+    setSearchInput('');
+    setSearchQuery('');
+    setCurrentPage(1);
+  };
+
+  const handleRoleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setRoleFilter(event.target.value);
+    setCurrentPage(1);
+  };
+
+  const handleStatusChange = (value: string) => {
+    setStatusFilter(value);
+    setCurrentPage(1);
+  };
+
+  const handleDepartmentsChange = (values: string[]) => {
+    setSelectedDepartments(values);
+    setCurrentPage(1);
+  };
+
+  return (
+    <main {...props} className={`${classes.page} ${className ?? ''}`}>
+      <header className={classes.header}>
+        <div className={classes.heading}>
+          <Heading level={1} data-size="md">
+            Ansatte og tilganger
+          </Heading>
+          <p>Administrer brukere ved Solsiden videregående skole</p>
+        </div>
+        <Switch
+          label="Kompakt visning"
+          checked={isCompact}
+          onChange={(event) => setIsCompact(event.currentTarget.checked)}
+        />
+      </header>
+
+      <section
+        aria-label="Ansattoversikt"
+        className={classes.region}
+        data-density={isCompact ? 'compact' : 'default'}
+      >
+        <Tabs defaultValue="employees">
+          <Tabs.List>
+            <Tabs.Tab value="employees">Ansatte</Tabs.Tab>
+            <Tabs.Tab value="invitations">Invitasjoner</Tabs.Tab>
+          </Tabs.List>
+          <Tabs.Panel value="employees" className={classes.panel}>
+            <div className={classes.toolbar}>
+              <Field className={classes.search}>
+                <Label>Søk etter ansatte</Label>
+                <form onSubmit={handleSearchSubmit} onReset={handleSearchReset}>
+                  <Search>
+                    <Search.Input
+                      value={searchInput}
+                      onChange={(event) => setSearchInput(event.target.value)}
+                    />
+                    <Search.Clear onClick={handleSearchReset} />
+                    <Search.Button aria-label="Søk etter ansatte" />
+                  </Search>
+                </form>
+              </Field>
+              <Button>Legg til ansatt</Button>
+            </div>
+
+            <div className={classes.filters}>
+              <Field className={classes.filterControl}>
+                <Label>Rolle</Label>
+                <Select value={roleFilter} onChange={handleRoleChange}>
+                  <Select.Option value="all">Alle roller</Select.Option>
+                  <Select.Option value="Rektor">Rektor</Select.Option>
+                  <Select.Option value="Ass. rektor">Ass. rektor</Select.Option>
+                  <Select.Option value="Lektor">Lektor</Select.Option>
+                  <Select.Option value="Rådgiver">Rådgiver</Select.Option>
+                </Select>
+              </Field>
+              <Field className={classes.filterControl}>
+                <Label>Avdelinger</Label>
+                <Suggestion
+                  multiple
+                  display="count"
+                  selected={selectedDepartments}
+                  onSelectedChange={(items) =>
+                    handleDepartmentsChange(items.map((item) => item.value))
+                  }
+                >
+                  <Suggestion.Input />
+                  <Suggestion.Clear />
+                  <Suggestion.List>
+                    <Suggestion.Empty>Ingen avdelinger</Suggestion.Empty>
+                    {departments.map((department) => (
+                      <Suggestion.Option
+                        key={department}
+                        label={department}
+                        value={department}
+                      >
+                        {department}
+                      </Suggestion.Option>
+                    ))}
+                  </Suggestion.List>
+                </Suggestion>
+              </Field>
+              <ToggleGroup
+                aria-label="Filtrer etter tilgangsstatus"
+                className={classes.toggleGroup}
+                value={statusFilter}
+                onChange={handleStatusChange}
+              >
+                <ToggleGroup.Item value="all">Alle</ToggleGroup.Item>
+                <ToggleGroup.Item value="Aktiv">Aktive</ToggleGroup.Item>
+                <ToggleGroup.Item value="Deaktivert">
+                  Deaktiverte
+                </ToggleGroup.Item>
+              </ToggleGroup>
+            </div>
+
+            {selectedDepartments.length > 0 && (
+              <div className={classes.activeFilters}>
+                <Label>Avdelinger</Label>
+                <ul>
+                  {selectedDepartments.map((department) => (
+                    <li key={department}>
+                      <Chip.Removable
+                        aria-label={`Fjern ${department}`}
+                        onClick={() =>
+                          handleDepartmentsChange(
+                            selectedDepartments.filter(
+                              (selectedDepartment) =>
+                                selectedDepartment !== department,
+                            ),
+                          )
+                        }
+                      >
+                        {department}
+                      </Chip.Removable>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div className={classes.tableFrame}>
+              <Table hover className={classes.table}>
+                <caption>Ansatte ved Solsiden</caption>
+                <Table.Head>
+                  <Table.Row>
+                    <Table.HeaderCell>Navn</Table.HeaderCell>
+                    <Table.HeaderCell>Rolle</Table.HeaderCell>
+                    <Table.HeaderCell>Avdeling</Table.HeaderCell>
+                    <Table.HeaderCell>E-post</Table.HeaderCell>
+                    <Table.HeaderCell>Tilgang</Table.HeaderCell>
+                    <Table.HeaderCell>Handling</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Head>
+                <Table.Body>
+                  {paginatedEmployees.map((employee) => (
+                    <Table.Row key={employee.id}>
+                      <Table.Cell>{employee.name}</Table.Cell>
+                      <Table.Cell>{employee.role}</Table.Cell>
+                      <Table.Cell>{employee.department}</Table.Cell>
+                      <Table.Cell>{employee.email}</Table.Cell>
+                      <Table.Cell>
+                        <Tag data-color={statusColor(employee.status)}>
+                          {employee.status}
+                        </Tag>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Button
+                          aria-label={`Åpne ${employee.name}`}
+                          variant="tertiary"
+                        >
+                          Åpne
+                        </Button>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table>
+            </div>
+
+            <footer className={classes.footer}>
+              <Pagination
+                aria-label="Sidenavigering for ansatte"
+                data-size="sm"
+              >
+                <Pagination.List>
+                  <Pagination.Item>
+                    <Pagination.Button
+                      aria-label="Forrige side"
+                      {...prevButtonProps}
+                    />
+                  </Pagination.Item>
+                  {pages.map(({ page, itemKey, buttonProps }) => (
+                    <Pagination.Item key={itemKey}>
+                      {typeof page === 'number' && (
+                        <Pagination.Button
+                          {...buttonProps}
+                          aria-label={`Side ${page}`}
+                        >
+                          {page}
+                        </Pagination.Button>
+                      )}
+                    </Pagination.Item>
+                  ))}
+                  <Pagination.Item>
+                    <Pagination.Button
+                      aria-label="Neste side"
+                      {...nextButtonProps}
+                    />
+                  </Pagination.Item>
+                </Pagination.List>
+              </Pagination>
+              <div className={classes.paginationControls}>
+                <span className={classes.subtleText}>
+                  Rad {rangeStart}-{rangeEnd} av {totalRows}
+                </span>
+                <Field className={classes.itemsPerPage}>
+                  <Label>Rader per side</Label>
+                  <Select
+                    value={String(itemsPerPage)}
+                    onChange={handleItemsPerPageChange}
+                    autoComplete="off"
+                  >
+                    {[5, 10, 25, 50].map((size) => (
+                      <Select.Option key={size} value={String(size)}>
+                        {size}
+                      </Select.Option>
+                    ))}
+                  </Select>
+                </Field>
+              </div>
+            </footer>
+          </Tabs.Panel>
+          <Tabs.Panel value="invitations" className={classes.emptyState}>
+            Ingen ventende invitasjoner.
+          </Tabs.Panel>
+        </Tabs>
+      </section>
+    </main>
+  );
+};

--- a/@udir-design/react/src/components/KompaktVisning.mdx
+++ b/@udir-design/react/src/components/KompaktVisning.mdx
@@ -1,0 +1,76 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as DensityDemoStories from '../demo/DensityDemo.stories';
+
+<Meta title="components/Kompakt visning" />
+
+# Kompakt visning
+
+Kompakt visning reduserer luft i komponenter slik at mer informasjon får plass på skjermen. Bruk visningen i avgrensede, datatunge arbeidsflater, for eksempel tabeller med søk, filtre og handlinger.
+
+Det er ofte ikke nødvendig å bruke kompakt visning som standard for hele løsningen. Normal visning gir større klikkflater og mer luft, og passer best for de fleste oppgaver.
+
+## Slik bruker du kompakt visning
+
+Sett `data-density="compact"` på elementet som omslutter arbeidsflaten. Innstillingen arves av komponentene inni elementet.
+
+```tsx
+<section data-density="compact">
+  <Search>{/* ... */}</Search>
+  <Table>{/* ... */}</Table>
+</section>
+```
+
+Bruk `data-density="default"` for å gå tilbake til normal visning i en del av en kompakt arbeidsflate.
+
+```tsx
+<section data-density="compact">
+  <Table>{/* ... */}</Table>
+
+  <form data-density="default">{/* normal visning */}</form>
+</section>
+```
+
+Du kan også la brukeren velge visning:
+
+```tsx
+const [compact, setCompact] = useState(false);
+
+<>
+  <Switch
+    label="Kompakt visning"
+    checked={compact}
+    onChange={(event) => setCompact(event.currentTarget.checked)}
+  />
+  <section data-density={compact ? 'compact' : 'default'}>
+    {/* datatung arbeidsflate */}
+  </section>
+</>;
+```
+
+## Eksempel
+
+<Canvas of={DensityDemoStories.DensityStory} />
+
+## Komponenter som støttes
+
+Kompakt visning påvirker disse komponentene:
+
+- [`Button`](/docs/components-button--docs)
+- [`Input`](/docs/components-input--docs)
+- [`Textfield`](/docs/components-textfield--docs)
+- [`Select`](/docs/components-select--docs)
+- [`Search`](/docs/components-search--docs)
+- [`Suggestion`](/docs/components-suggestion--docs)
+- [`Table`](/docs/components-table--docs)
+- [`Tabs`](/docs/components-tabs--docs)
+- [`ToggleGroup`](/docs/components-togglegroup--docs)
+- [`Tag`](/docs/components-tag--docs)
+- [`Pagination`](/docs/components-pagination--docs)
+
+Andre komponenter beholder normal størrelse. Støtte legges bare til når en komponent har et tydelig bruksområde i datatunge arbeidsflater.
+
+## Størrelse og tilgjengelighet
+
+Kompakte skjemakontroller og knapper er 40 piksler høye. Tekststørrelsen endres ikke. Komponentene reduserer i stedet høyde, padding eller avstand, avhengig av hvordan komponenten er bygget.
+
+Plasser bryteren for kompakt visning utenfor området den styrer. Da beholder bryteren normal størrelse og er enkel å finne og bruke.

--- a/@udir-design/react/src/components/button/button.css
+++ b/@udir-design/react/src/components/button/button.css
@@ -1,4 +1,10 @@
 :not(.ds-toggle-group) > .ds-button {
+  --dsc-button-size: var(--udsc-density-button-size, var(--ds-size-12));
+  --dsc-button-padding: var(
+    --udsc-density-button-padding,
+    var(--ds-size-2) var(--ds-size-4)
+  );
+
   &[data-variant='tertiary']:not([data-color='danger']),
   &[data-variant='secondary']:not([data-color='danger']) {
     --dsc-button-color: var(--ds-color-text-default);

--- a/@udir-design/react/src/components/chip/Chip.stories.tsx
+++ b/@udir-design/react/src/components/chip/Chip.stories.tsx
@@ -76,6 +76,7 @@ export const Preview = meta.story({
   ),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
+    const chips = [...canvasElement.querySelectorAll('.ds-chip')];
     const inputButton = canvas.getByRole('button', { name: 'Button' });
     const inputCheckbox = canvas.getByRole('checkbox', { name: 'Checkbox' });
     const inputRadio = canvas.getByRole('radio', { name: 'Radio' });
@@ -89,6 +90,26 @@ export const Preview = meta.story({
     await step('Render labels', async () => {
       const label = canvas.getByLabelText('Radio');
       expect(label).toBeInTheDocument();
+    });
+
+    await step('All chip variants respond to inherited density', async () => {
+      for (const chip of chips) {
+        expect(chip.getBoundingClientRect().height).toBe(32);
+      }
+
+      canvasElement.setAttribute('data-density', 'compact');
+      for (const chip of chips) {
+        expect(chip.getBoundingClientRect().height).toBe(24);
+        const style = getComputedStyle(chip);
+        expect(Number.parseFloat(style.paddingBlockStart)).toBeCloseTo(
+          Number.parseFloat(style.paddingBlockEnd),
+        );
+      }
+      expect(inputCheckbox.getBoundingClientRect().width).toBe(16);
+      expect(inputCheckbox.getBoundingClientRect().height).toBe(16);
+      expect(inputRadio.getBoundingClientRect().width).toBe(16);
+      expect(inputRadio.getBoundingClientRect().height).toBe(16);
+      canvasElement.removeAttribute('data-density');
     });
 
     await step('Select Checkbox', async () => {

--- a/@udir-design/react/src/components/chip/chip.css
+++ b/@udir-design/react/src/components/chip/chip.css
@@ -1,4 +1,12 @@
 .ds-chip {
+  --dsc-chip-height: var(--udsc-density-chip-height, var(--ds-size-8));
+  --dsc-chip-icon-size: var(--udsc-density-chip-icon-size, var(--ds-icon-size));
+  --dsc-chip-input-size: var(--udsc-density-chip-input-size, var(--ds-size-5));
+  --dsc-chip-padding-inline: var(
+    --udsc-density-chip-padding-inline,
+    var(--ds-size-3)
+  );
+
   padding-block: calc(
     var(--dsc-chip-height) / 2 - var(--dsc-chip-border-width) - 0.5lh
   );

--- a/@udir-design/react/src/components/input/input.css
+++ b/@udir-design/react/src/components/input/input.css
@@ -10,6 +10,7 @@
 ) {
   /* This fixes Å looking like Ă (top part of ring was cut off) in Chrome and Safari */
   height: unset;
+  --dsc-input-size: var(--udsc-density-input-size, var(--ds-size-12));
   --dsc-input-line-height: var(--ds-line-height-md);
   --dsc-input-padding-block: calc(
     (var(--dsc-input-size) - var(--dsc-input-line-height) * 1em) / 2 -
@@ -22,6 +23,16 @@
 }
 
 .ds-input:is(select) {
+  --dsc-input-size: var(--udsc-density-input-size, var(--ds-size-12));
+  --dsc-input-line-height: var(--ds-line-height-md);
+  --dsc-input-padding-block: calc(
+    (var(--dsc-input-size) - var(--dsc-input-line-height) * 1em) / 2 -
+      var(--dsc-input-border-width)
+  );
+  --dsc-input-padding: var(--dsc-input-padding-block)
+    var(--dsc-input-padding-inline);
+  line-height: var(--dsc-input-line-height);
+
   /* SVG background-images can't inherit currentColor, so the chevron uses a
      pre-colored icon (see chevronIcon.css) swapped per color scheme, instead
      of using upstream's gradient trick. */

--- a/@udir-design/react/src/components/pagination/pagination.css
+++ b/@udir-design/react/src/components/pagination/pagination.css
@@ -1,4 +1,6 @@
 .ds-pagination {
+  --dsc-pagination-gap: var(--udsc-density-pagination-gap, var(--ds-size-2));
+
   button[aria-current='true'],
   a[aria-current='true'] {
     color: var(--ds-color-base-contrast-default);

--- a/@udir-design/react/src/components/search/search.css
+++ b/@udir-design/react/src/components/search/search.css
@@ -1,4 +1,8 @@
 .ds-search {
   /* adjust icon size to before Digdir v1.16.0 */
   --ds-icon-size: var(--ds-size-7);
+
+  > .ds-button {
+    --dsc-button-size: var(--udsc-density-input-size, var(--ds-size-12));
+  }
 }

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -521,6 +521,25 @@ export const MultipleCount = meta.story({
       </Field>
     );
   },
+  play: async ({ canvasElement, step }) => {
+    await testSuggestion(canvasElement);
+    const input = within(canvasElement).getByRole('combobox');
+    await userEvent.keyboard('{Escape}');
+    input.blur();
+    const suggestion = input.closest('.ds-suggestion');
+
+    await step('Count tag responds to inherited density', async () => {
+      await expect(
+        Number.parseFloat(getComputedStyle(suggestion!, '::after').minHeight),
+      ).toBe(32);
+
+      canvasElement.setAttribute('data-density', 'compact');
+      await expect(
+        Number.parseFloat(getComputedStyle(suggestion!, '::after').minHeight),
+      ).toBe(24);
+      canvasElement.removeAttribute('data-density');
+    });
+  },
 });
 
 export const DefaultValue = meta.story({

--- a/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
+++ b/@udir-design/react/src/components/suggestion/__snapshots__/Suggestion.stories.tsx.snap
@@ -1249,7 +1249,7 @@ exports[`Multiple Count 1`] = `
       popovertarget=":u-datalist10"
       aria-autocomplete="list"
       aria-controls=":u-datalist10"
-      aria-expanded="true"
+      aria-expanded="false"
       autocomplete="off"
       enterkeyhint="done"
       role="combobox"
@@ -1276,6 +1276,7 @@ exports[`Multiple Count 1`] = `
       aria-label="Velg destinasjoner"
       style="<removed>"
       data-floating="bottom"
+      hidden
     >
       <u-option
         label="Sogndal"

--- a/@udir-design/react/src/components/suggestion/suggestion.css
+++ b/@udir-design/react/src/components/suggestion/suggestion.css
@@ -13,6 +13,19 @@
 }
 
 .ds-suggestion {
+  --dsc-suggestion-count-min-height: var(
+    --udsc-density-tag-min-height,
+    var(--ds-size-8)
+  );
+  --dsc-suggestion-count-padding: var(
+    --udsc-density-tag-padding,
+    0 var(--ds-size-2)
+  );
+  --dsc-suggestion-option-padding: var(
+    --udsc-density-suggestion-option-padding,
+    var(--ds-size-3)
+  );
+
   /* u-combobox 2.0.5 changed [role="listbox"] from display:contents to inline-flex,
      so chips no longer participate in the host's flex-wrap. Restore wrapping. */
   &::part(items) {
@@ -52,8 +65,8 @@
       color: var(--ds-color-text-default);
       font-size: var(--ds-body-sm-font-size);
       line-height: var(--ds-line-height-sm);
-      min-height: var(--ds-size-8);
-      padding: 0 var(--ds-size-2);
+      min-height: var(--dsc-suggestion-count-min-height);
+      padding: var(--dsc-suggestion-count-padding);
       display: inline-flex;
     }
 

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -13,6 +13,10 @@
 .ds-table {
   --dsc-table-background--zebra: var(--ds-color-background-tinted);
   --dsc-table-header-background--sorted: var(--ds-color-surface-active);
+  --dsc-table-padding: var(
+    --udsc-density-table-padding,
+    var(--ds-size-2) var(--ds-size-3)
+  );
 
   td {
     font-feature-settings: 'tnum' 1;

--- a/@udir-design/react/src/components/tabs/tabs.css
+++ b/@udir-design/react/src/components/tabs/tabs.css
@@ -1,4 +1,8 @@
 .ds-tabs {
+  --dsc-tabs-tab-padding: var(
+    --udsc-density-tabs-tab-padding,
+    var(--ds-size-3) var(--ds-size-5)
+  );
   --dsc-tabs-tab-color: var(--ds-color-text-subtle);
   --dsc-tabs-tab-color--hover: var(--ds-color-text-sublte);
   --dsc-tabs-list-border-color: var(--ds-color-border-subtle);

--- a/@udir-design/react/src/components/tag/Tag.tsx
+++ b/@udir-design/react/src/components/tag/Tag.tsx
@@ -1,4 +1,5 @@
 import { Tag, type TagProps } from '@digdir/designsystemet-react';
+import './tag.css';
 
 export type { TagProps };
 export { Tag };

--- a/@udir-design/react/src/components/tag/tag.css
+++ b/@udir-design/react/src/components/tag/tag.css
@@ -1,0 +1,4 @@
+.ds-tag {
+  --dsc-tag-min-height: var(--udsc-density-tag-min-height, var(--ds-size-8));
+  --dsc-tag-padding: var(--udsc-density-tag-padding, 0 var(--ds-size-2));
+}

--- a/@udir-design/react/src/components/toggleGroup/togglegroup.css
+++ b/@udir-design/react/src/components/toggleGroup/togglegroup.css
@@ -1,4 +1,9 @@
 :is(.ds-togglegroup, .ds-toggle-group) {
+  --dsc-togglegroup-button-size: var(
+    --udsc-density-toggle-group-button-size,
+    var(--ds-size-12)
+  );
+
   label {
     height: var(--dsc-togglegroup-button-size);
   }

--- a/@udir-design/react/src/demo/DensityDemo.stories.tsx
+++ b/@udir-design/react/src/demo/DensityDemo.stories.tsx
@@ -1,0 +1,137 @@
+import './demoSizing.css';
+import '../components/input/input.css';
+import { expect, userEvent, within } from 'storybook/test';
+import preview from '.storybook/preview';
+import { DensityDemo } from '../../demo-pages/density-demo/DensityDemo';
+import { demoParameters } from './demoParameters';
+
+const meta = preview.meta({
+  title: 'demo/Density Demo',
+  component: DensityDemo,
+  parameters: {
+    ...demoParameters,
+    componentOrigin: {
+      originator: 'self',
+    },
+    a11y: {
+      config: {
+        rules: [
+          {
+            id: 'aria-allowed-role',
+            matches: (element) => !(element instanceof HTMLInputElement),
+          },
+        ],
+      },
+    },
+  },
+});
+
+export const DensityStory = meta.story({
+  args: {
+    'data-color-scheme': 'light',
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const densitySwitch = canvas.getByRole('switch', {
+      name: 'Kompakt visning',
+    });
+    const region = canvas.getByRole('region', { name: 'Ansattoversikt' });
+    const table = canvas.getByRole('table');
+    const headerCell = canvas.getByRole('columnheader', { name: 'Navn' });
+    const searchInput = canvas.getByRole('searchbox', {
+      name: 'Søk etter ansatte',
+    });
+    const searchButton = canvas.getByRole('button', {
+      name: 'Søk etter ansatte',
+    });
+    const select = canvas.getByRole('combobox', {
+      name: 'Rolle',
+    });
+    const suggestionInput = canvas.getByRole('combobox', {
+      name: 'Avdelinger',
+    });
+    const toggleGroupItem = canvas.getByText('Alle', { selector: 'label' });
+    const tab = canvas.getByRole('tab', { name: 'Ansatte' });
+    const rowAction = canvas.getByRole('button', {
+      name: 'Åpne Rita Nordmann',
+    });
+    const defaultToggleGroupHeight =
+      toggleGroupItem.getBoundingClientRect().height;
+    const defaultTabHeight = tab.getBoundingClientRect().height;
+    let defaultSuggestionOptionPadding = 0;
+
+    await step('Starts with default density', async () => {
+      await expect(densitySwitch).not.toBeChecked();
+      await expect(region).toHaveAttribute('data-density', 'default');
+      await expect(getComputedStyle(table).fontSize).toBe('18px');
+      await expect(getComputedStyle(headerCell).paddingBlockStart).toBe('8px');
+      await expect(searchInput.getBoundingClientRect().height).toBe(48);
+      await expect(searchButton.getBoundingClientRect().height).toBe(48);
+      await expect(select.getBoundingClientRect().height).toBe(48);
+      await expect(suggestionInput.getBoundingClientRect().height).toBe(48);
+      await expect(rowAction.getBoundingClientRect().height).toBe(48);
+
+      await userEvent.click(suggestionInput);
+      const suggestionOption = await canvas.findByRole('option', {
+        name: 'Ledelse',
+      });
+      defaultSuggestionOptionPadding = Number.parseFloat(
+        getComputedStyle(suggestionOption).paddingBlockStart,
+      );
+      await userEvent.keyboard('{Escape}');
+    });
+
+    await step(
+      'Switches the complete workspace to compact density',
+      async () => {
+        await userEvent.click(densitySwitch);
+        await expect(densitySwitch).toBeChecked();
+        await expect(region).toHaveAttribute('data-density', 'compact');
+        await expect(getComputedStyle(table).fontSize).toBe('18px');
+        await expect(getComputedStyle(headerCell).paddingBlockStart).toBe(
+          '4px',
+        );
+
+        await userEvent.click(suggestionInput);
+        const suggestionOption = await canvas.findByRole('option', {
+          name: 'Realfag',
+        });
+        await expect(
+          Number.parseFloat(
+            getComputedStyle(suggestionOption).paddingBlockStart,
+          ),
+        ).toBeLessThan(defaultSuggestionOptionPadding);
+        await userEvent.keyboard('{Escape}');
+
+        for (const control of [
+          searchInput,
+          searchButton,
+          select,
+          suggestionInput,
+          toggleGroupItem,
+          tab,
+          rowAction,
+        ]) {
+          const { width, height } = control.getBoundingClientRect();
+          await expect(width).toBeGreaterThanOrEqual(24);
+          await expect(height).toBeGreaterThanOrEqual(24);
+        }
+      },
+    );
+
+    await step('Restores default density', async () => {
+      await userEvent.click(densitySwitch);
+      await expect(densitySwitch).not.toBeChecked();
+      await expect(region).toHaveAttribute('data-density', 'default');
+      await expect(searchInput.getBoundingClientRect().height).toBe(48);
+      await expect(searchButton.getBoundingClientRect().height).toBe(48);
+      await expect(select.getBoundingClientRect().height).toBe(48);
+      await expect(suggestionInput.getBoundingClientRect().height).toBe(48);
+      await expect(rowAction.getBoundingClientRect().height).toBe(48);
+      await expect(toggleGroupItem.getBoundingClientRect().height).toBe(
+        defaultToggleGroupHeight,
+      );
+      await expect(tab.getBoundingClientRect().height).toBe(defaultTabHeight);
+    });
+  },
+});

--- a/@udir-design/react/src/demo/__snapshots__/DensityDemo.stories.tsx.snap
+++ b/@udir-design/react/src/demo/__snapshots__/DensityDemo.stories.tsx.snap
@@ -1,0 +1,532 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Density Story 1`] = `
+<main data-color-scheme="light">
+  <header>
+    <div>
+      <h1 data-size="md">
+        Ansatte og tilganger
+      </h1>
+      <p>
+        Administrer brukere ved Solsiden videregående skole
+      </p>
+    </div>
+    <ds-field data-clickdelegatefor="<removed>">
+      <input
+        role="switch"
+        type="checkbox"
+        id="<removed>"
+      >
+      <label
+        data-weight="regular"
+        for="<removed>"
+      >
+        Kompakt visning
+      </label>
+    </ds-field>
+  </header>
+  <section
+    aria-label="Ansattoversikt"
+    data-density="default"
+  >
+    <ds-tabs>
+      <ds-tablist role="tablist">
+        <ds-tab
+          aria-controls="_r_0_-employees"
+          aria-selected="true"
+          data-value="employees"
+          role="tab"
+          tabindex="0"
+          id="<removed>"
+        >
+          Ansatte
+        </ds-tab>
+        <ds-tab
+          aria-controls="_r_0_-invitations"
+          aria-selected="false"
+          data-value="invitations"
+          role="tab"
+          tabindex="-1"
+        >
+          Invitasjoner
+        </ds-tab>
+      </ds-tablist>
+      <ds-tabpanel
+        id="<removed>"
+        role="tabpanel"
+        aria-hidden="false"
+        tabindex="0"
+        aria-labelledby="<removed>"
+      >
+        <div>
+          <ds-field>
+            <label for="<removed>">
+              Søk etter ansatte
+            </label>
+            <form>
+              <div>
+                <input
+                  placeholder
+                  type="search"
+                  value
+                  id="<removed>"
+                >
+                <button
+                  data-icon="true"
+                  data-variant="tertiary"
+                  type="reset"
+                  aria-label="Tøm"
+                >
+                </button>
+                <button
+                  type="submit"
+                  aria-label="Søk etter ansatte"
+                >
+                  Søk
+                </button>
+              </div>
+            </form>
+          </ds-field>
+          <button type="button">
+            Legg til ansatt
+          </button>
+        </div>
+        <div>
+          <ds-field>
+            <label for="<removed>">
+              Rolle
+            </label>
+            <select id="<removed>">
+              <option value="all">
+                Alle roller
+              </option>
+              <option value="Rektor">
+                Rektor
+              </option>
+              <option value="Ass. rektor">
+                Ass. rektor
+              </option>
+              <option value="Lektor">
+                Lektor
+              </option>
+              <option value="Rådgiver">
+                Rådgiver
+              </option>
+            </select>
+          </ds-field>
+          <ds-field>
+            <label for="<removed>">
+              Avdelinger
+            </label>
+            <ds-suggestion
+              data-multiple
+              data-display="count"
+            >
+              <data
+                value="Ledelse"
+                aria-label="Ledelse, Press to remove"
+                role="option"
+                slot="items"
+                tabindex="-1"
+              >
+                Ledelse
+              </data>
+              <data
+                value="Realfag"
+                aria-label="Realfag, Press to remove"
+                role="option"
+                slot="items"
+                tabindex="-1"
+              >
+                Realfag
+              </data>
+              <input
+                placeholder=" "
+                type="text"
+                id="<removed>"
+                aria-description="Navigate left to find 2 selected"
+                list=":u-datalist1"
+                popovertarget=":u-datalist1"
+                aria-autocomplete="list"
+                aria-controls=":u-datalist1"
+                aria-expanded="false"
+                autocomplete="off"
+                enterkeyhint="done"
+                role="combobox"
+              >
+              <button
+                aria-label="Tøm"
+                hidden
+                type="reset"
+                aria-hidden="false"
+                tabindex="-1"
+              >
+              </button>
+              <u-datalist
+                data-nofilter
+                data-sr-plural="%d forslag"
+                data-sr-singular="%d forslag"
+                popover="manual"
+                role="listbox"
+                data-sr-of="of"
+                tabindex="-1"
+                aria-multiselectable="true"
+                id="<removed>"
+                data-is-floating="true"
+                aria-label="Avdelinger"
+                style="<removed>"
+                data-floating="bottom"
+                hidden
+              >
+                <u-option
+                  label="Ledelse"
+                  value="Ledelse"
+                  selected
+                  role="option"
+                  aria-disabled="false"
+                  aria-selected="true"
+                  id="<removed>"
+                  aria-hidden="false"
+                >
+                  Ledelse
+                </u-option>
+                <u-option
+                  label="Realfag"
+                  value="Realfag"
+                  selected
+                  role="option"
+                  aria-disabled="false"
+                  aria-selected="true"
+                  id="<removed>"
+                  aria-hidden="false"
+                >
+                  Realfag
+                </u-option>
+                <u-option
+                  label="Språkfag"
+                  value="Språkfag"
+                  role="option"
+                  aria-disabled="false"
+                  aria-selected="false"
+                  id="<removed>"
+                  aria-hidden="false"
+                >
+                  Språkfag
+                </u-option>
+                <u-option
+                  label="Samfunnsfag"
+                  value="Samfunnsfag"
+                  role="option"
+                  aria-disabled="false"
+                  aria-selected="false"
+                  id="<removed>"
+                  aria-hidden="false"
+                >
+                  Samfunnsfag
+                </u-option>
+              </u-datalist>
+            </ds-suggestion>
+          </ds-field>
+          <fieldset
+            data-toggle-group="Filtrer etter tilgangsstatus"
+            data-variant="secondary"
+            aria-label="Filtrer etter tilgangsstatus"
+          >
+            <label data-variant="tertiary">
+              <input
+                type="radio"
+                value="all"
+                checked
+                name="togglegroup-name-_r_2_"
+              >
+              Alle
+            </label>
+            <label data-variant="tertiary">
+              <input
+                type="radio"
+                value="Aktiv"
+                name="togglegroup-name-_r_2_"
+              >
+              Aktive
+            </label>
+            <label data-variant="tertiary">
+              <input
+                type="radio"
+                value="Deaktivert"
+                name="togglegroup-name-_r_2_"
+              >
+              Deaktiverte
+            </label>
+          </fieldset>
+        </div>
+        <div>
+          <label>
+            Avdelinger
+          </label>
+          <ul>
+            <li>
+              <button
+                type="button"
+                data-removable="true"
+                aria-label="Fjern Ledelse"
+              >
+                Ledelse
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                data-removable="true"
+                aria-label="Fjern Realfag"
+              >
+                Realfag
+              </button>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <table data-hover="true">
+            <caption>
+              Ansatte ved Solsiden
+            </caption>
+            <thead>
+              <tr>
+                <th>
+                  Navn
+                </th>
+                <th>
+                  Rolle
+                </th>
+                <th>
+                  Avdeling
+                </th>
+                <th>
+                  E-post
+                </th>
+                <th>
+                  Tilgang
+                </th>
+                <th>
+                  Handling
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  Rita Nordmann
+                </td>
+                <td>
+                  Rektor
+                </td>
+                <td>
+                  Ledelse
+                </td>
+                <td>
+                  rita@nordmann.no
+                </td>
+                <td>
+                  <span data-color="success">
+                    Aktiv
+                  </span>
+                </td>
+                <td>
+                  <button
+                    data-variant="tertiary"
+                    type="button"
+                    aria-label="Åpne Rita Nordmann"
+                  >
+                    Åpne
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Ola Nordmann
+                </td>
+                <td>
+                  Lektor
+                </td>
+                <td>
+                  Realfag
+                </td>
+                <td>
+                  ola@nordmann.no
+                </td>
+                <td>
+                  <span data-color="success">
+                    Aktiv
+                  </span>
+                </td>
+                <td>
+                  <button
+                    data-variant="tertiary"
+                    type="button"
+                    aria-label="Åpne Ola Nordmann"
+                  >
+                    Åpne
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Kai Nordmann
+                </td>
+                <td>
+                  Lektor
+                </td>
+                <td>
+                  Realfag
+                </td>
+                <td>
+                  kai@nordmann.no
+                </td>
+                <td>
+                  <span data-color="success">
+                    Aktiv
+                  </span>
+                </td>
+                <td>
+                  <button
+                    data-variant="tertiary"
+                    type="button"
+                    aria-label="Åpne Kai Nordmann"
+                  >
+                    Åpne
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Mateo Nordmann
+                </td>
+                <td>
+                  Ass. rektor
+                </td>
+                <td>
+                  Ledelse
+                </td>
+                <td>
+                  mateo@nordmann.no
+                </td>
+                <td>
+                  <span data-color="warning">
+                    Deaktivert
+                  </span>
+                </td>
+                <td>
+                  <button
+                    data-variant="tertiary"
+                    type="button"
+                    aria-label="Åpne Mateo Nordmann"
+                  >
+                    Åpne
+                  </button>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Liv Nordmann
+                </td>
+                <td>
+                  Lektor
+                </td>
+                <td>
+                  Realfag
+                </td>
+                <td>
+                  liv@nordmann.no
+                </td>
+                <td>
+                  <span data-color="success">
+                    Aktiv
+                  </span>
+                </td>
+                <td>
+                  <button
+                    data-variant="tertiary"
+                    type="button"
+                    aria-label="Åpne Liv Nordmann"
+                  >
+                    Åpne
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <footer>
+          <ds-pagination
+            aria-label="Sidenavigering for ansatte"
+            data-size="sm"
+            role="navigation"
+          >
+            <ul>
+              <li>
+                <button
+                  aria-disabled="true"
+                  type="button"
+                  aria-label="Forrige side"
+                >
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  aria-current="true"
+                  aria-label="Side 1"
+                >
+                  1
+                </button>
+              </li>
+              <li>
+                <button
+                  aria-disabled="true"
+                  type="button"
+                  aria-label="Neste side"
+                >
+                </button>
+              </li>
+            </ul>
+          </ds-pagination>
+          <div>
+            <span>
+              Rad 1-5 av 5
+            </span>
+            <ds-field>
+              <label for="<removed>">
+                Rader per side
+              </label>
+              <select
+                autocomplete="off"
+                id="<removed>"
+              >
+                <option value="5">
+                  5
+                </option>
+                <option value="10">
+                  10
+                </option>
+                <option value="25">
+                  25
+                </option>
+                <option value="50">
+                  50
+                </option>
+              </select>
+            </ds-field>
+          </div>
+        </footer>
+      </ds-tabpanel>
+      <ds-tabpanel
+        id="<removed>"
+        role="tabpanel"
+        aria-hidden="true"
+        hidden
+      >
+        Ingen ventende invitasjoner.
+      </ds-tabpanel>
+    </ds-tabs>
+  </section>
+</main>
+`;

--- a/@udir-design/react/src/design-tokens/Sizing.mdx
+++ b/@udir-design/react/src/design-tokens/Sizing.mdx
@@ -24,6 +24,8 @@ Komponentene endrer størrelse basert på hvilken størrelsesmodus som er aktiv:
 
 For å skape et helhetlig og oversiktlig design anbefaler vi å bruke én størrelsesmodus innenfor en gitt nettside eller kontekst. Mange ulike kombinasjoner kan føre til et rotete og uoversiktlig grensesnitt. I enkelte tilfeller kan komponenter i ulike størrelser kombineres for å skape bedre visuelle hierarkier og brukervennlighet.
 
+Skal grensesnittet vise mye informasjon på liten plass? Les om hvordan du kan bruke [kompakt visning for å utnytte plassen bedre](/docs/components-kompakt-visning--docs).
+
 ## Responsivitet i kode
 
 For å styre størrelsesmodus i kode kan man sette `data-size=` `'sm'`, `'md'` eller `'lg'`, typisk på et rot-element, men det er ofte lurt å sette størrelsesmodus basert på brukerens skjermstørrelse. Det kan man gjøre slik:

--- a/test-apps/nextjs/src/app/density/page.tsx
+++ b/test-apps/nextjs/src/app/density/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { DensityDemo } from '@udir-design/demos/density-demo/DensityDemo';
+
+export default function Index() {
+  return <DensityDemo data-size="md" data-color-scheme="light" />;
+}


### PR DESCRIPTION
Add compact density support for Button, Chip, Input, Pagination, Search, Select, Suggestion, Table, Tabs, Tag, Textfield, and ToggleGroup.

## Summary

Adds an inherited `data-density="compact"` mode for data-heavy interfaces. It reduces component height and spacing while preserving typography and accessibility.

Density is implemented through shared `--udsc-density-*` CSS variables. Components map these to their existing `--dsc-*` hooks, keeping compact styling scoped and avoiding duplicated selectors. A nested `data-density="default"` resets inheritance.

We chose density instead of:

- **Theme**, because this changes layout rather than color or visual identity.
- **Size modes**, because those also scale typography and broader design tokens. Compact view should fit more content without making text smaller.

The PR includes component coverage, documentation, and an interactive demo.