### PR TITLE
build: document injected dependency synchronization

### DIFF
--- a/@udir-design/icons/package.json
+++ b/@udir-design/icons/package.json
@@ -29,7 +29,7 @@
     "compile": "tsdown src/index.ts src/metadata.ts --format esm,cjs --dts --logLevel warn",
     "build": "pnpm clean && pnpm compile && pnpm copy-aksel-icons && pnpm copy-style && pnpm generate-css",
     "generate-css": "tsx generate-css.ts",
-    "inject": "echo 'Dummy script to trigger pnpm injected dependency sync'",
+    "inject": "echo 'Uncached dummy script: trigger pnpm injected-dependency sync for Turbo builds'",
     "clean": "rimraf ./dist && mkdir ./dist",
     "lint": "oxlint"
   },

--- a/@udir-design/react/package.json
+++ b/@udir-design/react/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "build": "vite build",
-    "inject": "echo 'Dummy script to trigger pnpm injected dependency sync'",
+    "inject": "echo 'Uncached dummy script: trigger pnpm injected-dependency sync for Turbo builds'",
     "lint": "oxlint",
     "lint:cycles": "pnpm dpdm --no-warning --no-tree --exit-code circular:1 ./src/alpha.ts",
     "typecheck": "tsc --build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -209,6 +209,8 @@ patchedDependencies:
 
 strictPeerDependencies: true
 
+# Keep this on the uncached `inject` task. Turbo may restore a cached `build`
+# output without running its package script, leaving injected dependencies stale.
 syncInjectedDepsAfterScripts:
   - inject
 


### PR DESCRIPTION
Explain why pnpm syncs injected dependencies after the uncached `inject` task rather than `build`, and make the dummy script's purpose explicit.