### PR TITLE
build: replace `ignoredOptionalDependencies` with an override for `@parcel/watcher`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -443,6 +443,7 @@ catalogs:
       version: 7.0.2
 
 overrides:
+  '@parcel/watcher': '-'
   axios@>=1.0.0 <1.15.0: '>=1.15.0'
   brace-expansion@<=5.0.7: ^5.0.8
   esbuild@>=0.17.0 <0.28.1: ^0.28.1
@@ -2918,6 +2919,11 @@ packages:
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -3042,11 +3048,14 @@ packages:
     resolution: {integrity: sha512-TaCLBrqVEr767+w58QDotDUiCTuE5cyRJuRcDlsKQyUIyGBv+lYD3lu8wBiVCYxgIjB/gu9HmqiC+0yx1rHzaw==}
     peerDependencies:
       esbuild: ^0.28.1
+      rollup: '*'
       storybook: ^10.5.10
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
       esbuild:
+        optional: true
+      rollup:
         optional: true
       vite:
         optional: true
@@ -8199,9 +8208,6 @@ packages:
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
-ignoredOptionalDependencies:
-  - '@parcel/watcher'
-
 snapshots:
 
   '@actions/core@3.0.1':
@@ -9830,6 +9836,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - esbuild
+      - rollup
       - vite
       - webpack
 
@@ -9854,6 +9861,7 @@ snapshots:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
+      - rollup
       - webpack
 
   '@storybook/csf-plugin@10.5.10(esbuild@0.28.2)(storybook@10.5.10(@types/react@19.2.18)(prettier@3.9.5)(react@19.2.8))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.6.1)(sass@1.103.1)(tsx@4.23.12)(yaml@2.9.0))':
@@ -9900,6 +9908,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - esbuild
+      - rollup
       - supports-color
       - webpack
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -151,9 +151,6 @@ cleanupUnusedCatalogs: true
 
 disallowWorkspaceCycles: true
 
-ignoredOptionalDependencies:
-  - "@parcel/watcher"
-
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
@@ -166,6 +163,8 @@ minimumReleaseAgeExclude:
   - next@16.2.11
 
 overrides:
+  # `sass` only needs this for `--watch`, which nothing here uses.
+  "@parcel/watcher": "-"
   axios@>=1.0.0 <1.15.0: ">=1.15.0"
   brace-expansion@<=5.0.7: ^5.0.8
   esbuild@>=0.17.0 <0.28.1: ^0.28.1


### PR DESCRIPTION
pnpm 12 reads `ignoredOptionalDependencies` — `pnpm config get` returns it — but no longer acts on
it during resolution, so `sass`'s optional `@parcel/watcher` comes back on the first full
re-resolution. The lockfile was unaffected when pnpm 12 landed because an up-to-date lockfile skips
resolution entirely; `pnpm dedupe` in the oxfmt workflow was the first thing to force one.
Reproduced against 12.0.0 through 12.3.4 in an isolated project; pnpm 10 and 11 both honour the
setting.

The documented `-` removal override is honoured and does the same job, so use that instead.

The `rollup` peer metadata in the lockfile is unrelated churn from removing `.pnpmfile.cjs`, since
only a full re-resolution refreshes those entries. Both peers are optional, so with
`autoInstallPeers: false` nothing extra is installed.

Reported upstream as pnpm/pnpm#14729, where 12.4.0 is confirmed affected as well.
