### PR TITLE
fix: make language variables resolve from the nearest [lang] ancestor

### DIFF
--- a/@udir-design/react/.storybook/preview-test.ts
+++ b/@udir-design/react/.storybook/preview-test.ts
@@ -25,6 +25,10 @@ export const testLifecycleHooks = {
     if (!viteExpect) {
       return;
     }
+    /* Stories that only assert behaviour opt out with `parameters.snapshot: false` */
+    if (storyContext.parameters['snapshot'] === false) {
+      return;
+    }
 
     const canvasElement = removeDecorators(storyContext.canvasElement);
 

--- a/@udir-design/react/.storybook/preview.tsx
+++ b/@udir-design/react/.storybook/preview.tsx
@@ -15,6 +15,7 @@ import type {
   ChromaticParameters,
   ComponentOriginParameters,
   CustomStylesParameters,
+  SnapshotParameters,
 } from './types';
 import { argTypesEnhancer } from './utils/argTypesEnhancer';
 import { CustomStylesDecorator } from './utils/customStylesDecorator';
@@ -93,7 +94,8 @@ export default definePreview({
 interface CustomTypes {
   parameters: ComponentOriginParameters &
     CustomStylesParameters &
-    ChromaticParameters;
+    ChromaticParameters &
+    SnapshotParameters;
 }
 function customParametersAddon(): PreviewAddon<CustomTypes> {
   return {};

--- a/@udir-design/react/.storybook/types/custom.ts
+++ b/@udir-design/react/.storybook/types/custom.ts
@@ -25,3 +25,15 @@ export type CustomStylesParameters = {
     story?: CSSProperties;
   };
 };
+
+export type SnapshotParameters = {
+  /**
+   * Set to `false` to skip the DOM snapshot that is otherwise taken after every story.
+   *
+   * Useful for stories that only assert behaviour: they still run as tests, but do not
+   * leave a baseline that has to be reviewed and kept up to date.
+   *
+   * This is a custom parameter, implemented by `preview-test.ts`.
+   * */
+  snapshot?: boolean;
+};

--- a/@udir-design/react/.storybook/utils/expectLanguageVariables.ts
+++ b/@udir-design/react/.storybook/utils/expectLanguageVariables.ts
@@ -1,0 +1,76 @@
+import { expect } from 'storybook/test';
+
+/** The languages we ship translations for. */
+const LANGS = ['nb', 'nn', 'en'] as const;
+
+/** Checks that a region subtag resolves like its base language, i.e. [lang|=] not [lang=]. */
+const SUBTAG = { lang: 'en-GB', sameAs: 'en' } as const;
+
+/**
+ * Asserts that CSS language variables resolve on a component element exactly as they do on
+ * a plain element in the same [lang] scope, for every language we translate.
+ *
+ * Comparing against a plain element rather than hardcoding the strings keeps the copy in
+ * CSS, and still catches the reason this exists: upstream declares some of these variables
+ * directly on the component element, where they shadow the values we declare on [lang]
+ * ancestors regardless of cascade layer. `lang` is set inside the story, below
+ * <html lang="nb">, which is the case that regressed — a component in a non-Norwegian
+ * region of a Norwegian document.
+ */
+export const expectLanguageVariables = async (
+  canvasElement: HTMLElement,
+  getElement: () => Element | null | undefined,
+  variables: string[],
+) => {
+  const previousLang = canvasElement.lang;
+  const reference = document.createElement('div');
+  canvasElement.append(reference);
+
+  try {
+    const resolved: Record<string, Record<string, string>> = {};
+
+    for (const lang of [...LANGS, SUBTAG.lang]) {
+      canvasElement.lang = lang;
+      const element = getElement();
+      await expect(
+        element,
+        `found no element to read ${variables.join(', ')} from`,
+      ).toBeTruthy();
+
+      for (const variable of variables) {
+        const expected = getComputedStyle(reference).getPropertyValue(variable);
+        await expect(
+          expected,
+          `${variable} has no value for [lang='${lang}']`,
+        ).not.toBe('');
+
+        const actual = getComputedStyle(element as Element).getPropertyValue(
+          variable,
+        );
+        await expect(
+          actual,
+          `${variable} is not translated for [lang='${lang}']`,
+        ).toBe(expected);
+
+        (resolved[variable] ??= {})[lang] = actual;
+      }
+    }
+
+    for (const variable of variables) {
+      await expect(
+        resolved[variable]?.[SUBTAG.lang],
+        `${variable} does not treat [lang='${SUBTAG.lang}'] as '${SUBTAG.sameAs}'`,
+      ).toBe(resolved[variable]?.[SUBTAG.sameAs]);
+    }
+
+    // Everything above also passes if no language is translated at all, so require that at
+    // least one of the variables actually differs between bokmål and English.
+    await expect(
+      variables.some((v) => resolved[v]?.['nb'] !== resolved[v]?.['en']),
+      `none of ${variables.join(', ')} differ between [lang='nb'] and [lang='en']`,
+    ).toBe(true);
+  } finally {
+    reference.remove();
+    canvasElement.lang = previousLang;
+  }
+};

--- a/@udir-design/react/src/components/Språkstøtte.mdx
+++ b/@udir-design/react/src/components/Språkstøtte.mdx
@@ -21,17 +21,23 @@ Komponentene med forhåndsdefinert tekst støtter språkene `"nb"` (bokmål), `"
 
 ```css
 /* Oversettelser for nordsamisk */
-[lang='se'] {
+[lang|='se' i] {
   --udsc-fileUpload-uploading-text: 'Viežžamin…';
   --udsc-fileUpload-chooseFile-text: 'Lasit fiilla';
   /* ...flere tekstvariabler... */
 }
 ```
 
+Vi bruker `[lang|='se' i]` i stedet for `[lang='se']` slik at oversettelsen også gjelder når `lang` inneholder en region, for eksempel `se-NO`.
+
 Se hvilke tekstvariabler som er tilgjengelige for overstyring i dokumentasjonen for komponentene:
 
+- [Breadcrumbs](/docs/components-breadcrumbs--docs#språkstøtte)
+- [DemoBanner](/docs/components-demobanner--docs#språkstøtte)
+- [Field](/docs/components-field--docs#språkstøtte)
 - [FieldNecessity](/docs/components-fieldnecessity--docs#språkstøtte)
 - [FileUpload](/docs/components-fileupload--docs#språkstøtte)
-- [DemoBanner](/docs/components-demobanner--docs#språkstøtte)
 - [FormSummary](/docs/components-formsummary--docs#språkstøtte)
+- [Pagination](/docs/components-pagination--docs#språkstøtte)
 - [Suggestion](/docs/components-suggestion--docs#språkstøtte)
+- [useDrilldownTable](/docs/hooks-usedrilldowntable--docs#språkstøtte)

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.mdx
@@ -1,5 +1,6 @@
 import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import * as BreadcrumbsStories from './Breadcrumbs.stories';
+import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
 
 <Meta of={BreadcrumbsStories} />
 
@@ -87,3 +88,13 @@ Den siste lenken skal tilsvare den nåværende siden. Den ser ut som vanlig teks
 Pass på at det ikke ligger andre interaktive elementer for nær `Breadcrumbs`, og at det ikke er noen skjulte elementer som kan forstyrre navigasjonen.
 
 Sørg for at [`SkipLink`](/docs/components-skiplink--docs) hopper over `Breadcrumbs`, slik at tastaturnavigerende brukere slipper å tabbe seg gjennom hvert punkt før de når hovedinnholdet på siden.
+
+## Språkstøtte
+
+Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+
+Teksten brukes som `aria-label` på `Breadcrumbs`, og gjelder bare når du ikke sender inn `aria-label` selv.
+
+Følgende tekstvariabler er tilgjengelige for overstyring:
+
+<CssLanguageVariables variables={['--dsc-breadcrumbs-label']} />

--- a/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/@udir-design/react/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import { expect, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { Header } from '../header';
 import { Breadcrumbs } from './Breadcrumbs';
 import { BreadcrumbsItem } from './docs/FakeBreadcrumbsItem';
@@ -195,4 +196,16 @@ export const PlacementWithHeader = meta.story({
       </div>
     </>
   ),
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.ds-breadcrumbs'),
+      ['--dsc-breadcrumbs-label'],
+    );
+  },
 });

--- a/@udir-design/react/src/components/breadcrumbs/breadcrumbs.css
+++ b/@udir-design/react/src/components/breadcrumbs/breadcrumbs.css
@@ -1,3 +1,24 @@
+/* Translations are defined outside component class so users can easily add translations.
+   Read from JS via getComputedStyle, so avoid " in the values (see suggestion.css). */
+
+/* Upstream sets the Norwegian label on the element itself, which beats any inherited
+   value regardless of layer. Reset to `inherit` so the nearest [lang] ancestor decides.
+   `:where()` keeps specificity at 0 so the [lang] blocks below always win. */
+:where(.ds-breadcrumbs) {
+  --dsc-breadcrumbs-label: inherit;
+}
+
+:root,
+[lang|='nb' i],
+[lang|='nn' i],
+[lang|='no' i] {
+  --dsc-breadcrumbs-label: 'Du er her:';
+}
+
+[lang|='en' i] {
+  --dsc-breadcrumbs-label: 'You are here:';
+}
+
 .ds-breadcrumbs {
   .ds-link {
     &:visited {

--- a/@udir-design/react/src/components/demoBanner/DemoBanner.stories.tsx
+++ b/@udir-design/react/src/components/demoBanner/DemoBanner.stories.tsx
@@ -1,4 +1,5 @@
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { Card } from 'src/components/card';
 import { Link } from 'src/components/link';
 import { Heading } from 'src/components/typography/heading';
@@ -189,4 +190,16 @@ export const WithScroll = meta.story({
       </DemoBanner>
     </>
   ),
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.uds-demo-banner'),
+      ['--udsc-demo-banner-text'],
+    );
+  },
 });

--- a/@udir-design/react/src/components/demoBanner/demoBanner.css
+++ b/@udir-design/react/src/components/demoBanner/demoBanner.css
@@ -1,13 +1,14 @@
 :root,
-[lang='nb'] {
+[lang|='nb' i],
+[lang|='no' i] {
   --udsc-demo-banner-text: 'Dette er en demo';
 }
 
-[lang='nn'] {
+[lang|='nn' i] {
   --udsc-demo-banner-text: 'Dette er ein demo';
 }
 
-[lang='en'] {
+[lang|='en' i] {
   --udsc-demo-banner-text: 'This is a demo';
 }
 

--- a/@udir-design/react/src/components/field/Field.mdx
+++ b/@udir-design/react/src/components/field/Field.mdx
@@ -1,6 +1,7 @@
 import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as FieldStories from './Field.stories';
+import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
 
 <Meta of={FieldStories} />
 
@@ -61,3 +62,15 @@ Bruk `position="end"` når du ønsker å plassere [`Input`](/docs/components-inp
 ## Tilgjengelighet
 
 `Field` hjelper deg med å strukturere skjemafelt på en tilgjengelig og konsistent måte. Komponenten kobler automatisk sammen [`Label`](/docs/components-typography--docs#label), `Field.Description`, [`ValidationMessage`](/docs/components-typography--docs#validationmessage) og `Field.Counter` med det tilhørende feltet via riktige ARIA-attributter.
+
+## Språkstøtte
+
+Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+
+Tekstene brukes av `Field.Counter`, hvor `%d` blir erstattet med antall tegn.
+
+Følgende tekstvariabler er tilgjengelige for overstyring:
+
+<CssLanguageVariables
+  variables={['--dsc-field-counter-over', '--dsc-field-counter-under']}
+/>

--- a/@udir-design/react/src/components/field/Field.stories.tsx
+++ b/@udir-design/react/src/components/field/Field.stories.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { expect, waitFor } from 'storybook/test';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Input } from '../input/Input';
 import { Textarea } from '../textarea/Textarea';
@@ -207,4 +208,16 @@ export const Position = meta.story({
       </div>
     ),
   ],
+});
+
+export const Translations = Counter.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector("[data-field='counter']"),
+      ['--dsc-field-counter-over', '--dsc-field-counter-under'],
+    );
+  },
 });

--- a/@udir-design/react/src/components/field/field.css
+++ b/@udir-design/react/src/components/field/field.css
@@ -1,3 +1,31 @@
+/* Translations are defined outside component class so users can easily add translations.
+   Read from JS via getComputedStyle, so avoid " in the values (see suggestion.css). */
+
+/* Upstream sets the Norwegian counter texts on .ds-field itself, which beats any inherited
+   value regardless of layer. Reset to `inherit` so the nearest [lang] ancestor decides.
+   `:where()` keeps specificity at 0 so the [lang] blocks below always win. */
+:where(.ds-field) {
+  --dsc-field-counter-over: inherit;
+  --dsc-field-counter-under: inherit;
+}
+
+:root,
+[lang|='nb' i],
+[lang|='no' i] {
+  --dsc-field-counter-over: '%d tegn for mye';
+  --dsc-field-counter-under: '%d tegn igjen';
+}
+
+[lang|='nn' i] {
+  --dsc-field-counter-over: '%d teikn for mykje';
+  --dsc-field-counter-under: '%d teikn igjen';
+}
+
+[lang|='en' i] {
+  --dsc-field-counter-over: '%d characters too many';
+  --dsc-field-counter-under: '%d characters left';
+}
+
 .ds-field:has([aria-readonly='true'], [readonly]) label::before {
   /* position lock icon correctly even if the label contains a Tag */
   vertical-align: middle;

--- a/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
+++ b/@udir-design/react/src/components/fieldNecessity/FieldNecessity.stories.tsx
@@ -1,4 +1,5 @@
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { useCheckboxGroup } from 'src/hooks/useCheckboxGroup';
 import { useRadioGroup } from 'src/hooks/useRadioGroup';
@@ -280,4 +281,21 @@ export const ManualSummaryPlacement = meta.story({
       </FieldNecessity>
     </>
   ),
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.uds-field-necessity'),
+      [
+        '--udsc-fieldNecessity-required-text',
+        '--udsc-fieldNecessity-optional-text',
+        '--udsc-fieldNecessity-all-required-text',
+        '--udsc-fieldNecessity-all-optional-text',
+      ],
+    );
+  },
 });

--- a/@udir-design/react/src/components/fieldNecessity/fieldNecessity.css
+++ b/@udir-design/react/src/components/fieldNecessity/fieldNecessity.css
@@ -1,20 +1,21 @@
 /* Translations are defined outside component class so users can easily add translations */
 :root,
-[lang='nb'] {
+[lang|='nb' i],
+[lang|='no' i] {
   --udsc-fieldNecessity-required-text: 'Må fylles ut';
   --udsc-fieldNecessity-optional-text: 'Valgfritt';
   --udsc-fieldNecessity-all-required-text: 'Alle felt må fylles ut';
   --udsc-fieldNecessity-all-optional-text: 'Alle felt er valgfri';
 }
 
-[lang='nn'] {
+[lang|='nn' i] {
   --udsc-fieldNecessity-required-text: 'Må fyllast ut';
   --udsc-fieldNecessity-optional-text: 'Valfritt';
   --udsc-fieldNecessity-all-required-text: 'Alle felt må fyllast ut';
   --udsc-fieldNecessity-all-optional-text: 'Alle felt er valfri';
 }
 
-[lang='en'] {
+[lang|='en' i] {
   --udsc-fieldNecessity-required-text: 'Required';
   --udsc-fieldNecessity-optional-text: 'Optional';
   --udsc-fieldNecessity-all-required-text: 'All fields are required';

--- a/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
+++ b/@udir-design/react/src/components/fileUpload/FileUpload.stories.tsx
@@ -4,6 +4,7 @@ import type { FileRejection, FileWithPath } from 'react-dropzone';
 import { useDropzone } from 'react-dropzone';
 import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Heading } from 'src/components/typography/heading';
 import { Prose } from '../typography/prose';
@@ -698,5 +699,29 @@ export const CompactList = meta.story({
         canvas.queryByText('kandidat-12.pdf'),
       ).not.toBeInTheDocument();
     });
+  },
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.uds-file-upload'),
+      [
+        '--udsc-fileUpload-chooseFile-text',
+        '--udsc-fileUpload-chooseFiles-text',
+        '--udsc-fileUpload-dropFile-text',
+        '--udsc-fileUpload-dropFiles-text',
+        '--udsc-fileUpload-dropFile-active-text',
+        '--udsc-fileUpload-dropFiles-active-text',
+        '--udsc-fileUpload-or-text',
+        '--udsc-fileUpload-uploading-text',
+        '--udsc-fileUpload-removeFile-text',
+        '--udsc-fileUpload-disabled-text-line-one',
+        '--udsc-fileUpload-disabled-text-line-two',
+      ],
+    );
   },
 });

--- a/@udir-design/react/src/components/fileUpload/fileUpload.css
+++ b/@udir-design/react/src/components/fileUpload/fileUpload.css
@@ -1,5 +1,6 @@
 :root,
-[lang='nb'] {
+[lang|='nb' i],
+[lang|='no' i] {
   --udsc-fileUpload-chooseFile-text: 'Velg fil';
   --udsc-fileUpload-chooseFiles-text: 'Velg filer';
   --udsc-fileUpload-dropFile-text: 'Dra og slipp filen her';
@@ -13,7 +14,7 @@
   --udsc-fileUpload-disabled-text-line-two: 'laste opp filer';
 }
 
-[lang='nn'] {
+[lang|='nn' i] {
   --udsc-fileUpload-chooseFile-text: 'Vel fil';
   --udsc-fileUpload-chooseFiles-text: 'Vel filer';
   --udsc-fileUpload-dropFile-text: 'Dra og slepp fila her';
@@ -27,7 +28,7 @@
   --udsc-fileUpload-disabled-text-line-two: 'laste opp filer';
 }
 
-[lang='en'] {
+[lang|='en' i] {
   --udsc-fileUpload-chooseFile-text: 'Choose file';
   --udsc-fileUpload-chooseFiles-text: 'Choose files';
   --udsc-fileUpload-dropFile-text: 'Drag and drop file here';

--- a/@udir-design/react/src/components/formSummary/FormSummary.stories.tsx
+++ b/@udir-design/react/src/components/formSummary/FormSummary.stories.tsx
@@ -1,5 +1,6 @@
 import { withResponsiveDataSize } from '.storybook/decorators/withResponsiveDataSize';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { FormSummary } from '.';
 import './formSummary.stories.modules.css';
 
@@ -156,4 +157,16 @@ export const ErrorStates = meta.story({
       </FormSummary.Section>
     </FormSummary>
   ),
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.uds-form-summary'),
+      ['--udsc-formSummary-empty-text'],
+    );
+  },
 });

--- a/@udir-design/react/src/components/formSummary/formSummary.css
+++ b/@udir-design/react/src/components/formSummary/formSummary.css
@@ -1,13 +1,14 @@
 :root,
-[lang='nb'] {
+[lang|='nb' i],
+[lang|='no' i] {
   --udsc-formSummary-empty-text: 'Ikke besvart';
 }
 
-[lang='nn'] {
+[lang|='nn' i] {
   --udsc-formSummary-empty-text: 'Ikkje svart';
 }
 
-[lang='en'] {
+[lang|='en' i] {
   --udsc-formSummary-empty-text: 'Not answered';
 }
 

--- a/@udir-design/react/src/components/pagination/Pagination.mdx
+++ b/@udir-design/react/src/components/pagination/Pagination.mdx
@@ -1,6 +1,7 @@
 import { Meta, Controls, Canvas, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as usePagination from '../../hooks/usePagination/usePagination.stories';
 import * as PaginationStories from './Pagination.stories';
+import { CssLanguageVariables } from '.storybook/docs/components/CssVariables/CssLanguageVariables';
 
 <Meta of={PaginationStories} />
 
@@ -89,3 +90,13 @@ Bruk `Pagination` når innholdet er for omfattende for én side, for eksempel ve
 Vi bruker et fast tekstmønster for `Pagination`: «Forrige» og «Neste».
 
 Unngå derfor «Forrige side», «Neste side», «Gå tilbake», «Gå videre», «Videre» og «Tilbake».
+
+## Språkstøtte
+
+Komponenten har innebygget støtte for bokmål, nynorsk og engelsk. [Slik støtter du flere språk](/docs/components-språkstøtte--docs).
+
+Teksten brukes som `aria-label` på `Pagination`, og gjelder bare når du ikke sender inn `aria-label` selv.
+
+Følgende tekstvariabler er tilgjengelige for overstyring:
+
+<CssLanguageVariables variables={['--dsc-pagination-label']} />

--- a/@udir-design/react/src/components/pagination/Pagination.stories.tsx
+++ b/@udir-design/react/src/components/pagination/Pagination.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Search } from 'src/components/search';
 import { usePagination } from 'src/hooks/usePagination';
@@ -237,6 +238,18 @@ export const WithAnchor = meta.story({
           </Pagination>
         </div>
       </>
+    );
+  },
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.ds-pagination'),
+      ['--dsc-pagination-label'],
     );
   },
 });

--- a/@udir-design/react/src/components/pagination/pagination.css
+++ b/@udir-design/react/src/components/pagination/pagination.css
@@ -1,3 +1,24 @@
+/* Translations are defined outside component class so users can easily add translations.
+   Read from JS via getComputedStyle, so avoid " in the values (see suggestion.css). */
+
+/* Upstream sets the Norwegian label on the element itself, which beats any inherited
+   value regardless of layer. Reset to `inherit` so the nearest [lang] ancestor decides.
+   `:where()` keeps specificity at 0 so the [lang] blocks below always win. */
+:where(.ds-pagination) {
+  --dsc-pagination-label: inherit;
+}
+
+:root,
+[lang|='nb' i],
+[lang|='nn' i],
+[lang|='no' i] {
+  --dsc-pagination-label: 'Bla i sider';
+}
+
+[lang|='en' i] {
+  --dsc-pagination-label: 'Browse pages';
+}
+
 .ds-pagination {
   button[aria-current='true'],
   a[aria-current='true'] {

--- a/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
+++ b/@udir-design/react/src/components/suggestion/Suggestion.stories.tsx
@@ -1,6 +1,7 @@
 import { type InputEvent, useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { Button } from 'src/components/button';
 import { Details } from 'src/components/details';
 import { Divider } from 'src/components/divider';
@@ -744,6 +745,22 @@ export const InDetails = meta.story({
           </Field>
         </Details.Content>
       </Details>
+    );
+  },
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('.ds-suggestion'),
+      [
+        '--dsc-suggestion-count-label',
+        '--dsc-suggestion-create-text',
+        '--dsc-suggestion-empty-text',
+      ],
     );
   },
 });

--- a/@udir-design/react/src/components/table/table.css
+++ b/@udir-design/react/src/components/table/table.css
@@ -1,12 +1,13 @@
 /* Drilldown: language-aware level label injected by useDrilldownTable.
  * These are read by the hook via getComputedStyle, not used in CSS content. */
 :root,
-[lang='nb'],
-[lang='nn'] {
+[lang|='nb' i],
+[lang|='nn' i],
+[lang|='no' i] {
   --udsc-table-level-prefix: Nivå;
 }
 
-[lang='en'] {
+[lang|='en' i] {
   --udsc-table-level-prefix: Level;
 }
 

--- a/@udir-design/react/src/hooks/useDrilldownTable/useDrilldownTable.stories.tsx
+++ b/@udir-design/react/src/hooks/useDrilldownTable/useDrilldownTable.stories.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useMemo, useRef, useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 import preview from '.storybook/preview';
+import { expectLanguageVariables } from '.storybook/utils/expectLanguageVariables';
 import { advancedCodeDocs } from '.storybook/utils/sourceTransformers';
 import { Table } from 'src/components/table';
 import { useDrilldownTable } from './useDrilldownTable';
@@ -221,5 +222,17 @@ export const Preview = meta.story({
         canvas.queryByTestId('row-np-nasjonalt-oslo-gamleoslo-tøyenskole'),
       ).not.toBeInTheDocument();
     });
+  },
+});
+
+export const Translations = Preview.extend({
+  tags: ['!dev'], // hides the story from the sidebar
+  parameters: { chromatic: { disableSnapshot: true }, snapshot: false },
+  play: async ({ canvasElement }) => {
+    await expectLanguageVariables(
+      canvasElement,
+      () => canvasElement.querySelector('tbody'),
+      ['--udsc-table-level-prefix'],
+    );
   },
 });


### PR DESCRIPTION
## Summary

Makes every CSS language variable resolve from the nearest `[lang]` ancestor, and adds nynorsk and English to the four upstream variables we did not previously cover.

### Two separate bugs

**Region subtags fell back to bokmål.** Our translations used exact `[lang='nb']` selectors, which do not match `lang="en-GB"`. Since `:root` is grouped into the bokmål block, an unmatched tag silently got Norwegian. So an English page using a region subtag rendered bokmål throughout (`nb-NO` was unaffected, since bokmål happened to be the right answer). The selectors now use `[lang|='xx' i]`, matching upstream, and the Norwegian groups also accept the generic `no`.

**Upstream's values could not easily be overridden.** Breadcrumbs, Pagination and Field have the same problem Suggestion had in #947: upstream declares the text on the component element, and a declaration that applies to an element always beats a value inherited from an ancestor, regardless of specificity or cascade layer.

### How the fix works

Each of the four gets the same shape:

```css
:where(.ds-breadcrumbs) {
  --dsc-breadcrumbs-label: inherit;
}

:root,
[lang|='nb' i],
[lang|='nn' i],
[lang|='no' i] {
  --dsc-breadcrumbs-label: 'Du er her:';
}
[lang|='en' i] {
  --dsc-breadcrumbs-label: 'You are here:';
}
```
(with `[lang|='nn' i]` in its own block if it should differ from `[lang|='nb' i]`)

The `inherit` overrides upstream to be easily overridable. It wins the cascade on that element (later layer), then explicitly defers to the parent's computed value, handing control back to normal inheritance so the nearest `[lang]` ancestor decides. This also means consumer's can override _our_ defaults with similar `[lang]` blocks.

The reset is wrapped in `:where()` so its specificity stays at `0`. It and our `[lang]` blocks are in the same layer, so the cascade falls through to specificity between them — and unwrapped they would tie at `(0,1,0)`, leaving the winner to depend on which appears first in the file. At `0` the `[lang]` blocks always win, whatever the order. With this in place, `@layer` order then ensures our rules win against upstream regardless of specificity, while unlayered styles defined by our consumers win against ours.

### Tests

A `Translations` story per component, using a shared `expectLanguageVariables` helper. It deliberately does not hardcode the strings: it sets `lang` on the story root and compares the component element against a plain probe element in the same `[lang]` scope. That is exactly the invariant upstream breaks — a component resolving differently from a plain element beside it — and it keeps the copy in CSS, so changing a translation does not mean editing a test. It also asserts that `en-GB` resolves like `en`, and that at least one variable differs between nb and en so it cannot pass vacuously.

This caught a real mistake during development: the Field reset was initially on `[data-field='counter']`, but upstream declares those variables on `.ds-field`, so the counter was still inheriting Norwegian.

The stories are hidden from the sidebar and excluded from Chromatic. `32c931d9` adds a `parameters.snapshot: false` opt-out so they do not leave DOM baselines either. Without it this PR added 3188 lines of snapshot churn.

### Known limitation

Because we reset to `inherit`, upstream's value is discarded entirely. If Designsystemet rewords their bokmål text we would silently keep our own wording and never pick it up, and no test would fail. Worth checking on a `@digdir/*` bump: `--dsc-breadcrumbs-label`, `--dsc-pagination-label` and `--dsc-field-counter-over/-under`.

## Sjekkliste

- [x] Dokumentasjonen er oppdatert om nødvendig
- [x] Commitmeldingene gir mening i kontekst av changelog
- [x] Komponenten har tester i Storybook
