### PR TITLE
build: declare `eslint` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@testing-library/react": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native": "catalog:",
+    "eslint": "catalog:",
     "eslint-plugin-import": "catalog:",
     "husky": "catalog:",
     "jsdom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ catalogs:
     dpdm:
       specifier: ^4.3.0
       version: 4.3.0
+    eslint:
+      specifier: ^9.39.5
+      version: 9.39.5
     eslint-plugin-import:
       specifier: ^2.32.0
       version: 2.32.0
@@ -478,6 +481,9 @@ importers:
       '@typescript/native':
         specifier: 'catalog:'
         version: typescript@7.0.2
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.5(jiti@2.6.1)(supports-color@8.1.1)
       eslint-plugin-import:
         specifier: 'catalog:'
         version: 2.32.0(@typescript-eslint/parser@8.64.0(@typescript/typescript6@6.0.2)(eslint@9.39.5(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)
@@ -4882,6 +4888,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,6 +72,7 @@ catalog:
   clsx: 2.1.1
   cssnano: ^7.1.9
   diffable-html: ^6.0.1
+  eslint: ^9.39.5
   eslint-plugin-import: ^2.32.0
   eslint-plugin-storybook: ^10.5.10
   fast-glob: ^3.3.3


### PR DESCRIPTION
`eslint-plugin-import` requires `eslint` at module load, so oxlint cannot load the plugin without
it. `autoInstallPeers` was quietly providing it until that was turned off, and the lockfile kept
the auto-installed copy because an up-to-date lockfile skips resolution. Nothing broke until
`pnpm update -r` forced a full re-resolution and `strictPeerDependencies` reported the peer as
missing — correctly, since it is genuinely needed.

Pinned to `^9` because `eslint-plugin-import@2.32.0` accepts no higher. eslint 10 is released, so
9.x is the maintenance line and the lockfile records a deprecation notice for it.

Fixes the failing [Update patch and minor versions](https://github.com/Utdanningsdirektoratet/designsystem/actions/runs/34333681584/job/102407940242)
run. Verified locally that `pnpm update -r && pnpm dedupe` completes and `pnpm lint` passes.
